### PR TITLE
Cleanup for I2C drivers

### DIFF
--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Linux.cs
@@ -58,7 +58,7 @@ namespace System.Device.I2c.Drivers
 
                 if (_deviceFileDescriptor < 0)
                 {
-                    throw new IOException($"Cannot open I2C device file '{deviceFileName}'.");
+                    throw new IOException($"Can not open I2C device file '{deviceFileName}'.");
                 }
 
                 I2cFunctionalityFlags tempFlags;

--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Linux.cs
@@ -197,17 +197,17 @@ namespace System.Device.I2c.Drivers
         /// <summary>
         /// Writes data to the I2C device.
         /// </summary>
-        /// <param name="buffer">
+        /// <param name="data">
         /// The buffer that contains the data to be written to the I2C device.
         /// The data should not include the I2C device address.
         /// </param>
-        public override unsafe void Write(Span<byte> buffer)
+        public override unsafe void Write(Span<byte> data)
         {
             Initialize();
 
-            fixed (byte* bufferPointer = buffer)
+            fixed (byte* dataPointer = data)
             {
-                Transfer(bufferPointer, null, buffer.Length, 0);
+                Transfer(dataPointer, null, data.Length, 0);
             }
         }
 

--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Windows.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 namespace System.Device.I2c.Drivers
 {
     public class UnixI2cDevice : I2cDevice
@@ -19,6 +18,6 @@ namespace System.Device.I2c.Drivers
 
         public override void Write(Span<byte> data) => throw new PlatformNotSupportedException();
 
-        public override void WriteByte(byte data) => throw new PlatformNotSupportedException();
+        public override void WriteByte(byte buffer) => throw new PlatformNotSupportedException();
     }
 }

--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Windows.cs
@@ -18,6 +18,6 @@ namespace System.Device.I2c.Drivers
 
         public override void Write(Span<byte> data) => throw new PlatformNotSupportedException();
 
-        public override void WriteByte(byte buffer) => throw new PlatformNotSupportedException();
+        public override void WriteByte(byte data) => throw new PlatformNotSupportedException();
     }
 }

--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Linux.cs
@@ -17,6 +17,6 @@ namespace System.Device.I2c.Drivers
 
         public override void WriteByte(byte data) => throw new PlatformNotSupportedException();
 
-        public override void Write(Span<byte> data) => throw new PlatformNotSupportedException();
+        public override void Write(Span<byte> buffer) => throw new PlatformNotSupportedException();
     }
 }

--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Linux.cs
@@ -17,6 +17,6 @@ namespace System.Device.I2c.Drivers
 
         public override void WriteByte(byte data) => throw new PlatformNotSupportedException();
 
-        public override void Write(Span<byte> buffer) => throw new PlatformNotSupportedException();
+        public override void Write(Span<byte> data) => throw new PlatformNotSupportedException();
     }
 }

