### PR TITLE
Cleanup for GPIO drivers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,160 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[project.json]
+indent_size = 2
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# only use var when it's obvious what the variable type is
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+
+# use language keywords instead of BCL types
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case 
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
+
+# Code style defaults
+dotnet_sort_system_directives_first = true
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.Linux.cs
@@ -77,10 +77,10 @@ namespace System.Device.Gpio.Drivers
         /// Blocks execution until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A structure that contains the result of the waiting operation.</returns>
-        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
@@ -89,19 +89,30 @@ namespace System.Device.Gpio.Drivers
         /// Async call until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="token">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
-        protected internal override ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        protected internal override ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Adds a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
         protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Removes a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
         protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
         {
             throw new NotImplementedException();

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.Linux.cs
@@ -9,9 +9,90 @@ namespace System.Device.Gpio.Drivers
 {
     public partial class HummingBoardDriver : GpioDriver
     {
+        /// <summary>
+        /// The number of pins provided by the driver.
+        /// </summary>
         protected internal override int PinCount => throw new NotImplementedException();
 
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Opens a pin in order for it to be ready to use.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        protected internal override void OpenPin(int pinNumber)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Closes an open pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        protected internal override void ClosePin(int pinNumber)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sets the mode to a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="mode">The mode to be set.</param>
+        protected internal override void SetPinMode(int pinNumber, PinMode mode)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Checks if a pin supports a specific mode.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="mode">The mode to check.</param>
+        /// <returns>The status if the pin supports the mode.</returns>
+        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Reads the current value of a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <returns>The value of the pin.</returns>
+        protected internal override PinValue Read(int pinNumber)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Writes a value to a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="value">The value to be written to the pin.</param>
+        protected internal override void Write(int pinNumber, PinValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Blocks execution until an event of type eventType is received or a cancellation is requested.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
+        /// <returns>A structure that contains the result of the waiting operation.</returns>
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Async call until an event of type eventType is received or a cancellation is requested.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="token">The cancellation token of when the operation should stop waiting for an event.</param>
+        /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
+        protected internal override ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
@@ -21,47 +102,12 @@ namespace System.Device.Gpio.Drivers
             throw new NotImplementedException();
         }
 
-        protected internal override void ClosePin(int pinNumber)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected internal override void OpenPin(int pinNumber)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected internal override PinValue Read(int pinNumber)
-        {
-            throw new NotImplementedException();
-        }
-
         protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
         {
             throw new NotImplementedException();
         }
 
-        protected internal override void SetPinMode(int pinNumber, PinMode mode)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected internal override ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected internal override void Write(int pinNumber, PinValue value)
+        protected override void Dispose(bool disposing)
         {
             throw new NotImplementedException();
         }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.cs
@@ -10,17 +10,25 @@ namespace System.Device.Gpio.Drivers
         {
             switch (pinNumber)
             {
-                case 7: return 1;
-                case 11: return 73;
-                case 12: return 72;
-                case 13: return 71;
-                case 15: return 10;
-                case 16: return 194;
-                case 18: return 195;
-                case 22: return 67;
+                case 7:
+                    return 1;
+                case 11:
+                    return 73;
+                case 12:
+                    return 72;
+                case 13:
+                    return 71;
+                case 15:
+                    return 10;
+                case 16:
+                    return 194;
+                case 18:
+                    return 195;
+                case 22:
+                    return 67;
             }
 
-            throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device", nameof(pinNumber));
+            throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber));
         }
 
         protected internal override PinMode GetPinMode(int pinNumber)

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.cs
@@ -4,8 +4,16 @@
 
 namespace System.Device.Gpio.Drivers
 {
+    /// <summary>
+    /// A GPIO driver for the HummingBoard.
+    /// </summary>
     public partial class HummingBoardDriver  // Different base classes declared in HummingboardDriver.Linux.cs and HummingboardDriver.Windows.cs
     {
+        /// <summary>
+        /// Converts a board pin number to the driver's logical numbering scheme.
+        /// </summary>
+        /// <param name="pinNumber">The board pin number to convert.</param>
+        /// <returns>The pin number in the driver's logical numbering scheme.</returns>
         protected internal override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
         {
             switch (pinNumber)
@@ -31,6 +39,11 @@ namespace System.Device.Gpio.Drivers
             throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber));
         }
 
+        /// <summary>
+        /// Gets the mode of a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <returns>The mode of the pin.</returns>
         protected internal override PinMode GetPinMode(int pinNumber)
         {
             throw new NotImplementedException();

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -19,143 +19,62 @@ namespace System.Device.Gpio.Drivers
         private UnixDriver _sysFSDriver = null;
         private readonly IDictionary<int, PinMode> _sysFSModes = new Dictionary<int, PinMode>();
 
-        protected override void Dispose(bool disposing)
+        private void Initialize()
         {
             if (_registerViewPointer != null)
             {
-                Interop.munmap((IntPtr)_registerViewPointer, 0);
-                _registerViewPointer = null;
+                return;
             }
+
+            lock (s_initializationLock)
+            {
+                if (_registerViewPointer != null)
+                {
+                    return;
+                }
+
+                int fileDescriptor = Interop.open(GpioMemoryFilePath, FileOpenFlags.O_RDWR | FileOpenFlags.O_SYNC);
+                if (fileDescriptor < 0)
+                {
+                    throw new IOException("Error initializing the Gpio driver.");
+                }
+
+                IntPtr mapPointer = Interop.mmap(IntPtr.Zero, Environment.SystemPageSize, (MemoryMappedProtections.PROT_READ | MemoryMappedProtections.PROT_WRITE), MemoryMappedFlags.MAP_SHARED, fileDescriptor, GpioRegisterOffset);
+                if (mapPointer.ToInt32() < 0)
+                {
+                    throw new IOException("Error initializing the Gpio driver.");
+                }
+
+                Interop.close(fileDescriptor);
+                _registerViewPointer = (RegisterView*)mapPointer;
+            }
+        }
+
+        private void InitializeSysFS()
+        {
             if (_sysFSDriver != null)
             {
-                _sysFSDriver.Dispose();
-                _sysFSDriver = null;
+                return;
             }
-        }
-
-        private PinMode GetModeForUnixDriver(PinMode mode)
-        {
-            switch (mode)
+            lock (s_sysFsInitializationLock)
             {
-                case PinMode.Input:
-                case PinMode.InputPullUp:
-                case PinMode.InputPullDown:
-                    return PinMode.Input;
-                case PinMode.Output:
-                    return PinMode.Output;
-                default:
-                    throw new InvalidOperationException($"Can not parse pin mode {_sysFSModes}");
+                if (_sysFSDriver != null)
+                {
+                    return;
+                }
+                _sysFSDriver = new UnixDriver();
             }
         }
 
-        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
-        {
-            ValidatePinNumber(pinNumber);
-            InitializeSysFS();
-
-            _sysFSDriver.OpenPin(pinNumber);
-            _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
-
-            _sysFSDriver.AddCallbackForPinValueChangedEvent(pinNumber, eventType, callback);
-        }
-
-        protected internal override void ClosePin(int pinNumber)
-        {
-            ValidatePinNumber(pinNumber);
-
-            if (_sysFSModes.ContainsKey(pinNumber) && _sysFSModes[pinNumber] == PinMode.Output)
-            {
-                Write(pinNumber, PinValue.Low);
-                SetPinMode(pinNumber, PinMode.Input);
-            }
-        }
-
-        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode)
-        {
-            switch(mode)
-            {
-                case PinMode.Input:
-                case PinMode.InputPullDown:
-                case PinMode.InputPullUp:
-                case PinMode.Output:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        protected internal override void OpenPin(int pinNumber)
-        {
-            ValidatePinNumber(pinNumber);
-            Initialize();
-            SetPinMode(pinNumber, PinMode.Input);
-        }
-
-        protected internal unsafe override PinValue Read(int pinNumber)
-        {
-            ValidatePinNumber(pinNumber);
-
-            /*
-             * There are two registers that contain the value of a pin. Each hold the value of 32 
-             * different pins. 1 bit represents the value of a pin, 0 is PinValue.Low and 1 is PinValue.High
-             */
-
-            uint register = _registerViewPointer->GPLEV[pinNumber / 32];
-            return Convert.ToBoolean((register >> (pinNumber % 32)) & 1) ? PinValue.High : PinValue.Low;
-        }
-
-        protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
-        {
-            ValidatePinNumber(pinNumber);
-            InitializeSysFS();
-
-            _sysFSDriver.OpenPin(pinNumber);
-            _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
-
-            _sysFSDriver.RemoveCallbackForPinValueChangedEvent(pinNumber, callback);
-        }
-
-        protected internal override void SetPinMode(int pinNumber, PinMode mode)
-        {
-            ValidatePinNumber(pinNumber);
-            IsPinModeSupported(pinNumber, mode);
-
-            /*
-             * There are 6 registers(4-byte ints) that control the mode for all pins. Each
-             * register controls the mode for 10 pins. Each pin uses 3 bits in the register
-             * containing the mode.
-             */
-
-            // Define the shift to get the right 3 bits in the register
-            int shift = (pinNumber % 10) * 3;
-            // Gets a pointer to the register that holds the mode for the pin
-            uint* registerPointer = &_registerViewPointer->GPFSEL[pinNumber / 10];
-            uint register = *registerPointer;
-            // Clear the 3 bits to 0 for the pin Number.
-            register &= ~(0b111U << shift);
-            // Set the 3 bits to the desired mode for that pin.
-            register |= (mode == PinMode.Output ? 1u : 0u) << shift;
-            *registerPointer = register;
-            
-            if (_sysFSModes.ContainsKey(pinNumber))
-            {
-                _sysFSModes[pinNumber] = mode;
-            }
-            else
-            {
-                _sysFSModes.Add(pinNumber, mode);
-            }
-
-            if (mode != PinMode.Output)
-            {
-                SetInputPullMode(pinNumber, mode);
-            }
-        }
-
+        /// <summary>
+        /// Sets the resistor pull up/down mode for an input pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="mode">The mode of a pin to set the resistor pull up/down mode.</param>
         private void SetInputPullMode(int pinNumber, PinMode mode)
         {
             byte modeToPullMode;
-            switch(mode)
+            switch (mode)
             {
                 case PinMode.Input:
                     modeToPullMode = 0;
@@ -210,28 +129,153 @@ namespace System.Device.Gpio.Drivers
             *gppudclkPointer = 0;
         }
 
-        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        /// <summary>
+        /// Gets the mode of a pin for Unix.
+        /// </summary>
+        /// <param name="mode">The mode of a pin to get.</param>
+        /// <returns>The mode of a pin for Unix.</returns>
+        private PinMode GetModeForUnixDriver(PinMode mode)
         {
-            ValidatePinNumber(pinNumber);
-            InitializeSysFS();
-
-            _sysFSDriver.OpenPin(pinNumber);
-            _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
-
-            return _sysFSDriver.WaitForEvent(pinNumber, eventType, cancellationToken);
+            switch (mode)
+            {
+                case PinMode.Input:
+                case PinMode.InputPullUp:
+                case PinMode.InputPullDown:
+                    return PinMode.Input;
+                case PinMode.Output:
+                    return PinMode.Output;
+                default:
+                    throw new InvalidOperationException($"Can not parse pin mode {_sysFSModes}");
+            }
         }
 
-        protected internal override ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        /// <summary>
+        /// Opens a pin in order for it to be ready to use.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        protected internal override void OpenPin(int pinNumber)
         {
             ValidatePinNumber(pinNumber);
-            InitializeSysFS();
-
-            _sysFSDriver.OpenPin(pinNumber);
-            _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
-
-            return _sysFSDriver.WaitForEventAsync(pinNumber, eventType, cancellationToken);
+            Initialize();
+            SetPinMode(pinNumber, PinMode.Input);
         }
 
+        /// <summary>
+        /// Closes an open pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        protected internal override void ClosePin(int pinNumber)
+        {
+            ValidatePinNumber(pinNumber);
+
+            if (_sysFSModes.ContainsKey(pinNumber) && _sysFSModes[pinNumber] == PinMode.Output)
+            {
+                Write(pinNumber, PinValue.Low);
+                SetPinMode(pinNumber, PinMode.Input);
+            }
+        }
+
+        /// <summary>
+        /// Sets the mode to a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="mode">The mode to be set.</param>
+        protected internal override void SetPinMode(int pinNumber, PinMode mode)
+        {
+            ValidatePinNumber(pinNumber);
+            IsPinModeSupported(pinNumber, mode);
+
+            /*
+             * There are 6 registers(4-byte ints) that control the mode for all pins. Each
+             * register controls the mode for 10 pins. Each pin uses 3 bits in the register
+             * containing the mode.
+             */
+
+            // Define the shift to get the right 3 bits in the register
+            int shift = (pinNumber % 10) * 3;
+            // Gets a pointer to the register that holds the mode for the pin
+            uint* registerPointer = &_registerViewPointer->GPFSEL[pinNumber / 10];
+            uint register = *registerPointer;
+            // Clear the 3 bits to 0 for the pin Number.
+            register &= ~(0b111U << shift);
+            // Set the 3 bits to the desired mode for that pin.
+            register |= (mode == PinMode.Output ? 1u : 0u) << shift;
+            *registerPointer = register;
+
+            if (_sysFSModes.ContainsKey(pinNumber))
+            {
+                _sysFSModes[pinNumber] = mode;
+            }
+            else
+            {
+                _sysFSModes.Add(pinNumber, mode);
+            }
+
+            if (mode != PinMode.Output)
+            {
+                SetInputPullMode(pinNumber, mode);
+            }
+        }
+
+        /// <summary>
+        /// Gets the mode of a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <returns>The mode of the pin.</returns>
+        protected internal override PinMode GetPinMode(int pinNumber)
+        {
+            ValidatePinNumber(pinNumber);
+
+            if (!_sysFSModes.ContainsKey(pinNumber))
+            {
+                throw new InvalidOperationException("Can not get a pin mode of a pin that is not open.");
+            }
+            return _sysFSModes[pinNumber];
+        }
+
+        /// <summary>
+        /// Checks if a pin supports a specific mode.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="mode">The mode to check.</param>
+        /// <returns>The status if the pin supports the mode.</returns>
+        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode)
+        {
+            switch(mode)
+            {
+                case PinMode.Input:
+                case PinMode.InputPullDown:
+                case PinMode.InputPullUp:
+                case PinMode.Output:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Reads the current value of a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <returns>The value of the pin.</returns>
+        protected internal unsafe override PinValue Read(int pinNumber)
+        {
+            ValidatePinNumber(pinNumber);
+
+            /*
+             * There are two registers that contain the value of a pin. Each hold the value of 32 
+             * different pins. 1 bit represents the value of a pin, 0 is PinValue.Low and 1 is PinValue.High
+             */
+
+            uint register = _registerViewPointer->GPLEV[pinNumber / 32];
+            return Convert.ToBoolean((register >> (pinNumber % 32)) & 1) ? PinValue.High : PinValue.Low;
+        }
+
+        /// <summary>
+        /// Writes a value to a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="value">The value to be written to the pin.</param>
         protected internal override void Write(int pinNumber, PinValue value)
         {
             ValidatePinNumber(pinNumber);
@@ -247,63 +291,77 @@ namespace System.Device.Gpio.Drivers
             register = 1U << (pinNumber % 32);
             *registerPointer = register;
         }
-        
-        private void InitializeSysFS()
+
+        /// <summary>
+        /// Blocks execution until an event of type eventType is received or a cancellation is requested.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
+        /// <returns>A structure that contains the result of the waiting operation.</returns>
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
         {
-            if (_sysFSDriver != null)
-            {
-                return;
-            }
-            lock (s_sysFsInitializationLock)
-            {
-                if (_sysFSDriver != null)
-                {
-                    return;
-                }
-                _sysFSDriver = new UnixDriver();
-            }
+            ValidatePinNumber(pinNumber);
+            InitializeSysFS();
+
+            _sysFSDriver.OpenPin(pinNumber);
+            _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
+
+            return _sysFSDriver.WaitForEvent(pinNumber, eventType, cancellationToken);
         }
 
-        private void Initialize()
+        /// <summary>
+        /// Async call until an event of type eventType is received or a cancellation is requested.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="token">The cancellation token of when the operation should stop waiting for an event.</param>
+        /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
+        protected internal override ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        {
+            ValidatePinNumber(pinNumber);
+            InitializeSysFS();
+
+            _sysFSDriver.OpenPin(pinNumber);
+            _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
+
+            return _sysFSDriver.WaitForEventAsync(pinNumber, eventType, cancellationToken);
+        }
+
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
+        {
+            ValidatePinNumber(pinNumber);
+            InitializeSysFS();
+
+            _sysFSDriver.OpenPin(pinNumber);
+            _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
+
+            _sysFSDriver.AddCallbackForPinValueChangedEvent(pinNumber, eventType, callback);
+        }
+
+        protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
+        {
+            ValidatePinNumber(pinNumber);
+            InitializeSysFS();
+
+            _sysFSDriver.OpenPin(pinNumber);
+            _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
+
+            _sysFSDriver.RemoveCallbackForPinValueChangedEvent(pinNumber, callback);
+        }
+
+        protected override void Dispose(bool disposing)
         {
             if (_registerViewPointer != null)
             {
-                return;
+                Interop.munmap((IntPtr)_registerViewPointer, 0);
+                _registerViewPointer = null;
             }
-
-            lock (s_initializationLock)
+            if (_sysFSDriver != null)
             {
-                if (_registerViewPointer != null)
-                {
-                    return;
-                }
-
-                int fileDescriptor = Interop.open(GpioMemoryFilePath, FileOpenFlags.O_RDWR | FileOpenFlags.O_SYNC);
-                if (fileDescriptor < 0)
-                {
-                    throw new IOException("Error initializing the Gpio driver.");
-                }
-
-                IntPtr mapPointer = Interop.mmap(IntPtr.Zero, Environment.SystemPageSize, (MemoryMappedProtections.PROT_READ | MemoryMappedProtections.PROT_WRITE), MemoryMappedFlags.MAP_SHARED, fileDescriptor, GpioRegisterOffset);
-                if (mapPointer.ToInt32() < 0)
-                {
-                    throw new IOException("Error initializing the Gpio driver.");
-                }
-
-                Interop.close(fileDescriptor);
-                _registerViewPointer = (RegisterView*)mapPointer;
+                _sysFSDriver.Dispose();
+                _sysFSDriver = null;
             }
-        }
-
-        protected internal override PinMode GetPinMode(int pinNumber)
-        {
-            ValidatePinNumber(pinNumber);
-
-            if (!_sysFSModes.ContainsKey(pinNumber))
-            {
-                throw new InvalidOperationException("Can not get a pin mode of a pin that is not open.");
-            }
-            return _sysFSModes[pinNumber];
         }
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -296,10 +296,10 @@ namespace System.Device.Gpio.Drivers
         /// Blocks execution until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A structure that contains the result of the waiting operation.</returns>
-        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             ValidatePinNumber(pinNumber);
             InitializeSysFS();
@@ -307,17 +307,17 @@ namespace System.Device.Gpio.Drivers
             _sysFSDriver.OpenPin(pinNumber);
             _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
 
-            return _sysFSDriver.WaitForEvent(pinNumber, eventType, cancellationToken);
+            return _sysFSDriver.WaitForEvent(pinNumber, eventTypes, cancellationToken);
         }
 
         /// <summary>
         /// Async call until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="token">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
-        protected internal override ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        protected internal override ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             ValidatePinNumber(pinNumber);
             InitializeSysFS();
@@ -325,9 +325,15 @@ namespace System.Device.Gpio.Drivers
             _sysFSDriver.OpenPin(pinNumber);
             _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
 
-            return _sysFSDriver.WaitForEventAsync(pinNumber, eventType, cancellationToken);
+            return _sysFSDriver.WaitForEventAsync(pinNumber, eventTypes, cancellationToken);
         }
 
+        /// <summary>
+        /// Adds a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
         protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
         {
             ValidatePinNumber(pinNumber);
@@ -339,6 +345,11 @@ namespace System.Device.Gpio.Drivers
             _sysFSDriver.AddCallbackForPinValueChangedEvent(pinNumber, eventType, callback);
         }
 
+        /// <summary>
+        /// Removes a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
         protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
         {
             ValidatePinNumber(pinNumber);

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -4,6 +4,9 @@
 
 namespace System.Device.Gpio.Drivers
 {
+    /// <summary>
+    /// A GPIO driver for the Raspberry Pi 3.
+    /// </summary>
     public partial class RaspberryPi3Driver  // Different base classes declared in RaspberryPi3Driver.Linux.cs and RaspberryPi3Driver.Windows.cs
     {
         /// <summary>
@@ -19,41 +22,74 @@ namespace System.Device.Gpio.Drivers
             }
         }
 
+        /// <summary>
+        /// Converts a board pin number to the driver's logical numbering scheme.
+        /// </summary>
+        /// <param name="pinNumber">The board pin number to convert.</param>
+        /// <returns>The pin number in the driver's logical numbering scheme.</returns>
         protected internal override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
         {
             switch (pinNumber)
             {
-                case 3: return 2;
-                case 5: return 3;
-                case 7: return 4;
-                case 8: return 14;
-                case 10: return 15;
-                case 11: return 17;
-                case 12: return 18;
-                case 13: return 27;
-                case 15: return 22;
-                case 16: return 23;
-                case 18: return 24;
-                case 19: return 10;
-                case 21: return 9;
-                case 22: return 25;
-                case 23: return 11;
-                case 24: return 8;
-                case 26: return 7;
-                case 27: return 0;
-                case 28: return 1;
-                case 29: return 5;
-                case 31: return 6;
-                case 32: return 12;
-                case 33: return 13;
-                case 35: return 19;
-                case 36: return 16;
-                case 37: return 26;
-                case 38: return 20;
-                case 40: return 21;
+                case 3:
+                    return 2;
+                case 5:
+                    return 3;
+                case 7:
+                    return 4;
+                case 8:
+                    return 14;
+                case 10:
+                    return 15;
+                case 11:
+                    return 17;
+                case 12:
+                    return 18;
+                case 13:
+                    return 27;
+                case 15:
+                    return 22;
+                case 16:
+                    return 23;
+                case 18:
+                    return 24;
+                case 19:
+                    return 10;
+                case 21:
+                    return 9;
+                case 22:
+                    return 25;
+                case 23:
+                    return 11;
+                case 24:
+                    return 8;
+                case 26:
+                    return 7;
+                case 27:
+                    return 0;
+                case 28:
+                    return 1;
+                case 29:
+                    return 5;
+                case 31:
+                    return 6;
+                case 32:
+                    return 12;
+                case 33:
+                    return 13;
+                case 35:
+                    return 19;
+                case 36:
+                    return 16;
+                case 37:
+                    return 26;
+                case 38:
+                    return 20;
+                case 40:
+                    return 21;
             }
 
-            throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {this.GetType().Name} device.", nameof(pinNumber));
+            throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber));
         }
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.Linux.cs
@@ -474,14 +474,14 @@ namespace System.Device.Gpio.Drivers
         /// Blocks execution until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A structure that contains the result of the waiting operation.</returns>
-        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             int pollFileDescriptor = -1;
             int valueFileDescriptor = -1;
-            SetPinEventsToDetect(pinNumber, eventType);
+            SetPinEventsToDetect(pinNumber, eventTypes);
             AddPinToPoll(pinNumber, ref valueFileDescriptor, ref pollFileDescriptor, out bool closePinValueFileDescriptor);
 
             bool eventDetected = WasEventDetected(pollFileDescriptor, valueFileDescriptor, out _, cancellationToken);
@@ -490,10 +490,16 @@ namespace System.Device.Gpio.Drivers
             return new WaitForEventResult
             {
                 TimedOut = !eventDetected,
-                EventType = eventType
+                EventType = eventTypes
             };
         }
 
+        /// <summary>
+        /// Adds a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
         protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
         {
             if (!_devicePins.ContainsKey(pinNumber))
@@ -514,6 +520,11 @@ namespace System.Device.Gpio.Drivers
             InitializeEventDetectionThread();
         }
 
+        /// <summary>
+        /// Removes a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
         protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
         {
             if (!_devicePins.ContainsKey(pinNumber))

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriverDevicePin.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriverDevicePin.Linux.cs
@@ -19,9 +19,13 @@ namespace System.Device.Gpio.Drivers
         public void OnPinValueChanged(PinValueChangedEventArgs args, PinEventTypes detectionOfEventTypes)
         {
             if (detectionOfEventTypes.HasFlag(PinEventTypes.Rising) && args.ChangeType == PinEventTypes.Rising)
+            {
                 ValueRising?.Invoke(this, args);
+            }
             if (detectionOfEventTypes.HasFlag(PinEventTypes.Falling) && args.ChangeType == PinEventTypes.Falling)
+            {
                 ValueFalling?.Invoke(this, args);
+            }
         }
 
         public bool IsCallbackListEmpty()

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.Windows.cs
@@ -123,15 +123,26 @@ namespace System.Device.Gpio.Drivers
         /// Blocks execution until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A structure that contains the result of the waiting operation.</returns>
-        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
-            => LookupOpenPin(pinNumber).WaitForEvent(eventType, cancellationToken);
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
+            => LookupOpenPin(pinNumber).WaitForEvent(eventTypes, cancellationToken);
 
-        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
-            => LookupOpenPin(pinNumber).AddCallbackForPinValueChangedEvent(eventType, callback);
+        /// <summary>
+        /// Adds a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+            => LookupOpenPin(pinNumber).AddCallbackForPinValueChangedEvent(eventTypes, callback);
 
+        /// <summary>
+        /// Removes a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
         protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
             => LookupOpenPin(pinNumber).RemoveCallbackForPinValueChangedEvent(callback);
 

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.Windows.cs
@@ -12,11 +12,9 @@ namespace System.Device.Gpio.Drivers
 {
     public class Windows10Driver : GpioDriver
     {
-        #region Fields
         private static readonly WinGpio.GpioController s_winGpioController = WinGpio.GpioController.GetDefault();
         private readonly Dictionary<int, Windows10DriverPin> _openPins = new Dictionary<int, Windows10DriverPin>();
-        #endregion Fields
-
+        
         public Windows10Driver()
         {
             if (s_winGpioController == null)
@@ -24,8 +22,6 @@ namespace System.Device.Gpio.Drivers
                 throw new NotSupportedException("No GPIO controllers exist on this system.");
             }
         }
-
-        #region GpioDriver Overrides
 
         protected internal override int PinCount => s_winGpioController.PinCount;
 
@@ -56,11 +52,9 @@ namespace System.Device.Gpio.Drivers
         protected internal override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
             => throw new PlatformNotSupportedException($"The {GetType().Name} driver does not support physical (board) numbering, since it's generic.");
 
-        protected internal override PinMode GetPinMode(int pinNumber)
-            => LookupOpenPin(pinNumber).GetPinMode();
+        protected internal override PinMode GetPinMode(int pinNumber) => LookupOpenPin(pinNumber).GetPinMode();
 
-        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode)
-            => LookupOpenPin(pinNumber).IsPinModeSupported(mode);
+        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode) => LookupOpenPin(pinNumber).IsPinModeSupported(mode);
 
         protected internal override void OpenPin(int pinNumber)
         {
@@ -84,21 +78,13 @@ namespace System.Device.Gpio.Drivers
         protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
             => LookupOpenPin(pinNumber).RemoveCallbackForPinValueChangedEvent(callback);
 
-        protected internal override void SetPinMode(int pinNumber, PinMode mode)
-            => LookupOpenPin(pinNumber).SetPinMode(mode);
+        protected internal override void SetPinMode(int pinNumber, PinMode mode) => LookupOpenPin(pinNumber).SetPinMode(mode);
 
         protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
             => LookupOpenPin(pinNumber).WaitForEvent(eventType, cancellationToken);
 
-        protected internal override void Write(int pinNumber, PinValue value)
-            => LookupOpenPin(pinNumber).Write(value);
-
-        #endregion GpioDriver Overrides
-
-        #region Private Implementation
+        protected internal override void Write(int pinNumber, PinValue value) => LookupOpenPin(pinNumber).Write(value);
 
         private Windows10DriverPin LookupOpenPin(int pinNumber) => _openPins[pinNumber];
-
-        #endregion Private Implementation
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10DriverPin.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10DriverPin.Windows.cs
@@ -53,7 +53,7 @@ namespace System.Device.Gpio.Drivers
         {
             if (eventType == PinEventTypes.None)
             {
-                throw new ArgumentException($"{PinEventTypes.None} is an invalid value", nameof(eventType));
+                throw new ArgumentException($"{PinEventTypes.None} is an invalid value.", nameof(eventType));
             }
 
             bool isFirstCallback = _risingCallbacks == null && _fallingCallbacks == null;
@@ -164,7 +164,7 @@ namespace System.Device.Gpio.Drivers
                 case PinMode.InputPullUp:
                     return WinGpio.GpioPinDriveMode.InputPullUp;
                 default:
-                    throw new ArgumentException($"GPIO pin mode not supported: {mode}", nameof(mode));
+                    throw new ArgumentException($"GPIO pin mode {mode} not supported.", nameof(mode));
             }
         }
 
@@ -181,7 +181,7 @@ namespace System.Device.Gpio.Drivers
                 case WinGpio.GpioPinDriveMode.InputPullUp:
                     return PinMode.InputPullUp;
                 default:
-                    throw new ArgumentException($"GPIO pin mode not supported: {mode}", nameof(mode));
+                    throw new ArgumentException($"GPIO pin mode {mode} not supported.", nameof(mode));
             }
         }
 
