### PR TITLE
Removing the register address parameter from the read/write methods of SPI and I2C as these aren't general

### DIFF
--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
@@ -7,10 +7,10 @@ namespace System.Device.I2c
     public abstract class I2cDevice : IDisposable
     {
         public abstract I2cConnectionSettings ConnectionSettings { get; }
-        public abstract byte ReadByte(int address);
-        public abstract void Read(int address, Span<byte> buffer);
-        public abstract void WriteByte(int address, byte data);
-        public abstract void Write(int address, Span<byte> data);
+        public abstract byte ReadByte();
+        public abstract void Read(Span<byte> buffer);
+        public abstract void WriteByte(byte data);
+        public abstract void Write(Span<byte> data);
         public void Dispose()
         {
             Dispose(true);

--- a/src/System.Device.Gpio/System/Device/I2c/UnixI2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/UnixI2cDevice.cs
@@ -26,22 +26,22 @@ namespace System.Device.I2c
             throw new NotImplementedException();
         }
 
-        public override byte ReadByte(int address)
+        public override byte ReadByte()
         {
             throw new NotImplementedException();
         }
 
-        public override void Read(int address, Span<byte> buffer)
+        public override void Read(Span<byte> buffer)
         {
             throw new NotImplementedException();
         }
 
-        public override void WriteByte(int address, byte data)
+        public override void WriteByte(byte data)
         {
             throw new NotImplementedException();
         }
 
-        public override void Write(int address, Span<byte> data)
+        public override void Write(Span<byte> data)
         {
             throw new NotImplementedException();
         }

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
@@ -7,10 +7,10 @@ namespace System.Device.Spi
     public abstract class SpiDevice : IDisposable
     {
         public abstract SpiConnectionSettings ConnectionSettings { get; }
-        public abstract byte ReadByte(int address);
-        public abstract void Read(int address, Span<byte> buffer);
-        public abstract void WriteByte(int address, byte data);
-        public abstract void Write(int address, Span<byte> data);
+        public abstract byte ReadByte();
+        public abstract void Read(Span<byte> buffer);
+        public abstract void WriteByte(byte data);
+        public abstract void Write(Span<byte> data);
         public void Dispose()
         {
             Dispose(true);

--- a/src/System.Device.Gpio/System/Device/Spi/UnixSpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/UnixSpiDevice.cs
@@ -26,22 +26,22 @@ namespace System.Device.Spi
             throw new NotImplementedException();
         }
 
-        public override byte ReadByte(int address)
+        public override byte ReadByte()
         {
             throw new NotImplementedException();
         }
 
-        public override void Read(int address, Span<byte> buffer)
+        public override void Read(Span<byte> buffer)
         {
             throw new NotImplementedException();
         }
 
-        public override void WriteByte(int address, byte data)
+        public override void WriteByte(byte data)
         {
             throw new NotImplementedException();
         }
 
-        public override void Write(int address, Span<byte> data)
+        public override void Write(Span<byte> data)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
cc: @tarekgh @JohnTasler 

Fixing this after @JohnTasler correctly pointed out the the read/write protocols from a register might differ from sensor to sensor, so we should instead provide only the physical way of reading and have sensor's implement the way to read from a specific register instead.