--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Windows.cs
@@ -7,11 +7,18 @@ using WinI2c = Windows.Devices.I2c;
 
 namespace System.Device.I2c.Drivers
 {
+    /// <summary>
+    /// Represents an I2C communication channel running on Windows 10 IoT.
+    /// </summary>
     public class Windows10I2cDevice : I2cDevice
     {
         private readonly I2cConnectionSettings _settings;
-        private WinI2c.I2cDevice _winDevice;
+        private WinI2c.I2cDevice _winI2cDevice;
 
+        /// <summary>
+        /// Initializes new instance of Windows10I2cDevice that will use the specified settings to communicate with the I2C device.
+        /// </summary>
+        /// <param name="settings">The connection settings of a device on an I2C bus.</param>
         public Windows10I2cDevice(I2cConnectionSettings settings)
         {
             _settings = settings;
@@ -23,46 +30,71 @@ namespace System.Device.I2c.Drivers
             DeviceInformationCollection deviceInformationCollection = DeviceInformation.FindAllAsync(deviceSelector).WaitForCompletion();
             if (deviceInformationCollection.Count == 0)
             {
-                throw new ArgumentException($"No I2C device exists for BusId {settings.BusId}", $"{nameof(settings)}.{nameof(settings.BusId)}");
+                throw new ArgumentException($"No I2C device exists for bus ID {settings.BusId}.", $"{nameof(settings)}.{nameof(settings.BusId)}");
             }
 
-            _winDevice = WinI2c.I2cDevice.FromIdAsync(deviceInformationCollection[0].Id, winSettings).WaitForCompletion();
-            if (_winDevice == null)
+            _winI2cDevice = WinI2c.I2cDevice.FromIdAsync(deviceInformationCollection[0].Id, winSettings).WaitForCompletion();
+            if (_winI2cDevice == null)
             {
                 throw new PlatformNotSupportedException($"I2C devices are not supported.");
             }
         }
 
+        /// <summary>
+        /// The connection settings of a device on an I2C bus.
+        /// </summary>
         public override I2cConnectionSettings ConnectionSettings => _settings;
 
+        /// <summary>
+        /// Reads a byte from the I2C device.        
+        /// </summary>
+        /// <returns>A byte read from the I2C device.</returns>
         public override byte ReadByte()
         {
             byte[] buffer = new byte[1];
-            _winDevice.Read(buffer);
+            _winI2cDevice.Read(buffer);
             return buffer[0];
         }
 
+        /// <summary>
+        /// Reads data from the I2C device.
+        /// </summary>
+        /// <param name="buffer">
+        /// The buffer to read the data from the I2C device.
+        /// The length of the buffer determines how much data to read from the I2C device.
+        /// </param>
         public override void Read(Span<byte> buffer)
         {
             byte[] byteArray = new byte[buffer.Length];
-            _winDevice.Read(byteArray);
+            _winI2cDevice.Read(byteArray);
             new Span<byte>(byteArray).CopyTo(buffer);
         }
 
+        /// <summary>
+        /// Writes a byte to the I2C device.
+        /// </summary>
+        /// <param name="data">The byte to be written to the I2C device.</param>
         public override void WriteByte(byte data)
         {
-            _winDevice.Write(new[] { data });
+            _winI2cDevice.Write(new[] { data });
         }
 
-        public override void Write(Span<byte> data)
+        /// <summary>
+        /// Writes data to the I2C device.
+        /// </summary>
+        /// <param name="buffer">
+        /// The buffer that contains the data to be written to the I2C device.
+        /// The data should not include the I2C device address.
+        /// </param>
+        public override void Write(Span<byte> buffer)
         {
-            _winDevice.Write(data.ToArray());
+            _winI2cDevice.Write(buffer.ToArray());
         }
 
         public override void Dispose(bool disposing)
         {
-            _winDevice?.Dispose();
-            _winDevice = null;
+            _winI2cDevice?.Dispose();
+            _winI2cDevice = null;
 
             base.Dispose(disposing);
         }

--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Windows.cs
@@ -46,7 +46,7 @@ namespace System.Device.I2c.Drivers
         public override I2cConnectionSettings ConnectionSettings => _settings;
 
         /// <summary>
-        /// Reads a byte from the I2C device.        
+        /// Reads a byte from the I2C device.
         /// </summary>
         /// <returns>A byte read from the I2C device.</returns>
         public override byte ReadByte()
@@ -82,13 +82,13 @@ namespace System.Device.I2c.Drivers
         /// <summary>
         /// Writes data to the I2C device.
         /// </summary>
-        /// <param name="buffer">
+        /// <param name="data">
         /// The buffer that contains the data to be written to the I2C device.
         /// The data should not include the I2C device address.
         /// </param>
-        public override void Write(Span<byte> buffer)
+        public override void Write(Span<byte> data)
         {
-            _winI2cDevice.Write(buffer.ToArray());
+            _winI2cDevice.Write(data.ToArray());
         }
 
         public override void Dispose(bool disposing)

--- a/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
@@ -5,7 +5,7 @@
 namespace System.Device.I2c
 {
     /// <summary>
-    /// The connection settings of a device on a I2C bus.
+    /// The connection settings of a device on an I2C bus.
     /// </summary>
     public sealed class I2cConnectionSettings
     {
@@ -14,8 +14,8 @@ namespace System.Device.I2c
         /// <summary>
         /// Initializes new instance of I2cConnectionSettings.
         /// </summary>
-        /// <param name="busId">The bus ID the device is connected to.</param>
-        /// <param name="deviceAddress">The bus address of the device.</param>
+        /// <param name="busId">The bus ID the I2C device is connected to.</param>
+        /// <param name="deviceAddress">The bus address of the I2C device.</param>
         public I2cConnectionSettings(int busId, int deviceAddress)
         {
             BusId = busId;
@@ -23,12 +23,12 @@ namespace System.Device.I2c
         }
 
         /// <summary>
-        /// The bus ID the device is connected to.
+        /// The bus ID the I2C device is connected to.
         /// </summary>
         public int BusId { get; }
 
         /// <summary>
-        /// The bus address of the device.
+        /// The bus address of the I2C device.
         /// </summary>
         public int DeviceAddress { get; }
     }

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
@@ -15,7 +15,7 @@ namespace System.Device.I2c
         public abstract I2cConnectionSettings ConnectionSettings { get; }
 
         /// <summary>
-        /// Reads a byte from the I2C device.        
+        /// Reads a byte from the I2C device.
         /// </summary>
         /// <returns>A byte read from the I2C device.</returns>
         public abstract byte ReadByte();
@@ -38,11 +38,11 @@ namespace System.Device.I2c
         /// <summary>
         /// Writes data to the I2C device.
         /// </summary>
-        /// <param name="buffer">
+        /// <param name="data">
         /// The buffer that contains the data to be written to the I2C device.
         /// The data should not include the I2C device address.
         /// </param>
-        public abstract void Write(Span<byte> buffer);
+        public abstract void Write(Span<byte> data);
 
         public void Dispose()
         {

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
@@ -4,13 +4,45 @@
 
 namespace System.Device.I2c
 {
+    /// <summary>
+    /// The communications channel to a device on an I2C bus.
+    /// </summary>
     public abstract class I2cDevice : IDisposable
     {
+        /// <summary>
+        /// The connection settings of a device on an I2C bus.
+        /// </summary>
         public abstract I2cConnectionSettings ConnectionSettings { get; }
+
+        /// <summary>
+        /// Reads a byte from the I2C device.        
+        /// </summary>
+        /// <returns>A byte read from the I2C device.</returns>
         public abstract byte ReadByte();
+
+        /// <summary>
+        /// Reads data from the I2C device.
+        /// </summary>
+        /// <param name="buffer">
+        /// The buffer to read the data from the I2C device.
+        /// The length of the buffer determines how much data to read from the I2C device.
+        /// </param>
         public abstract void Read(Span<byte> buffer);
+
+        /// <summary>
+        /// Writes a byte to the I2C device.
+        /// </summary>
+        /// <param name="data">The byte to be written to the I2C device.</param>
         public abstract void WriteByte(byte data);
-        public abstract void Write(Span<byte> data);
+
+        /// <summary>
+        /// Writes data to the I2C device.
+        /// </summary>
+        /// <param name="buffer">
+        /// The buffer that contains the data to be written to the I2C device.
+        /// The data should not include the I2C device address.
+        /// </param>
+        public abstract void Write(Span<byte> buffer);
 
         public void Dispose()
         {


### PR DESCRIPTION
Added summaries and random cleaning for I2C drivers.

It doesn't include the unsupported drivers (Windows10I2cDevice.Linux.cs, etc.) and private methods.

Referencing #72

**NOTE**: The editconfig file commit was from a previous PR.  Let me know if the causes an issue and I'll try to fix.