@@ -194,7 +194,7 @@ namespace System.Device.Gpio.Drivers
                 case WinGpio.GpioPinValue.High:
                     return PinValue.High;
                 default:
-                    throw new ArgumentException($"GPIO pin value not supported: {value}", nameof(value));
+                    throw new ArgumentException($"GPIO pin value {value} not supported.", nameof(value));
             }
         }
 
@@ -207,7 +207,7 @@ namespace System.Device.Gpio.Drivers
                 case PinValue.High:
                     return WinGpio.GpioPinValue.High;
                 default:
-                    throw new ArgumentException($"GPIO pin value not supported: {value}", nameof(value));
+                    throw new ArgumentException($"GPIO pin value {value} not supported.", nameof(value));
             }
         }
 
@@ -220,7 +220,7 @@ namespace System.Device.Gpio.Drivers
                 case WinGpio.GpioPinEdge.RisingEdge:
                     return PinEventTypes.Rising;
                 default:
-                    throw new ArgumentException($"GPIO pin edge value not supported: {edge}", nameof(edge));
+                    throw new ArgumentException($"GPIO pin edge value {edge} not supported.", nameof(edge));
             }
         }
 

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10DriverPin.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10DriverPin.Windows.cs
@@ -13,7 +13,6 @@ namespace System.Device.Gpio.Drivers
     internal class Windows10DriverPin : IDisposable
     {
         private const int ReasonableDebounceTimeoutMillseconds = 50;
-
         private WeakReference<Windows10Driver> _driver;
         private WinGpio.GpioPin _pin;
         private readonly int _pinNumber;

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -198,76 +198,76 @@ namespace System.Device.Gpio
         /// Blocks execution until an event of type eventType is received or a period of time has expired.
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="timeout">The time to wait for the event.</param>
         /// <returns>A structure that contains the result of the waiting operation.</returns>
-        public WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, TimeSpan timeout)
+        public WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, TimeSpan timeout)
         {
             CancellationTokenSource tokenSource = new CancellationTokenSource(timeout);
-            return WaitForEvent(pinNumber, eventType, tokenSource.Token);
+            return WaitForEvent(pinNumber, eventTypes, tokenSource.Token);
         }
 
         /// <summary>
         /// Blocks execution until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A structure that contains the result of the waiting operation.</returns>
