### PR TITLE
Added UART pins as GPIO pins for Board/Logical conversion

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -9,7 +9,7 @@ namespace System.Device.Gpio.Drivers
         /// <summary>
         /// Raspberry Pi 3 has 24 Gpio Pins.
         /// </summary>
-        protected internal override int PinCount => 24;
+        protected internal override int PinCount => 26;
 
         private void ValidatePinNumber(int pinNumber)
         {
@@ -26,6 +26,8 @@ namespace System.Device.Gpio.Drivers
                 case 3: return 2;
                 case 5: return 3;
                 case 7: return 4;
+                case 8: return 14;
+                case 10: return 15;
                 case 11: return 17;
                 case 12: return 18;
                 case 13: return 27;


### PR DESCRIPTION
RaspberryPi3Driver is missing the UART pins to perform the Board/Logical conversion.  The pins work while using the `PinNumberingScheme.Logical` scheme, but not `PinNumberingScheme.Board`.

If you tried creating a new `GpioController(PinNumberingScheme.Board)` and use related Tx (14) and Rx (15) for Read/Write, you get the following error.

Error: Board (header) pin 14 is not a GPIO pin on the RaspberryPi3Driver device
Parameter name: pinNumber

This PR adds the TXD (14) & RXD (15) pins and updates the pin count to 26.
