### PR TITLE
Added pin options, abstract class and I2C

### DIFF
--- a/src/devices/Mcp23xxx/Mcp23008.cs
+++ b/src/devices/Mcp23xxx/Mcp23008.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.I2c;
+
+namespace Iot.Device.Mcp23xxx
+{
+    public class Mcp23008 : Mcp230xx
+    {
+        public Mcp23008(I2cDevice i2cDevice, int? reset = null, int? intA = null, int? intB = null)
+            : base(i2cDevice, reset, intA, intB)
+        {
+        }
+
+        public override int PinCount => 8;
+
+        public byte Read(Register.Address registerAddress)
+        {
+            return Read(registerAddress, Port.PortA, Bank.Bank1);
+        }
+
+        public byte[] Read(Register.Address startingRegisterAddress, byte byteCount)
+        {
+            return Read(startingRegisterAddress, byteCount, Port.PortA, Bank.Bank1);
+        }
+
+        public void Write(Register.Address registerAddress, byte data)
+        {
+            Write(registerAddress, data, Port.PortA, Bank.Bank1);
+        }
+
+        public void Write(Register.Address startingRegisterAddress, byte[] data)
+        {
+            Write(startingRegisterAddress, data, Port.PortA, Bank.Bank1);
+        }
+    }
+}