-        public WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        public WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException("Can not wait for events from a pin that is not open.");
             }
-            return _driver.WaitForEvent(logicalPinNumber, eventType, cancellationToken);
+            return _driver.WaitForEvent(logicalPinNumber, eventTypes, cancellationToken);
         }
 
         /// <summary>
         /// Async call to wait until an event of type eventType is received or a period of time has expired.
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="timeout">The time to wait for the event.</param>
         /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation.</returns>
-        public ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, TimeSpan timeout)
+        public ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, TimeSpan timeout)
         {
             CancellationTokenSource tokenSource = new CancellationTokenSource(timeout);
-            return WaitForEventAsync(pinNumber, eventType, tokenSource.Token);
+            return WaitForEventAsync(pinNumber, eventTypes, tokenSource.Token);
         }
 
         /// <summary>
         /// Async call until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="token">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
-        public ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, CancellationToken token)
+        public ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, CancellationToken token)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException("Can not wait for events from a pin that is not open.");
             }
-            return _driver.WaitForEventAsync(logicalPinNumber, eventType, token);
+            return _driver.WaitForEventAsync(logicalPinNumber, eventTypes, token);
         }
 
         /// <summary>
         /// Adds a callback that will be invoked when pinNumber has an event of type eventType.
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="callback">The callback method that will be invoked.</param>
-        public void RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
+        public void RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException("Can not add callback for a pin that is not open.");
             }
