### PR TITLE
fix PWM output by changing duty cycle after starting pin output

### DIFF
--- a/src/System.Device.Gpio/System/Device/Pwm/Drivers/Windows10PwmDriverChannel.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Drivers/Windows10PwmDriverChannel.Windows.cs
@@ -26,7 +26,9 @@ namespace System.Device.Pwm.Drivers
 
         public void Start(double dutyCyclePercentage)
         {
+            this.ChangeDutyCycle(dutyCyclePercentage);
             _winPin?.Start();
+            // This extra call is required to generate PWM output - remove when the underlying issue is fixed. See issue #109
             this.ChangeDutyCycle(dutyCyclePercentage);
         }
 

--- a/src/System.Device.Gpio/System/Device/Pwm/Drivers/Windows10PwmDriverChannel.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Drivers/Windows10PwmDriverChannel.Windows.cs
@@ -26,8 +26,8 @@ namespace System.Device.Pwm.Drivers
 
         public void Start(double dutyCyclePercentage)
         {
-            this.ChangeDutyCycle(dutyCyclePercentage);
             _winPin?.Start();
+            this.ChangeDutyCycle(dutyCyclePercentage);
         }
 
         public void Stop()


### PR DESCRIPTION
This change sets the pin/channel duty cycle after the output is started.
Confirmed that PWM output is now working on Hummingboard Edge with IoT Core 17763 with this change.