--- a/src/devices/Mcp23xxx/Mcp23008.cs
+++ b/src/devices/Mcp23xxx/Mcp23008.cs
@@ -8,8 +8,16 @@ namespace Iot.Device.Mcp23xxx
 {
     public class Mcp23008 : Mcp230xx
     {
-        public Mcp23008(I2cDevice i2cDevice, int? reset = null, int? intA = null, int? intB = null)
-            : base(i2cDevice, reset, intA, intB)
+        /// <summary>
+        /// Initializes new instance of Mcp23008 device.
+        /// A general purpose parallel I/O expansion for I2C applications.
+        /// </summary>
+        /// <param name="i2cDevice">I2C device used for communication.</param>
+        /// <param name="reset">Output pin number that is connected to the hardware reset.</param>
+        /// <param name="interruptA">Input pin number that is connected to the interrupt for Port A (INTA).</param>
+        /// <param name="interruptB">Input pin number that is connected to the interrupt for Port B (INTB).</param>
+        public Mcp23008(I2cDevice i2cDevice, int? reset = null, int? interruptA = null, int? interruptB = null)
+            : base(i2cDevice, reset, interruptA, interruptB)
         {
         }
 

--- a/src/devices/Mcp23xxx/Mcp23009.cs
+++ b/src/devices/Mcp23xxx/Mcp23009.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.I2c;
+
+namespace Iot.Device.Mcp23xxx
+{
+    public class Mcp23009 : Mcp230xx
+    {
+        public Mcp23009(I2cDevice i2cDevice, int? reset = null, int? intA = null, int? intB = null)
+            : base(i2cDevice, reset, intA, intB)
+        {
+        }
+
+        public override int PinCount => 8;
+
+        public byte Read(Register.Address registerAddress)
+        {
+            return Read(registerAddress, Port.PortA, Bank.Bank1);
+        }
+
+        public byte[] Read(Register.Address startingRegisterAddress, byte byteCount)
+        {
+            return Read(startingRegisterAddress, byteCount, Port.PortA, Bank.Bank1);
+        }
+
+        public void Write(Register.Address registerAddress, byte data)
+        {
+            Write(registerAddress, data, Port.PortA, Bank.Bank1);
+        }
+
+        public void Write(Register.Address startingRegisterAddress, byte[] data)
+        {
+            Write(startingRegisterAddress, data, Port.PortA, Bank.Bank1);
+        }
+    }
+}

--- a/src/devices/Mcp23xxx/Mcp23009.cs
+++ b/src/devices/Mcp23xxx/Mcp23009.cs
@@ -8,8 +8,16 @@ namespace Iot.Device.Mcp23xxx
 {
     public class Mcp23009 : Mcp230xx
     {
-        public Mcp23009(I2cDevice i2cDevice, int? reset = null, int? intA = null, int? intB = null)
-            : base(i2cDevice, reset, intA, intB)
+        /// <summary>
+        /// Initializes new instance of Mcp23009 device.
+        /// A general purpose parallel I/O expansion for I2C applications.
+        /// </summary>
+        /// <param name="i2cDevice">I2C device used for communication.</param>
+        /// <param name="reset">Output pin number that is connected to the hardware reset.</param>
+        /// <param name="interruptA">Input pin number that is connected to the interrupt for Port A (INTA).</param>
+        /// <param name="interruptB">Input pin number that is connected to the interrupt for Port B (INTB).</param>
+        public Mcp23009(I2cDevice i2cDevice, int? reset = null, int? interruptA = null, int? interruptB = null)
+            : base(i2cDevice, reset, interruptA, interruptB)
         {
         }
 

--- a/src/devices/Mcp23xxx/Mcp23017.cs
+++ b/src/devices/Mcp23xxx/Mcp23017.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.I2c;
+
+namespace Iot.Device.Mcp23xxx
+{
+    public class Mcp23017 : Mcp230xx
+    {
+        public Mcp23017(I2cDevice i2cDevice, int? reset = null, int? intA = null, int? intB = null)
+            : base(i2cDevice, reset, intA, intB)
+        {
+        }
+
+        public override int PinCount => 16;
+    }
+}

--- a/src/devices/Mcp23xxx/Mcp23017.cs
+++ b/src/devices/Mcp23xxx/Mcp23017.cs
@@ -8,8 +8,16 @@ namespace Iot.Device.Mcp23xxx
 {
     public class Mcp23017 : Mcp230xx
     {
-        public Mcp23017(I2cDevice i2cDevice, int? reset = null, int? intA = null, int? intB = null)
-            : base(i2cDevice, reset, intA, intB)
+        /// <summary>
+        /// Initializes new instance of Mcp23017 device.
+        /// A general purpose parallel I/O expansion for I2C applications.
+        /// </summary>
+        /// <param name="i2cDevice">I2C device used for communication.</param>
+        /// <param name="reset">Output pin number that is connected to the hardware reset.</param>
+        /// <param name="interruptA">Input pin number that is connected to the interrupt for Port A (INTA).</param>
+        /// <param name="interruptB">Input pin number that is connected to the interrupt for Port B (INTB).</param>
+        public Mcp23017(I2cDevice i2cDevice, int? reset = null, int? interruptA = null, int? interruptB = null)
+            : base(i2cDevice, reset, interruptA, interruptB)
         {
         }
 

--- a/src/devices/Mcp23xxx/Mcp23018.cs
+++ b/src/devices/Mcp23xxx/Mcp23018.cs
@@ -8,8 +8,16 @@ namespace Iot.Device.Mcp23xxx
 {
     public class Mcp23018 : Mcp230xx
     {
-        public Mcp23018(I2cDevice i2cDevice, int? reset = null, int? intA = null, int? intB = null)
-            : base(i2cDevice, reset, intA, intB)
+        /// <summary>
+        /// Initializes new instance of Mcp23018 device.
+        /// A general purpose parallel I/O expansion for I2C applications.
+        /// </summary>
+        /// <param name="i2cDevice">I2C device used for communication.</param>
+        /// <param name="reset">Output pin number that is connected to the hardware reset.</param>
+        /// <param name="interruptA">Input pin number that is connected to the interrupt for Port A (INTA).</param>
+        /// <param name="interruptB">Input pin number that is connected to the interrupt for Port B (INTB).</param>
+        public Mcp23018(I2cDevice i2cDevice, int? reset = null, int? interruptA = null, int? interruptB = null)
+            : base(i2cDevice, reset, interruptA, interruptB)
         {
         }
 

--- a/src/devices/Mcp23xxx/Mcp23018.cs
+++ b/src/devices/Mcp23xxx/Mcp23018.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.I2c;
+
+namespace Iot.Device.Mcp23xxx
+{
+    public class Mcp23018 : Mcp230xx
+    {
+        public Mcp23018(I2cDevice i2cDevice, int? reset = null, int? intA = null, int? intB = null)
+            : base(i2cDevice, reset, intA, intB)
+        {
+        }
+
+        public override int PinCount => 16;
+    }
+}

--- a/src/devices/Mcp23xxx/Mcp230xx.cs
+++ b/src/devices/Mcp23xxx/Mcp230xx.cs
@@ -10,8 +10,15 @@ namespace Iot.Device.Mcp23xxx
     {
         private readonly I2cDevice _i2cDevice;
 
-        public Mcp230xx(I2cDevice i2cDevice, int? reset = null, int? intA = null, int? intB = null)
-            : base(i2cDevice.ConnectionSettings.DeviceAddress, reset, intA, intB)
+        /// <summary>
+        /// A general purpose parallel I/O expansion for I2C applications.
+        /// </summary>
+        /// <param name="i2cDevice">I2C device used for communication.</param>
+        /// <param name="reset">Output pin number that is connected to the hardware reset.</param>
+        /// <param name="interruptA">Input pin number that is connected to the interrupt for Port A (INTA).</param>
+        /// <param name="interruptB">Input pin number that is connected to the interrupt for Port B (INTB).</param>
+        public Mcp230xx(I2cDevice i2cDevice, int? reset = null, int? interruptA = null, int? interruptB = null)
+            : base(i2cDevice.ConnectionSettings.DeviceAddress, reset, interruptA, interruptB)
         {
             _i2cDevice = i2cDevice;
         }

--- a/src/devices/Mcp23xxx/Mcp230xx.cs
+++ b/src/devices/Mcp23xxx/Mcp230xx.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.I2c;
+
+namespace Iot.Device.Mcp23xxx
+{
+    public class Mcp230xx : Mcp23xxx
+    {
+        private readonly I2cDevice _i2cDevice;
+
+        public Mcp230xx(I2cDevice i2cDevice, int? reset = null, int? intA = null, int? intB = null)
+            : base(i2cDevice.ConnectionSettings.DeviceAddress, reset, intA, intB)
+        {
+            _i2cDevice = i2cDevice;
+        }
+
+        public override byte Read(Register.Address registerAddress, Port port = Port.PortA, Bank bank = Bank.Bank1)
+        {
+            byte[] data = Read(registerAddress, 1, port, bank);
+            return data[0];
+        }
+
+        public override byte[] Read(Register.Address startingRegisterAddress, byte byteCount, Port port = Port.PortA, Bank bank = Bank.Bank1)
+        {
+            Write(startingRegisterAddress, new byte[] { }, port, bank); // Set address to register first.
+
+            byte[] readBuffer = new byte[byteCount];
+            _i2cDevice.Read(readBuffer);
+            return readBuffer;
+        }
+
+        public override void Write(Register.Address registerAddress, byte data, Port port = Port.PortA, Bank bank = Bank.Bank1)
+        {
+            Write(registerAddress, new byte[] { data }, port, bank);
+        }
+
+        public override void Write(Register.Address startingRegisterAddress, byte[] data, Port port = Port.PortA, Bank bank = Bank.Bank1)
+        {
+            byte[] writeBuffer = new byte[data.Length + 1]; // Include Register Address.
+            writeBuffer[0] = Register.GetMappedAddress(startingRegisterAddress, port, bank);
+            data.CopyTo(writeBuffer, 1);
+            _i2cDevice.Write(writeBuffer);
+        }
+
+        public override void Dispose()
+        {
+            _i2cDevice?.Dispose();
+            base.Dispose();
+        }
+    }
+}

--- a/src/devices/Mcp23xxx/Mcp230xx.cs
+++ b/src/devices/Mcp23xxx/Mcp230xx.cs
@@ -6,7 +6,7 @@ using System.Device.I2c;
 
 namespace Iot.Device.Mcp23xxx
 {
-    public class Mcp230xx : Mcp23xxx
+    public abstract class Mcp230xx : Mcp23xxx
     {
         private readonly I2cDevice _i2cDevice;
 

--- a/src/devices/Mcp23xxx/Mcp230xx.cs
+++ b/src/devices/Mcp23xxx/Mcp230xx.cs
@@ -23,12 +23,6 @@ namespace Iot.Device.Mcp23xxx
             _i2cDevice = i2cDevice;
         }
 
-        public override byte Read(Register.Address registerAddress, Port port = Port.PortA, Bank bank = Bank.Bank1)
-        {
-            byte[] data = Read(registerAddress, 1, port, bank);
-            return data[0];
-        }
-
         public override byte[] Read(Register.Address startingRegisterAddress, byte byteCount, Port port = Port.PortA, Bank bank = Bank.Bank1)
         {
             Write(startingRegisterAddress, new byte[] { }, port, bank); // Set address to register first.
@@ -36,11 +30,6 @@ namespace Iot.Device.Mcp23xxx
             byte[] readBuffer = new byte[byteCount];
             _i2cDevice.Read(readBuffer);
             return readBuffer;
-        }
-
-        public override void Write(Register.Address registerAddress, byte data, Port port = Port.PortA, Bank bank = Bank.Bank1)
-        {
-            Write(registerAddress, new byte[] { data }, port, bank);
         }
 
         public override void Write(Register.Address startingRegisterAddress, byte[] data, Port port = Port.PortA, Bank bank = Bank.Bank1)

--- a/src/devices/Mcp23xxx/Mcp23S08.cs
+++ b/src/devices/Mcp23xxx/Mcp23S08.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Spi;
+
+namespace Iot.Device.Mcp23xxx
+{
+    public class Mcp23S08 : Mcp23Sxx
+    {
+        public Mcp23S08(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? intA = null, int? intB = null)
+            : base(deviceAddress, spiDevice, reset, intA, intB)
+        {
+        }
+
+        public override int PinCount => 8;
+
+        public byte Read(Register.Address registerAddress)
+        {
+            return Read(registerAddress, Port.PortA, Bank.Bank1);
+        }
+
+        public byte[] Read(Register.Address startingRegisterAddress, byte byteCount)
+        {
+            return Read(startingRegisterAddress, byteCount, Port.PortA, Bank.Bank1);
+        }
+
+        public void Write(Register.Address registerAddress, byte data)
+        {
+            Write(registerAddress, data, Port.PortA, Bank.Bank1);
+        }
+
+        public void Write(Register.Address startingRegisterAddress, byte[] data)
+        {
+            Write(startingRegisterAddress, data, Port.PortA, Bank.Bank1);
+        }
+    }
+}

--- a/src/devices/Mcp23xxx/Mcp23S08.cs
+++ b/src/devices/Mcp23xxx/Mcp23S08.cs
@@ -8,8 +8,17 @@ namespace Iot.Device.Mcp23xxx
 {
     public class Mcp23S08 : Mcp23Sxx
     {
-        public Mcp23S08(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? intA = null, int? intB = null)
-            : base(deviceAddress, spiDevice, reset, intA, intB)
+        /// <summary>
+        /// Initializes new instance of Mcp23S08 device.
+        /// A general purpose parallel I/O expansion for I2C or SPI applications.
+        /// </summary>
+        /// <param name="deviceAddress">The device address for the connection on the SPI bus.</param>
+        /// <param name="spiDevice">SPI device used for communication.</param>
+        /// <param name="reset">Output pin number that is connected to the hardware reset.</param>
+        /// <param name="interruptA">Input pin number that is connected to the interrupt for Port A (INTA).</param>
+        /// <param name="interruptB">Input pin number that is connected to the interrupt for Port B (INTB).</param>
+        public Mcp23S08(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? interruptA = null, int? interruptB = null)
+            : base(deviceAddress, spiDevice, reset, interruptA, interruptB)
         {
         }
 

--- a/src/devices/Mcp23xxx/Mcp23S09.cs
+++ b/src/devices/Mcp23xxx/Mcp23S09.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Spi;
+
+namespace Iot.Device.Mcp23xxx
+{
+    public class Mcp23S09 : Mcp23Sxx
+    {
+        public Mcp23S09(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? intA = null, int? intB = null)
+           : base(deviceAddress, spiDevice, reset, intA, intB)
+        {
+        }
+
+        public override int PinCount => 8;
+
+        public byte Read(Register.Address registerAddress)
+        {
+            return Read(registerAddress, Port.PortA, Bank.Bank1);
+        }
+
+        public byte[] Read(Register.Address startingRegisterAddress, byte byteCount)
+        {
+            return Read(startingRegisterAddress, byteCount, Port.PortA, Bank.Bank1);
+        }
+
+        public void Write(Register.Address registerAddress, byte data)
+        {
+            Write(registerAddress, data, Port.PortA, Bank.Bank1);
+        }
+
+        public void Write(Register.Address startingRegisterAddress, byte[] data)
+        {
+            Write(startingRegisterAddress, data, Port.PortA, Bank.Bank1);
+        }
+    }
+}

--- a/src/devices/Mcp23xxx/Mcp23S09.cs
+++ b/src/devices/Mcp23xxx/Mcp23S09.cs
@@ -8,8 +8,17 @@ namespace Iot.Device.Mcp23xxx
 {
     public class Mcp23S09 : Mcp23Sxx
     {
-        public Mcp23S09(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? intA = null, int? intB = null)
-           : base(deviceAddress, spiDevice, reset, intA, intB)
+        /// <summary>
+        /// Initializes new instance of Mcp23S09 device.
+        /// A general purpose parallel I/O expansion for SPI applications.
+        /// </summary>
+        /// <param name="deviceAddress">The device address for the connection on the SPI bus.</param>
+        /// <param name="spiDevice">SPI device used for communication.</param>
+        /// <param name="reset">Output pin number that is connected to the hardware reset.</param>
+        /// <param name="interruptA">Input pin number that is connected to the interrupt for Port A (INTA).</param>
+        /// <param name="interruptB">Input pin number that is connected to the interrupt for Port B (INTB).</param>
+        public Mcp23S09(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? interruptA = null, int? interruptB = null)
+           : base(deviceAddress, spiDevice, reset, interruptA, interruptB)
         {
         }
 

--- a/src/devices/Mcp23xxx/Mcp23S17.cs
+++ b/src/devices/Mcp23xxx/Mcp23S17.cs
@@ -8,8 +8,17 @@ namespace Iot.Device.Mcp23xxx
 {
     public class Mcp23S17 : Mcp23Sxx
     {
-        public Mcp23S17(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? intA = null, int? intB = null)
-            : base(deviceAddress, spiDevice, reset, intA, intB)
+        /// <summary>
+        /// Initializes new instance of Mcp23xxx device.
+        /// A general purpose parallel I/O expansion for I2C or SPI applications.
+        /// </summary>
+        /// <param name="deviceAddress">The device address for the connection on the I2C or SPI bus.</param>
+        /// <param name="spiDevice">SPI device used for communication.</param>
+        /// <param name="reset">Output pin number that is connected to the hardware reset.</param>
+        /// <param name="interruptA">Input pin number that is connected to the interrupt for Port A (INTA).</param>
+        /// <param name="interruptB">Input pin number that is connected to the interrupt for Port B (INTB).</param>
+        public Mcp23S17(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? interruptA = null, int? interruptB = null)
+            : base(deviceAddress, spiDevice, reset, interruptA, interruptB)
         {
         }
 

--- a/src/devices/Mcp23xxx/Mcp23S17.cs
+++ b/src/devices/Mcp23xxx/Mcp23S17.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Spi;
+
+namespace Iot.Device.Mcp23xxx
+{
+    public class Mcp23S17 : Mcp23Sxx
+    {
+        public Mcp23S17(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? intA = null, int? intB = null)
+            : base(deviceAddress, spiDevice, reset, intA, intB)
+        {
+        }
+
+        public override int PinCount => 16;
+    }
+}

--- a/src/devices/Mcp23xxx/Mcp23S18.cs
+++ b/src/devices/Mcp23xxx/Mcp23S18.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Spi;
+
+namespace Iot.Device.Mcp23xxx
+{
+    public class Mcp23S18 : Mcp23Sxx
+    {
+        public Mcp23S18(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? intA = null, int? intB = null)
+            : base(deviceAddress, spiDevice, reset, intA, intB)
+        {
+        }
+
+        public override int PinCount => 16;
+    }
+}

--- a/src/devices/Mcp23xxx/Mcp23S18.cs
+++ b/src/devices/Mcp23xxx/Mcp23S18.cs
@@ -8,8 +8,17 @@ namespace Iot.Device.Mcp23xxx
 {
     public class Mcp23S18 : Mcp23Sxx
     {
-        public Mcp23S18(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? intA = null, int? intB = null)
-            : base(deviceAddress, spiDevice, reset, intA, intB)
+        /// <summary>
+        /// Initializes new instance of Mcp23S18 device.
+        /// A general purpose parallel I/O expansion for SPI applications.
+        /// </summary>
+        /// <param name="deviceAddress">The device address for the connection on the SPI bus.</param>
+        /// <param name="spiDevice">SPI device used for communication.</param>
+        /// <param name="reset">Output pin number that is connected to the hardware reset.</param>
+        /// <param name="interruptA">Input pin number that is connected to the interrupt for Port A (INTA).</param>
+        /// <param name="interruptB">Input pin number that is connected to the interrupt for Port B (INTB).</param>
+        public Mcp23S18(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? interruptA = null, int? interruptB = null)
+            : base(deviceAddress, spiDevice, reset, interruptA, interruptB)
         {
         }
 

--- a/src/devices/Mcp23xxx/Mcp23Sxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23Sxx.cs
@@ -10,9 +10,17 @@ namespace Iot.Device.Mcp23xxx
     public abstract class Mcp23Sxx : Mcp23xxx
     {
         private readonly SpiDevice _spiDevice;
-        
-        public Mcp23Sxx(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? intA = null, int? intB = null)
-            : base(deviceAddress, reset, intA, intB)
+
+        /// <summary>
+        /// A general purpose parallel I/O expansion for SPI applications.
+        /// </summary>
+        /// <param name="deviceAddress">The device address for the connection on the SPI bus.</param>
+        /// <param name="spiDevice">SPI device used for communication.</param>
+        /// <param name="reset">Output pin number that is connected to the hardware reset.</param>
+        /// <param name="interruptA">Input pin number that is connected to the interrupt for Port A (INTA).</param>
+        /// <param name="interruptB">Input pin number that is connected to the interrupt for Port B (INTB).</param>
+        public Mcp23Sxx(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? interruptA = null, int? interruptB = null)
+            : base(deviceAddress, reset, interruptA, interruptB)
         {
             _spiDevice = spiDevice;
         }

--- a/src/devices/Mcp23xxx/Mcp23Sxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23Sxx.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Device.Spi;
+
+namespace Iot.Device.Mcp23xxx
+{
+    public class Mcp23Sxx : Mcp23xxx
+    {
+        private readonly SpiDevice _spiDevice;
+        
+        public Mcp23Sxx(int deviceAddress, SpiDevice spiDevice, int? reset = null, int? intA = null, int? intB = null)
+            : base(deviceAddress, reset, intA, intB)
+        {
+            _spiDevice = spiDevice;
+        }
+
+        public override byte Read(Register.Address registerAddress, Port port = Port.PortA, Bank bank = Bank.Bank1)
+        {
+            byte[] readBuffer = Read(registerAddress, 1, port, bank);
+            return readBuffer[0];
+        }
+
+        public override byte[] Read(Register.Address startingRegisterAddress, byte byteCount, Port port = Port.PortA, Bank bank = Bank.Bank1)
+        {
+            byteCount += 2;  // Include OpCode and Register Address.
+            byte[] writeBuffer = new byte[byteCount];
+            writeBuffer[0] = OpCode.GetOpCode(DeviceAddress, true);
+            writeBuffer[1] = Register.GetMappedAddress(startingRegisterAddress, port, bank);
+            byte[] readBuffer = new byte[byteCount];
+
+            _spiDevice.TransferFullDuplex(writeBuffer, readBuffer);
+            return readBuffer.AsSpan().Slice(2).ToArray();  // First 2 bytes are from sending OpCode and Register Address.
+        }
+
+        public override void Write(Register.Address registerAddress, byte data, Port port = Port.PortA, Bank bank = Bank.Bank1)
+        {
+            Write(registerAddress, new byte[] { data }, port, bank);
+        }
+
+        public override void Write(Register.Address startingRegisterAddress, byte[] data, Port port = Port.PortA, Bank bank = Bank.Bank1)
+        {
+            byte[] writeBuffer = new byte[data.Length + 2]; // Include OpCode and Register Address.
+            writeBuffer[0] = OpCode.GetOpCode(DeviceAddress, false);
+            writeBuffer[1] = Register.GetMappedAddress(startingRegisterAddress, port, bank);
+            data.CopyTo(writeBuffer, 2);
+
+            _spiDevice.Write(writeBuffer);
+        }
+
+        public override void Dispose()
+        {
+            _spiDevice?.Dispose();
+            base.Dispose();
+        }
+    }
+}

--- a/src/devices/Mcp23xxx/Mcp23Sxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23Sxx.cs
@@ -25,12 +25,6 @@ namespace Iot.Device.Mcp23xxx
             _spiDevice = spiDevice;
         }
 
-        public override byte Read(Register.Address registerAddress, Port port = Port.PortA, Bank bank = Bank.Bank1)
-        {
-            byte[] readBuffer = Read(registerAddress, 1, port, bank);
-            return readBuffer[0];
-        }
-
         public override byte[] Read(Register.Address startingRegisterAddress, byte byteCount, Port port = Port.PortA, Bank bank = Bank.Bank1)
         {
             byteCount += 2;  // Include OpCode and Register Address.
@@ -41,11 +35,6 @@ namespace Iot.Device.Mcp23xxx
 
             _spiDevice.TransferFullDuplex(writeBuffer, readBuffer);
             return readBuffer.AsSpan().Slice(2).ToArray();  // First 2 bytes are from sending OpCode and Register Address.
-        }
-
-        public override void Write(Register.Address registerAddress, byte data, Port port = Port.PortA, Bank bank = Bank.Bank1)
-        {
-            Write(registerAddress, new byte[] { data }, port, bank);
         }
 
         public override void Write(Register.Address startingRegisterAddress, byte[] data, Port port = Port.PortA, Bank bank = Bank.Bank1)

--- a/src/devices/Mcp23xxx/Mcp23Sxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23Sxx.cs
@@ -7,7 +7,7 @@ using System.Device.Spi;
 
 namespace Iot.Device.Mcp23xxx
 {
-    public class Mcp23Sxx : Mcp23xxx
+    public abstract class Mcp23Sxx : Mcp23xxx
     {
         private readonly SpiDevice _spiDevice;
         

--- a/src/devices/Mcp23xxx/Mcp23xxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23xxx.cs
@@ -7,7 +7,25 @@ using System.Device.Gpio;
 
 namespace Iot.Device.Mcp23xxx
 {
-    // IGpioControllerProvider.  TODO: https://github.com/dotnet/iot/issues/125
+    // TODO: https://github.com/dotnet/iot/issues/125
+    // Implement IGpioControllerProvider.
+    // The thinking is to implement this interface where it can provide a GpioController
+    // that looks like a regular controller, but controls the bindings I/O via I2C/SPI drivers.
+    //
+    // For example...
+    // var connectionSettings = new SpiConnectionSettings(0, 0);
+    // var spiDevice = new UnixSpiDevice(connectionSettings);
+    // var mcp23Sxx = new Mcp23Sxx(0, spiDevice);
+    // GpioController mcp23SxxController = mcp23Sxx.GetDefaultGpioController();
+    // 
+    // Now when you call the GpioController methods, the master controller will send the respective SPI commands
+    // to the binding behind the scenes to update its I/O.
+    //
+    // The code below would interact with the MCP23XXX related registers (IODIR, GPIO, etc.)
+    // to configure the pin as an input and read the the value.
+    // mcp23SxxController.SetPinMode(1, PinMode.Input);
+    // PinValue pin1Value = mcp23SxxController.Read(1);
+
     public abstract class Mcp23xxx : IDisposable
     {
         protected int DeviceAddress { get; }
@@ -62,6 +80,8 @@ namespace Iot.Device.Mcp23xxx
                 Disable();
             }
         }
+
+        public abstract int PinCount { get; }
 
         public abstract byte Read(Register.Address registerAddress, Port port = Port.PortA, Bank bank = Bank.Bank1);
         public abstract byte[] Read(Register.Address startingRegisterAddress, byte byteCount, Port port = Port.PortA, Bank bank = Bank.Bank1);

--- a/src/devices/Mcp23xxx/Mcp23xxx.csproj
+++ b/src/devices/Mcp23xxx/Mcp23xxx.csproj
@@ -8,6 +8,14 @@
 
   <ItemGroup>
     <Compile Include="Bank.cs" />
+    <Compile Include="Mcp23018.cs" />
+    <Compile Include="Mcp23017.cs" />
+    <Compile Include="Mcp23S18.cs" />
+    <Compile Include="Mcp23S17.cs" />
+    <Compile Include="Mcp23S09.cs" />
+    <Compile Include="Mcp23S08.cs" />
+    <Compile Include="Mcp23009.cs" />
+    <Compile Include="Mcp23008.cs" />
     <Compile Include="Mcp23Sxx.cs" />
     <Compile Include="Mcp230xx.cs" />
     <Compile Include="Mcp23xxx.cs" />

--- a/src/devices/Mcp23xxx/Mcp23xxx.csproj
+++ b/src/devices/Mcp23xxx/Mcp23xxx.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <Compile Include="Bank.cs" />
+    <Compile Include="Mcp23Sxx.cs" />
+    <Compile Include="Mcp230xx.cs" />
     <Compile Include="Mcp23xxx.cs" />
     <Compile Include="OpCode.cs" />
     <Compile Include="Port.cs" />

--- a/src/devices/Mcp23xxx/OpCode.cs
+++ b/src/devices/Mcp23xxx/OpCode.cs
@@ -8,7 +8,7 @@ namespace Iot.Device.Mcp23xxx
     {
         public static byte GetOpCode(int deviceAddress, bool isReadCommand)
         {
-            int opCode = 0b0100_0000 | (deviceAddress << 1);
+            int opCode = deviceAddress << 1;
 
             if (isReadCommand)
             {

--- a/src/devices/Mcp23xxx/OpCode.cs
+++ b/src/devices/Mcp23xxx/OpCode.cs
@@ -4,7 +4,7 @@
 
 namespace Iot.Device.Mcp23xxx
 {
-    public class OpCode
+    public static class OpCode
     {
         public static byte GetOpCode(int deviceAddress, bool isReadCommand)
         {

--- a/src/devices/Mcp23xxx/README.md
+++ b/src/devices/Mcp23xxx/README.md
@@ -1,10 +1,10 @@
 ﻿# Microchip Mcp23xxx
 
 ## Summary
-The `Mcp23xxx` device family provides 8/16-bit, general purpose parallel I/O expansion for I2C or SPI applications.  These devices include a range of addressing schemes and I/O configurations including pull-up resistors, polarity inverting, and interrupts.
+The MCP23XXX device family provides 8/16-bit, general purpose parallel I/O expansion for I2C or SPI applications.  These devices include a range of addressing schemes and I/O configurations including pull-up resistors, polarity inverting, and interrupts.
 
 ## Device Family
-`Mcp23xxx` devices contain different markings to distinguish features like interfacing, packaging, and temperature ratings.  For example, MCP23017 contains an I2C interface and MCP23S17 contains a SPI interface.  Please review specific datasheet for more information.
+MCP23XXX devices contain different markings to distinguish features like interfacing, packaging, and temperature ratings.  For example, MCP23017 contains an I2C interface and MCP23S17 contains a SPI interface.  Please review specific datasheet for more information.
 
 **MCP23X08**: http://ww1.microchip.com/downloads/en/DeviceDoc/21919e.pdf  
 **MCP23X09**: http://ww1.microchip.com/downloads/en/DeviceDoc/20002121C.pdf  
@@ -40,7 +40,7 @@ var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice);
 ```
   
 ### Register Banking
-The number of ports vary between `Mcp23xxx` devices depending if it is 8-bit (1 port) or 16-bit (2 ports) expander.  The internal circuitry has a banking concept to group by port registers or by register type.  This enables different configurations for reading/writing schemes.  
+The number of ports vary between MCP23XXX devices depending if it is 8-bit (1 port) or 16-bit (2 ports) expander.  The internal circuitry has a banking concept to group by port registers or by register type.  This enables different configurations for reading/writing schemes.  
 
 To allow this binding to work across the device family, you must use the provided arguments when using Reading/Writing methods.
 
@@ -65,7 +65,7 @@ byte data = mcp23xxx.Read(Register.Address.GPPU, Port.PortA, Bank.Bank1);
 ```
 
 ### Controller Pins
-The `Mcp23xxx` has overloaded pin options when instantiating the device.  This includes a reset line, which is an output pin of the controller to the `Mcp23xxx` RST input pin.  The other pins are interrupt options, which are inputs to the controller from the `Mcp23xxx` INTA/INTB output pins.  They are optional arguments.  Assign as `null` for the pins you don't use.
+The `Mcp23xxx` has overloaded pin options when instantiating the device.  This includes a reset line, which is an output pin of the controller to the MCP23XXX RST input pin.  The other pins are interrupt options, which are inputs to the controller from the MCP23XXX INTA/INTB output pins.  They are optional arguments.  Assign as `null` for the pins you don't use.
 
 ```csharp
 // Pin 10: Reset; Output to Mcp23xxx
@@ -74,7 +74,7 @@ The `Mcp23xxx` has overloaded pin options when instantiating the device.  This i
 var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice, 10, 25, 17);
 ```
 
-The `Mcp23xxx` will be in the reset/disabled state by default if you use the reset pin.  You must call the `Enable()` method to activate the device.
+The MCP23XXX will be in the reset/disabled state by default if you use the reset pin.  You must call the `Enable()` method to activate the device.
 
 ```csharp
 var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice, 10, 25, 17);

--- a/src/devices/Mcp23xxx/README.md
+++ b/src/devices/Mcp23xxx/README.md
@@ -15,7 +15,7 @@ The `Mcp23xxx` device family provides 8/16-bit, general purpose parallel I/O exp
 
 ## Binding Notes
 
-The `Mcp23xxx` is an abstract class that has an implementation for both I2C (`Mcp230xx`) and SPI (`Mcp23Sxx`) interfaces.  You can create either one by passing in the respective I2C driver.
+This binding includes an `Mcp23xxx` abstract class and implementations for both I2C (`Mcp230xx`) and SPI (`Mcp23Sxx`) interfaces.  You can create either one by passing in the respective communication driver.
 
 #### Mcp230xx I2C
 ```csharp
@@ -40,7 +40,7 @@ var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice);
 ```
   
 ### Register Banking
-The number of ports vary between `Mcp23xxx` devices depending if it is 8-bit (1 port) or 16-bit (2 ports).  The internal circuitry has a banking concept to group by port registers or by register type.  This enables different configurations for reading/writing schemes.  
+The number of ports vary between `Mcp23xxx` devices depending if it is 8-bit (1 port) or 16-bit (2 ports) expander.  The internal circuitry has a banking concept to group by port registers or by register type.  This enables different configurations for reading/writing schemes.  
 
 To allow this binding to work across the device family, you must use the provided arguments when using Reading/Writing methods.
 
@@ -65,7 +65,7 @@ byte data = mcp23xxx.Read(Register.Address.GPPU, Port.PortA, Bank.Bank1);
 ```
 
 ### Controller Pins
-The `Mcp23xxx` has overloaded pin options when instantiating the device.  This includes a reset line, which is an output pin of the controller to the `Mcp23xxx` RST input pin.  The other pins are interrupt options, which are inputs to the controller from the `Mcp23xxx` INTA/INTB output pins.  They are optional parameters.  Assign as `null` for the pins you don't need.
+The `Mcp23xxx` has overloaded pin options when instantiating the device.  This includes a reset line, which is an output pin of the controller to the `Mcp23xxx` RST input pin.  The other pins are interrupt options, which are inputs to the controller from the `Mcp23xxx` INTA/INTB output pins.  They are optional arguments.  Assign as `null` for the pins you don't use.
 
 ```csharp
 // Pin 10: Reset; Output to Mcp23xxx
@@ -94,3 +94,4 @@ PinValue valueB = mcp23Sxx.ReadIntB();
 
 ## References 
 https://www.adafruit.com/product/732  
+https://learn.adafruit.com/using-mcp23008-mcp23017-with-circuitpython/overview

--- a/src/devices/Mcp23xxx/README.md
+++ b/src/devices/Mcp23xxx/README.md
@@ -1,10 +1,10 @@
 ﻿# Microchip Mcp23xxx
 
 ## Summary
-The MCP23XXX device family provides 8/16-bit, general purpose parallel I/O expansion for I2C or SPI applications.  These devices include a range of addressing schemes and I/O configurations including pull-up resistors, polarity inverting, and interrupts.
+The `Mcp23xxx` device family provides 8/16-bit, general purpose parallel I/O expansion for I2C or SPI applications.  These devices include a range of addressing schemes and I/O configurations including pull-up resistors, polarity inverting, and interrupts.
 
 ## Device Family
-MCP23XXX devices contain different markings to distinguish features like interfacing, packaging, and temperature ratings.  For example, MCP23017 contains an I2C interface and MCP23S17 contains a SPI interface.  Please review specific datasheet for more information.
+`Mcp23xxx` devices contain different markings to distinguish features like interfacing, packaging, and temperature ratings.  For example, MCP23017 contains an I2C interface and MCP23S17 contains a SPI interface.  Please review specific datasheet for more information.
 
 **MCP23X08**: http://ww1.microchip.com/downloads/en/DeviceDoc/21919e.pdf  
 **MCP23X09**: http://ww1.microchip.com/downloads/en/DeviceDoc/20002121C.pdf  
@@ -15,8 +15,32 @@ MCP23XXX devices contain different markings to distinguish features like interfa
 
 ## Binding Notes
 
+The `Mcp23xxx` is an abstract class that has an implementation for both I2C (`Mcp230xx`) and SPI (`Mcp23Sxx`) interfaces.  You can create either one by passing in the respective I2C driver.
+
+#### Mcp230xx I2C
+```csharp
+ // 0x20 is the device address in this example.
+var connectionSettings = new I2cConnectionSettings(1, 0x20);
+var i2cDevice = new UnixI2cDevice(connectionSettings);
+var mcp23Sxx = new Mcp230xx(i2cDevice);
+```
+
+#### Mcp23Sxx SPI
+```csharp
+var connectionSettings = new SpiConnectionSettings(0, 0)
+{
+    ClockFrequency = 1000000,
+    Mode = SpiMode.Mode0
+};
+
+var spiDevice = new UnixSpiDevice(connectionSettings);
+
+// 0x20 is the device address in this example.
+var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice);
+```
+  
 ### Register Banking
-The number of ports vary between Mcp23xxx devices depending if it is 8-bit (1 port) or 16-bit (2 ports).  The internal circuitry has a banking concept to group by port registers or by register type.  This enables different configurations for reading/writing schemes.  
+The number of ports vary between `Mcp23xxx` devices depending if it is 8-bit (1 port) or 16-bit (2 ports).  The internal circuitry has a banking concept to group by port registers or by register type.  This enables different configurations for reading/writing schemes.  
 
 To allow this binding to work across the device family, you must use the provided arguments when using Reading/Writing methods.
 
@@ -24,20 +48,48 @@ To allow this binding to work across the device family, you must use the provide
 The MCP23X17 has registers defaulted to Bank 1, which group port registers by type.  It is recommended to use the optional arguments for port and bank when addressing the correct register.
 
 ``` csharp
-// Read Port B's Input Polarity Port Register (IPOL) from device 3.
-byte data = mcp23xxx.Read(3, Register.Address.IPOL, Port.PortB, Bank.Bank0);
+// Read Port B's Input Polarity Port Register (IPOL).
+byte data = mcp23xxx.Read(Register.Address.IPOL, Port.PortB, Bank.Bank0);
 
 // If the device is configured for Bank 1, you can ignore the optional argument.
-byte data = mcp23xxx.Read(3, Register.Address.IPOL, Port.PortB);
+byte data = mcp23xxx.Read(Register.Address.IPOL, Port.PortB);
 ```
 #### Example for 8-bit device
 The MCP23X08 only contains 1 port so you must use Bank 1 when addressing the correct register.  In this case, the optional arguments can be ignored.
 
 ``` csharp
-// Read port A's GPIO Pull-Up Resistor Register (GPPU) from device 1.
-byte data = mcp23xxx.Read(1, Register.Address.GPPU);
+// Read port A's GPIO Pull-Up Resistor Register (GPPU).
+byte data = mcp23xxx.Read(Register.Address.GPPU);
 // or..
-byte data = mcp23xxx.Read(1, Register.Address.GPPU, Port.PortA, Bank.Bank1);
+byte data = mcp23xxx.Read(Register.Address.GPPU, Port.PortA, Bank.Bank1);
+```
+
+### Controller Pins
+The `Mcp23xxx` has overloaded pin options when instantiating the device.  This includes a reset line, which is an output pin of the controller to the `Mcp23xxx` RST input pin.  The other pins are interrupt options, which are inputs to the controller from the `Mcp23xxx` INTA/INTB output pins.  They are optional parameters.  Assign as `null` for the pins you don't need.
+
+```csharp
+// Pin 10: Reset; Output to Mcp23xxx
+// Pin 25: INTA;  Input from Mcp23xxx
+// Pin 17: INTB;  Input from Mcp23xxx
+var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice, 10, 25, 17);
+```
+
+The `Mcp23xxx` will be in the reset/disabled state by default if you use the reset pin.  You must call the `Enable()` method to activate the device.
+
+```csharp
+var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice, 10, 25, 17);
+mcp23Sxx.Enable();
+// Can now communicate with device.
+
+// Turn off again if needed.
+mcp23Sxx.Disable();
+```
+
+**TODO**: Interrupt pins can only be read for now.  Events are coming in a future PR.
+```csharp
+var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice, 10, 25, 17);
+PinValue valueA = mcp23Sxx.ReadIntA();
+PinValue valueB = mcp23Sxx.ReadIntB();
 ```
 
 ## References 

--- a/src/devices/Mcp23xxx/README.md
+++ b/src/devices/Mcp23xxx/README.md
@@ -22,7 +22,7 @@ This binding includes an `Mcp23xxx` abstract class and implementations for both 
  // 0x20 is the device address in this example.
 var connectionSettings = new I2cConnectionSettings(1, 0x20);
 var i2cDevice = new UnixI2cDevice(connectionSettings);
-var mcp23Sxx = new Mcp230xx(i2cDevice);
+var mcp23S17 = new Mcp23017(i2cDevice);
 ```
 
 #### Mcp23Sxx SPI
@@ -36,7 +36,7 @@ var connectionSettings = new SpiConnectionSettings(0, 0)
 var spiDevice = new UnixSpiDevice(connectionSettings);
 
 // 0x20 is the device address in this example.
-var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice);
+var mcp23S17 = new Mcp23S17(0x20, spiDevice);
 ```
   
 ### Register Banking
@@ -49,19 +49,17 @@ The MCP23X17 has registers defaulted to Bank 1, which group port registers by ty
 
 ``` csharp
 // Read Port B's Input Polarity Port Register (IPOL).
-byte data = mcp23xxx.Read(Register.Address.IPOL, Port.PortB, Bank.Bank0);
+byte data = mcp23S17.Read(Register.Address.IPOL, Port.PortB, Bank.Bank0);
 
 // If the device is configured for Bank 1, you can ignore the optional argument.
-byte data = mcp23xxx.Read(Register.Address.IPOL, Port.PortB);
+byte data = mcp23S17.Read(Register.Address.IPOL, Port.PortB);
 ```
 #### Example for 8-bit device
-The MCP23X08 only contains 1 port so you must use Bank 1 when addressing the correct register.  In this case, the optional arguments can be ignored.
+The MCP23X08 only contains 1 port so there is not choice for port and bank when addressing the register.
 
 ``` csharp
 // Read port A's GPIO Pull-Up Resistor Register (GPPU).
-byte data = mcp23xxx.Read(Register.Address.GPPU);
-// or..
-byte data = mcp23xxx.Read(Register.Address.GPPU, Port.PortA, Bank.Bank1);
+byte data = mcp23S08.Read(Register.Address.GPPU);
 ```
 
 ### Controller Pins
@@ -71,25 +69,25 @@ The `Mcp23xxx` has overloaded pin options when instantiating the device.  This i
 // Pin 10: Reset; Output to Mcp23xxx
 // Pin 25: INTA;  Input from Mcp23xxx
 // Pin 17: INTB;  Input from Mcp23xxx
-var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice, 10, 25, 17);
+var mcp23S17 = new Mcp23S17(0x20, spiDevice, 10, 25, 17);
 ```
 
 The MCP23XXX will be in the reset/disabled state by default if you use the reset pin.  You must call the `Enable()` method to activate the device.
 
 ```csharp
-var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice, 10, 25, 17);
-mcp23Sxx.Enable();
+var mcp23S17 = new Mcp23S17(0x20, spiDevice, 10, 25, 17);
+mcp23S17.Enable();
 // Can now communicate with device.
 
 // Turn off again if needed.
-mcp23Sxx.Disable();
+mcp23S17.Disable();
 ```
 
 **TODO**: Interrupt pins can only be read for now.  Events are coming in a future PR.
 ```csharp
-var mcp23Sxx = new Mcp23Sxx(0x20, spiDevice, 10, 25, 17);
-PinValue valueA = mcp23Sxx.ReadIntA();
-PinValue valueB = mcp23Sxx.ReadIntB();
+var mcp23S17 = new Mcp23S17(0x20, spiDevice, 10, 25, 17);
+PinValue interruptA = mcp23S17.ReadInterruptA();
+PinValue interruptB = mcp23S17.ReadInterruptB();
 ```
 
 ## References 

--- a/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
+++ b/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
@@ -20,27 +20,55 @@ namespace Iot.Device.Mcp23xxx.Samples
             Console.WriteLine("Hello Mcp23xxx!");
 
             Mcp23xxx mcp23xxx;
-            mcp23xxx = GetMcp230xx(); // I2C
-            //mcp23xxx = GetMcp23Sxx(); // SPI
+            //mcp23xxx = GetMcp23Sxx(Mcp23SxxDevice.Mcp23S08); // SPI
+            mcp23xxx = GetMcp230xx(Mcp230xxDevice.Mcp23017); // I2C
 
             // Uncomment sample to run.
             // ReadSwitchesWriteLeds(mcp23xxx);
-            // ReadAllRegisters(mcp23xxx);
-            WriteIndividualByte(mcp23xxx);
+            ReadAllRegisters(mcp23xxx);
+            // WriteIndividualByte(mcp23xxx);
             // WriteSequentialBytes(mcp23xxx);
         }
 
-        private static Mcp23xxx GetMcp230xx()
+        private enum Mcp230xxDevice
+        {
+            Mcp23008,
+            Mcp23009,
+            Mcp23017,
+            Mcp23018
+        }
+
+        private enum Mcp23SxxDevice
+        {
+            Mcp23S08,
+            Mcp23S09,
+            Mcp23S17,
+            Mcp23S18
+        }
+
+        private static Mcp230xx GetMcp230xx(Mcp230xxDevice mcp230xxDevice)
         {
             Console.WriteLine("Using I2C protocol");
 
             var connectionSettings = new I2cConnectionSettings(1, s_deviceAddress);
             var i2cDevice = new UnixI2cDevice(connectionSettings);
-            var mcp23Sxx = new Mcp230xx(i2cDevice);
-            return mcp23Sxx;
+
+            switch (mcp230xxDevice)
+            {
+                case Mcp230xxDevice.Mcp23008:
+                    return new Mcp23008(i2cDevice);
+                case Mcp230xxDevice.Mcp23009:
+                    return new Mcp23009(i2cDevice);
+                case Mcp230xxDevice.Mcp23017:
+                    return new Mcp23017(i2cDevice);
+                case Mcp230xxDevice.Mcp23018:
+                    return new Mcp23018(i2cDevice);
+                default:
+                    throw new Exception($"Invalid Mcp230xxDevice: {nameof(mcp230xxDevice)}");
+            }
         }
 
-        private static Mcp23xxx GetMcp23Sxx()
+        private static Mcp23Sxx GetMcp23Sxx(Mcp23SxxDevice mcp23SxxDevice)
         {
             Console.WriteLine("Using SPI protocol");
 
@@ -51,11 +79,23 @@ namespace Iot.Device.Mcp23xxx.Samples
             };
 
             var spiDevice = new UnixSpiDevice(connectionSettings);
-            var mcp23Sxx = new Mcp23Sxx(s_deviceAddress, spiDevice);
-            return mcp23Sxx;
+
+            switch (mcp23SxxDevice)
+            {
+                case Mcp23SxxDevice.Mcp23S08:
+                    return new Mcp23S08(s_deviceAddress, spiDevice);
+                case Mcp23SxxDevice.Mcp23S09:
+                    return new Mcp23S09(s_deviceAddress, spiDevice);
+                case Mcp23SxxDevice.Mcp23S17:
+                    return new Mcp23S17(s_deviceAddress, spiDevice);
+                case Mcp23SxxDevice.Mcp23S18:
+                    return new Mcp23S18(s_deviceAddress, spiDevice);
+                default:
+                    throw new Exception($"Invalid Mcp230xxDevice: {nameof(mcp23SxxDevice)}");
+            }
         }
 
-        private static void ReadSwitchesWriteLeds(Mcp23xxx mcp23xxx)
+        private static void ReadSwitchesWriteLeds(Mcp23Sxx mcp23xxx)
         {
             Console.WriteLine("Read Switches & Write LEDs");
 

--- a/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
+++ b/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Device.I2c;
+using System.Device.I2c.Drivers;
 using System.Device.Spi;
 using System.Device.Spi.Drivers;
 using System.Threading;
@@ -11,33 +13,46 @@ namespace Iot.Device.Mcp23xxx.Samples
 {
     class Program
     {
-        private static readonly int s_deviceAddress = 0;
+        private static readonly int s_deviceAddress = 0x20;
 
         static void Main(string[] args)
         {
             Console.WriteLine("Hello Mcp23xxx!");
 
-            Mcp23xxx mcp23xxx = GetMcp23xxxWithSpi();
+            Mcp23xxx mcp23xxx;
+            mcp23xxx = GetMcp230xx(); // I2C
+            //mcp23xxx = GetMcp23Sxx(); // SPI
 
             // Uncomment sample to run.
-            ReadSwitchesWriteLeds(mcp23xxx);
+            // ReadSwitchesWriteLeds(mcp23xxx);
             // ReadAllRegisters(mcp23xxx);
+            WriteIndividualByte(mcp23xxx);
             // WriteSequentialBytes(mcp23xxx);
         }
 
-        private static Mcp23xxx GetMcp23xxxWithSpi()
+        private static Mcp23xxx GetMcp230xx()
+        {
+            Console.WriteLine("Using I2C protocol");
+
+            var connectionSettings = new I2cConnectionSettings(1, s_deviceAddress);
+            var i2cDevice = new UnixI2cDevice(connectionSettings);
+            var mcp23Sxx = new Mcp230xx(i2cDevice);
+            return mcp23Sxx;
+        }
+
+        private static Mcp23xxx GetMcp23Sxx()
         {
             Console.WriteLine("Using SPI protocol");
 
-            var connection = new SpiConnectionSettings(0, 0)
+            var connectionSettings = new SpiConnectionSettings(0, 0)
             {
                 ClockFrequency = 1000000,
                 Mode = SpiMode.Mode0
             };
 
-            var spi = new UnixSpiDevice(connection);
-            var mcp23xxx = new Mcp23xxx(spi);
-            return mcp23xxx;
+            var spiDevice = new UnixSpiDevice(connectionSettings);
+            var mcp23Sxx = new Mcp23Sxx(s_deviceAddress, spiDevice);
+            return mcp23Sxx;
         }
 
         private static void ReadSwitchesWriteLeds(Mcp23xxx mcp23xxx)
@@ -47,16 +62,16 @@ namespace Iot.Device.Mcp23xxx.Samples
             using (mcp23xxx)
             {
                 // Input direction for switches.
-                mcp23xxx.Write(s_deviceAddress, Register.Address.IODIR, 0b1111_1111, Port.PortA, Bank.Bank0);                
+                mcp23xxx.Write(Register.Address.IODIR, 0b1111_1111, Port.PortA, Bank.Bank0);                
                 // Output direction for LEDs.
-                mcp23xxx.Write(s_deviceAddress, Register.Address.IODIR, 0b0000_0000, Port.PortB, Bank.Bank0);
+                mcp23xxx.Write(Register.Address.IODIR, 0b0000_0000, Port.PortB, Bank.Bank0);
 
                 while (true)
                 {
                     // Read switches.
-                    byte data = mcp23xxx.Read(s_deviceAddress, Register.Address.GPIO, Port.PortA, Bank.Bank0);
+                    byte data = mcp23xxx.Read(Register.Address.GPIO, Port.PortA, Bank.Bank0);
                     // Write data to LEDs.
-                    mcp23xxx.Write(s_deviceAddress, Register.Address.GPIO, data, Port.PortB, Bank.Bank0);
+                    mcp23xxx.Write(Register.Address.GPIO, data, Port.PortB, Bank.Bank0);
                     Console.WriteLine(data);
                     Thread.Sleep(500);
                 }
@@ -71,12 +86,44 @@ namespace Iot.Device.Mcp23xxx.Samples
             using (mcp23xxx)
             {
                 // Start at first register.  Total of 22 registers for MCP23x17.
-                byte[] data = mcp23xxx.Read(s_deviceAddress, 0, 22, Port.PortA, Bank.Bank0);
+                byte[] data = mcp23xxx.Read(0, 22, Port.PortA, Bank.Bank0);
 
                 for (int index = 0; index < data.Length; index++)
                 {
                     Console.WriteLine($"0x{index:X2}: 0x{data[index]:X2}");
                 }
+            }
+        }
+
+        private static void WriteIndividualByte(Mcp23xxx mcp23xxx)
+        {
+            // This assumes the device is in default Sequential Operation mode.
+            Console.WriteLine("Write Individual Byte");
+
+            using (mcp23xxx)
+            {
+                Register.Address address = Register.Address.IODIR;
+
+                void IndividualRead(Mcp23xxx mcp, Register.Address addressToRead)
+                {
+                    byte[] dataRead = mcp23xxx.Read(addressToRead, 1, Port.PortB, Bank.Bank0);
+                    Console.WriteLine($"\tIODIRB: 0x{dataRead[0]:X2}");
+                }
+
+                Console.WriteLine("Before Write");
+                IndividualRead(mcp23xxx, address);
+
+                byte[] dataWrite = new byte[] { 0x12 };
+                mcp23xxx.Write(address, dataWrite, Port.PortB, Bank.Bank0);
+
+                Console.WriteLine("After Write");
+                IndividualRead(mcp23xxx, address);
+
+                dataWrite = new byte[] { 0xFF };
+                mcp23xxx.Write(address, dataWrite, Port.PortB, Bank.Bank0);
+
+                Console.WriteLine("After Writing Again");
+                IndividualRead(mcp23xxx, address);
             }
         }
 
@@ -89,7 +136,7 @@ namespace Iot.Device.Mcp23xxx.Samples
             {
                 void SequentialRead(Mcp23xxx mcp)
                 {
-                    byte[] dataRead = mcp23xxx.Read(s_deviceAddress, 0, 2, Port.PortA, Bank.Bank0);
+                    byte[] dataRead = mcp23xxx.Read(0, 2, Port.PortA, Bank.Bank0);
                     Console.WriteLine($"\tIODIRA: 0x{dataRead[0]:X2}");
                     Console.WriteLine($"\tIODIRB: 0x{dataRead[1]:X2}");
                 }
@@ -98,9 +145,15 @@ namespace Iot.Device.Mcp23xxx.Samples
                 SequentialRead(mcp23xxx);
 
                 byte[] dataWrite = new byte[] { 0x12, 0x34 };
-                mcp23xxx.Write(s_deviceAddress, 0, dataWrite, Port.PortA, Bank.Bank0);
+                mcp23xxx.Write(0, dataWrite, Port.PortA, Bank.Bank0);
 
                 Console.WriteLine("After Write");
+                SequentialRead(mcp23xxx);
+
+                dataWrite = new byte[] { 0xFF, 0xFF };
+                mcp23xxx.Write(0, dataWrite, Port.PortA, Bank.Bank0);
+
+                Console.WriteLine("After Writing Again");
                 SequentialRead(mcp23xxx);
             }
         }

--- a/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
+++ b/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
@@ -19,13 +19,15 @@ namespace Iot.Device.Mcp23xxx.Samples
         {
             Console.WriteLine("Hello Mcp23xxx!");
 
-            var mcp23xxx = GetMcp23xxxDevice(Mcp23xxxDevice.Mcp23017);
-            
-            // Uncomment sample to run.
-            // ReadSwitchesWriteLeds(mcp23xxx);
-            ReadAllRegisters(mcp23xxx);
-            // WriteIndividualByte(mcp23xxx);
-            // WriteSequentialBytes(mcp23xxx);
+            using (var mcp23xxx = GetMcp23xxxDevice(Mcp23xxxDevice.Mcp23017))
+            {
+                // Uncomment sample to run.
+                // ReadSwitchesWriteLeds(mcp23xxx);
+                // ReadAllRegisters(mcp23xxx);
+                // WriteIndividualByte(mcp23xxx);
+                // WriteSequentialBytes(mcp23xxx);
+                ReadBits(mcp23xxx);
+            }
         }
 
         private enum Mcp23xxxDevice
@@ -184,6 +186,20 @@ namespace Iot.Device.Mcp23xxx.Samples
 
                 Console.WriteLine("After Writing Again");
                 SequentialRead(mcp23xxx);
+            }
+        }
+
+        private static void ReadBits(Mcp23xxx mcp23xxx)
+        {
+            Console.WriteLine("Read Bits");
+
+            using (mcp23xxx)
+            {
+                for (int bitNumber = 0; bitNumber < 8; bitNumber++)
+                {
+                    bool bit = mcp23xxx.ReadBit(Register.Address.GPIO, bitNumber, Port.PortA, Bank.Bank0);
+                    Console.WriteLine($"{bitNumber}: {bit}");
+                }
             }
         }
     }

--- a/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
+++ b/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
@@ -19,10 +19,8 @@ namespace Iot.Device.Mcp23xxx.Samples
         {
             Console.WriteLine("Hello Mcp23xxx!");
 
-            Mcp23xxx mcp23xxx;
-            //mcp23xxx = GetMcp23Sxx(Mcp23SxxDevice.Mcp23S08); // SPI
-            mcp23xxx = GetMcp230xx(Mcp230xxDevice.Mcp23017); // I2C
-
+            var mcp23xxx = GetMcp23xxxDevice(Mcp23xxxDevice.Mcp23017);
+            
             // Uncomment sample to run.
             // ReadSwitchesWriteLeds(mcp23xxx);
             ReadAllRegisters(mcp23xxx);
@@ -30,72 +28,63 @@ namespace Iot.Device.Mcp23xxx.Samples
             // WriteSequentialBytes(mcp23xxx);
         }
 
-        private enum Mcp230xxDevice
+        private enum Mcp23xxxDevice
         {
+            // I2C.
             Mcp23008,
             Mcp23009,
             Mcp23017,
-            Mcp23018
-        }
-
-        private enum Mcp23SxxDevice
-        {
+            Mcp23018,
+            // SPI.
             Mcp23S08,
             Mcp23S09,
             Mcp23S17,
             Mcp23S18
         }
 
-        private static Mcp230xx GetMcp230xx(Mcp230xxDevice mcp230xxDevice)
+        private static Mcp23xxx GetMcp23xxxDevice(Mcp23xxxDevice mcp23xxxDevice)
         {
-            Console.WriteLine("Using I2C protocol");
+            var i2cConnectionSettings = new I2cConnectionSettings(1, s_deviceAddress);
+            var i2cDevice = new UnixI2cDevice(i2cConnectionSettings);
 
-            var connectionSettings = new I2cConnectionSettings(1, s_deviceAddress);
-            var i2cDevice = new UnixI2cDevice(connectionSettings);
-
-            switch (mcp230xxDevice)
+            // I2C.
+            switch (mcp23xxxDevice)
             {
-                case Mcp230xxDevice.Mcp23008:
+                case Mcp23xxxDevice.Mcp23008:
                     return new Mcp23008(i2cDevice);
-                case Mcp230xxDevice.Mcp23009:
+                case Mcp23xxxDevice.Mcp23009:
                     return new Mcp23009(i2cDevice);
-                case Mcp230xxDevice.Mcp23017:
+                case Mcp23xxxDevice.Mcp23017:
                     return new Mcp23017(i2cDevice);
-                case Mcp230xxDevice.Mcp23018:
+                case Mcp23xxxDevice.Mcp23018:
                     return new Mcp23018(i2cDevice);
-                default:
-                    throw new Exception($"Invalid Mcp230xxDevice: {nameof(mcp230xxDevice)}");
             }
-        }
 
-        private static Mcp23Sxx GetMcp23Sxx(Mcp23SxxDevice mcp23SxxDevice)
-        {
-            Console.WriteLine("Using SPI protocol");
-
-            var connectionSettings = new SpiConnectionSettings(0, 0)
+            var spiConnectionSettings = new SpiConnectionSettings(0, 0)
             {
                 ClockFrequency = 1000000,
                 Mode = SpiMode.Mode0
             };
 
-            var spiDevice = new UnixSpiDevice(connectionSettings);
+            var spiDevice = new UnixSpiDevice(spiConnectionSettings);
 
-            switch (mcp23SxxDevice)
+            // SPI.
+            switch (mcp23xxxDevice)
             {
-                case Mcp23SxxDevice.Mcp23S08:
+                case Mcp23xxxDevice.Mcp23S08:
                     return new Mcp23S08(s_deviceAddress, spiDevice);
-                case Mcp23SxxDevice.Mcp23S09:
+                case Mcp23xxxDevice.Mcp23S09:
                     return new Mcp23S09(s_deviceAddress, spiDevice);
-                case Mcp23SxxDevice.Mcp23S17:
+                case Mcp23xxxDevice.Mcp23S17:
                     return new Mcp23S17(s_deviceAddress, spiDevice);
-                case Mcp23SxxDevice.Mcp23S18:
+                case Mcp23xxxDevice.Mcp23S18:
                     return new Mcp23S18(s_deviceAddress, spiDevice);
-                default:
-                    throw new Exception($"Invalid Mcp230xxDevice: {nameof(mcp23SxxDevice)}");
             }
+
+            throw new Exception($"Invalid Mcp23xxxDevice: {nameof(mcp23xxxDevice)}");
         }
 
-        private static void ReadSwitchesWriteLeds(Mcp23Sxx mcp23xxx)
+        private static void ReadSwitchesWriteLeds(Mcp23xxx mcp23xxx)
         {
             Console.WriteLine("Read Switches & Write LEDs");
 

--- a/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
+++ b/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
@@ -26,7 +26,8 @@ namespace Iot.Device.Mcp23xxx.Samples
                 // ReadAllRegisters(mcp23xxx);
                 // WriteIndividualByte(mcp23xxx);
                 // WriteSequentialBytes(mcp23xxx);
-                ReadBits(mcp23xxx);
+                // ReadBits(mcp23xxx);
+                WriteBits(mcp23xxx);
             }
         }
 
@@ -199,6 +200,28 @@ namespace Iot.Device.Mcp23xxx.Samples
                 {
                     bool bit = mcp23xxx.ReadBit(Register.Address.GPIO, bitNumber, Port.PortA, Bank.Bank0);
                     Console.WriteLine($"{bitNumber}: {bit}");
+                }
+            }
+        }
+
+        private static void WriteBits(Mcp23xxx mcp23xxx)
+        {
+            Console.WriteLine("Write Bits");
+
+            // Make port output and set all pins.
+            mcp23xxx.Write(Register.Address.IODIR, 0x00, Port.PortB, Bank.Bank0);
+            mcp23xxx.Write(Register.Address.GPIO, 0xFF, Port.PortB, Bank.Bank0);
+
+            using (mcp23xxx)
+            {
+                for (int bitNumber = 0; bitNumber < 8; bitNumber++)
+                {
+                    mcp23xxx.WriteBit(Register.Address.GPIO, bitNumber, false, Port.PortB, Bank.Bank0);
+                    Console.WriteLine($"Bit {bitNumber} low");
+                    Thread.Sleep(500);
+                    mcp23xxx.WriteBit(Register.Address.GPIO, bitNumber, true, Port.PortB, Bank.Bank0);
+                    Console.WriteLine($"Bit {bitNumber} high");
+                    Thread.Sleep(500);
                 }
             }
         }


### PR DESCRIPTION
Created an abstract and separated for I2C and SPI.

Modified addressing approach to instantiate binding with device instead of being able to address multiple devices within Read/Write methods.  This fits better with the connection settings.

Added controller pin options for reset and interrupt pins.  Events are planned for future PR.

Updated samples and documentation.

See https://github.com/dotnet/iot/issues/88 for future details.