-            _driver.AddCallbackForPinValueChangedEvent(logicalPinNumber, eventType, callback);
+            _driver.AddCallbackForPinValueChangedEvent(logicalPinNumber, eventTypes, callback);
         }
 
         /// <summary>

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -44,7 +44,7 @@ namespace System.Device.Gpio
         public PinNumberingScheme NumberingScheme { get; }
 
         /// <summary>
-        /// Returns the number of pins provided by the controller.
+        /// The number of pins provided by the controller.
         /// </summary>
         public int PinCount => _driver.PinCount;
 
@@ -122,7 +122,7 @@ namespace System.Device.Gpio
         /// Gets the mode of a pin.
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
-        /// <returns></returns>
+        /// <returns>The mode of the pin.</returns>
         public PinMode GetPinMode(int pinNumber)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
@@ -73,25 +73,36 @@ namespace System.Device.Gpio
         /// Blocks execution until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A structure that contains the result of the waiting operation.</returns>
-        protected internal abstract WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken);
+        protected internal abstract WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken);
 
         /// <summary>
         /// Async call until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
-        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="token">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
-        protected internal virtual ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        protected internal virtual ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
-            return new ValueTask<WaitForEventResult>(Task.Run(() => WaitForEvent(pinNumber, eventType, cancellationToken)));
+            return new ValueTask<WaitForEventResult>(Task.Run(() => WaitForEvent(pinNumber, eventTypes, cancellationToken)));
         }
 
