### PR TITLE
Adding TransferFullDuplex Api to Spi

### DIFF
--- a/src/System.Device.Gpio/System/Device/Spi/Drivers/UnixSpiDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Drivers/UnixSpiDevice.Linux.cs
@@ -127,6 +127,21 @@ namespace System.Device.Spi.Drivers
                 Transfer(dataPtr, null, data.Length);
             }
         }
+        public override unsafe void TransferFullDuplex(Span<byte> writeBuffer, Span<byte> readBuffer)
+        {
+            Initialize();
+
+            if (writeBuffer.Length != readBuffer.Length)
+            {
+                throw new ArgumentException($"Parameters '{nameof(writeBuffer)}' and '{nameof(readBuffer)}' must have the same length");
+            }
+
+            fixed (byte* writeBufferPtr = writeBuffer)
+            fixed (byte* readBufferPtr = readBuffer)
+            {
+                Transfer(writeBufferPtr, readBufferPtr, writeBuffer.Length);
+            }
+        }
 
         private unsafe void Transfer(byte* writeBufferPtr, byte* readBufferPtr, int buffersLength)
         {

--- a/src/System.Device.Gpio/System/Device/Spi/Drivers/UnixSpiDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Drivers/UnixSpiDevice.Windows.cs
@@ -16,6 +16,8 @@ namespace System.Device.Spi.Drivers
 
         public override byte ReadByte() => throw new PlatformNotSupportedException();
 
+        public override void TransferFullDuplex(Span<byte> writeBuffer, Span<byte> readBuffer) => throw new PlatformNotSupportedException();
+
         public override void Write(Span<byte> data) => throw new PlatformNotSupportedException();
 
         public override void WriteByte(byte data) => throw new PlatformNotSupportedException();

--- a/src/System.Device.Gpio/System/Device/Spi/Drivers/Windows10SpiDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Drivers/Windows10SpiDevice.Linux.cs
@@ -18,5 +18,7 @@ namespace System.Device.Spi.Drivers
         public override void WriteByte(byte data) => throw new PlatformNotSupportedException();
 
         public override void Write(Span<byte> data) => throw new PlatformNotSupportedException();
+
+        public override void TransferFullDuplex(Span<byte> writeBuffer, Span<byte> readBuffer) => throw new PlatformNotSupportedException();
     }
 }

--- a/src/System.Device.Gpio/System/Device/Spi/Drivers/Windows10SpiDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Drivers/Windows10SpiDevice.Windows.cs
@@ -60,6 +60,16 @@ namespace System.Device.Spi.Drivers
             _winDevice.Write(data.ToArray());
         }
 
+        public override void TransferFullDuplex(Span<byte> writeBuffer, Span<byte> readBuffer)
+        {
+            if (writeBuffer.Length != readBuffer.Length)
+            {
+                throw new ArgumentException($"Parameters '{nameof(writeBuffer)}' and '{nameof(readBuffer)}' must have the same length");
+            }
+            byte[] byteArray = new byte[readBuffer.Length];
+            _winDevice.TransferFullDuplex(writeBuffer.ToArray(), byteArray);
+        }
+
         public override void Dispose(bool disposing)
         {
             _winDevice?.Dispose();

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
@@ -11,6 +11,7 @@ namespace System.Device.Spi
         public abstract void Read(Span<byte> buffer);
         public abstract void WriteByte(byte data);
         public abstract void Write(Span<byte> data);
+        public abstract void TransferFullDuplex(Span<byte> writeBuffer, Span<byte> readBuffer);
         public void Dispose()
         {
             Dispose(true);


### PR DESCRIPTION
I was porting the samples to our new API and noticed that we didn't add the implementation of TransferFullDuplex to our Spi devices. This PR will take care of that for both windows and linux.