### PR TITLE
Added initial Binding Markdown template

### DIFF
--- a/samples/Device Binding Template.md
+++ b/samples/Device Binding Template.md
@@ -1,0 +1,18 @@
+﻿# [Component Name Here]
+
+## Summary
+Provide a brief description on what the component is and its functonality.
+
+## Device Family
+Provide a list of component names and link to datasheets (if available) the binding will work with.
+
+**[Family Name Here]**: [Datasheet link here]
+
+## Binding Notes
+
+Provide any specifics related to binding API.  This could include how to configure component for particular functions and example code.
+
+**NOTE**:  Don't repeat the basics related to System.Device.API* (e.g. connection settings, etc.).  This helps keep text/steps down to a minimum for maintainability.
+
+## References 
+Provide any references to other tutorials, blogs and hardware related to the component that could help others get started.

--- a/src/devices/Device Binding Template.md
+++ b/src/devices/Device Binding Template.md
@@ -1,0 +1,18 @@
+﻿# [Component Name Here]
+
+## Summary
+Provide a brief description on what the component is and its functonality.
+
+## Device Family
+Provide a list of component names and link to datasheets (if available) the binding will work with.
+
+**[Family Name Here]**: [Datasheet link here]
+
+## Binding Notes
+
+Provide any specifics related to binding API.  This could include how to configure component for particular functions and example code.
+
+**NOTE**:  Don't repeat the basics related to System.Device.API* (e.g. connection settings, etc.).  This helps keep text/steps down to a minimum for maintainability.
+
+## References 
+Provide any references to other tutorials, blogs and hardware related to the component that could help others get started.

--- a/src/devices/README.md
+++ b/src/devices/README.md
@@ -16,7 +16,7 @@ We may publish NuGet packages of device bindings at a later date.
 
 ## Contributing a binding
 
-Anyone can contribute a binding. Please do! Bindings should follow the model that is used for the [Mcp23xxx](Mcp23xxx%2FREADME.md) or [Mcp3008](Mcp3008/README.md) implementations.  There is a [Binding Markdown template](Device%20Binding%20Template.md) that can help you get started, as well.
+Anyone can contribute a binding. Please do! Bindings should follow the model that is used for the [Mcp23xxx](Mcp23xxx/README.md) or [Mcp3008](Mcp3008/README.md) implementations.  There is a [Binding Markdown template](Device%20Binding%20Template.md) that can help you get started, as well.
 
 Bindings must:
 

--- a/src/devices/README.md
+++ b/src/devices/README.md
@@ -16,7 +16,7 @@ We may publish NuGet packages of device bindings at a later date.
 
 ## Contributing a binding
 
-Anyone can contribute a binding. Please do! Bindings should following the model that is used for the [Mcp3008](Mcp3008/README.md) implementation.
+Anyone can contribute a binding. Please do! Bindings should follow the model that is used for the [Mcp23xxx](Mcp23xxx%2FREADME.md) or [Mcp3008](Mcp3008/README.md) implementations.  There is a [Binding Markdown template](Device%20Binding%20Template.md) that can help you get started, as well.
 
 Bindings must:
 


### PR DESCRIPTION
This is a starting markdown to help users quickly begin writing information for a top-level device binding.  While it will be difficult to manage the format/content included across all future binding markdowns, this template is to help keep binding markdown consistent.

This addresses part of https://github.com/dotnet/iot/issues/84.

Future PRs will be created to...
1. Add more content in the [Device Bindings markdown](https://github.com/dotnet/iot/blob/master/src/devices/README.md) explaining steps using this template.
2. Add a binding sample template (this would include a markdown structure for sections on example description, components used, Fritzing drawings, etc.).