-        protected internal abstract void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback);
+        /// <summary>
+        /// Adds a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
+        protected internal abstract void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback);
 
+        /// <summary>
+        /// Removes a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
         protected internal abstract void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback);
 
         public void Dispose()

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
@@ -9,27 +9,97 @@ namespace System.Device.Gpio
 {
     public abstract class GpioDriver : IDisposable
     {
+        /// <summary>
+        /// The number of pins provided by the driver.
+        /// </summary>
         protected internal abstract int PinCount { get; }
+
+        /// <summary>
+        /// Converts a board pin number to the driver's logical numbering scheme.
+        /// </summary>
+        /// <param name="pinNumber">The board pin number to convert.</param>
+        /// <returns>The pin number in the driver's logical numbering scheme.</returns>
         protected internal abstract int ConvertPinNumberToLogicalNumberingScheme(int pinNumber);
+
+        /// <summary>
+        /// Opens a pin in order for it to be ready to use.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         protected internal abstract void OpenPin(int pinNumber);
+
+        /// <summary>
+        /// Closes an open pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         protected internal abstract void ClosePin(int pinNumber);
+
+        /// <summary>
+        /// Sets the mode to a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="mode">The mode to be set.</param>
         protected internal abstract void SetPinMode(int pinNumber, PinMode mode);
+
+        /// <summary>
+        /// Gets the mode of a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <returns>The mode of the pin.</returns>
         protected internal abstract PinMode GetPinMode(int pinNumber);
+
+        /// <summary>
+        /// Checks if a pin supports a specific mode.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="mode">The mode to check.</param>
+        /// <returns>The status if the pin supports the mode.</returns>
         protected internal abstract bool IsPinModeSupported(int pinNumber, PinMode mode);
+
+        /// <summary>
+        /// Reads the current value of a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <returns>The value of the pin.</returns>
         protected internal abstract PinValue Read(int pinNumber);
+
+        /// <summary>
+        /// Writes a value to a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="value">The value to be written to the pin.</param>
         protected internal abstract void Write(int pinNumber, PinValue value);
+
+        /// <summary>
+        /// Blocks execution until an event of type eventType is received or a cancellation is requested.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
+        /// <returns>A structure that contains the result of the waiting operation.</returns>
         protected internal abstract WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Async call until an event of type eventType is received or a cancellation is requested.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="eventType">The event type to listen for.</param>
+        /// <param name="token">The cancellation token of when the operation should stop waiting for an event.</param>
+        /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
         protected internal virtual ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
         {
             return new ValueTask<WaitForEventResult>(Task.Run(() => WaitForEvent(pinNumber, eventType, cancellationToken)));
         }
+
         protected internal abstract void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback);
+
         protected internal abstract void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback);
+
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
+
         protected virtual void Dispose(bool disposing)
         {
             // Nothing to do in the base class.

--- a/src/System.Device.Gpio/System/Device/Gpio/PinChangeEventHandler.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinChangeEventHandler.cs
@@ -5,7 +5,7 @@
 namespace System.Device.Gpio
 {
     /// <summary>
-    /// Delegate that defines the structure for callbacks when an event occurs.
+    /// Delegate that defines the structure for callbacks when a pin value changed event occurs.
     /// </summary>
     /// <param name="sender">The sender of the event.</param>
     /// <param name="pinValueChangedEventArgs">The pin value changed arguments from the event.</param>

--- a/src/System.Device.Gpio/System/Device/Gpio/WaitForEventResult.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/WaitForEventResult.cs
@@ -10,7 +10,7 @@ namespace System.Device.Gpio
     public struct WaitForEventResult
     {
         /// <summary>
-        /// The event type to wait for.
+        /// The event types to wait for.
         /// </summary>
         public PinEventTypes EventType;
         /// <summary>


### PR DESCRIPTION
Added summaries and random cleaning for GPIO drivers.

There are a few areas that were rearranged for better grouping of method names.

It doesn't include the unsupported drivers (Windows10Device.Linux.cs, etc.).