### PR TITLE
Adding a Xunit project for running tests for System.Device.Gpio library.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
   	<PublishWindowsPdb>false</PublishWindowsPdb>
     <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
     <Language>C#</Language>
-    <TargetsWindows Condition="'$(RuntimeIdentifier)' == 'win'">true</TargetsWindows>
-    <TargetsLinux Condition="'$(RuntimeIdentifier)' == 'linux'">true</TargetsLinux>
+    <TargetsWindows Condition="$(RuntimeIdentifier.StartsWith('win'))">true</TargetsWindows>
+    <TargetsLinux Condition="$(RuntimeIdentifier.StartsWith('linux'))">true</TargetsLinux>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 

--- a/src/System.Device.Gpio.Tests/Directory.Build.props
+++ b/src/System.Device.Gpio.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <!--Project Configurations properties for VS-->
+  <PropertyGroup>
+    <RuntimeIdentifier Condition="'$(Configuration)' == 'Windows-Debug'">win-arm</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(Configuration)' == 'Linux-Debug'">linux-arm</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <Import Project="..\..\Directory.Build.props" />
+</Project>

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Threading;
+using Xunit;
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace System.Device.Gpio.Tests
+{
+    public abstract class GpioControllerTestBase
+    {
+        private const int LedPin = 18;
+        private const int OutputPin = 16;
+        private const int InputPin = 12;
+
+        [Fact]
+        public void ControllerCanTurnOnLEDs()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(LedPin, PinMode.Output);
+                Thread.Sleep(1_000);
+                controller.Write(LedPin, PinValue.High);
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+                controller.Write(LedPin, PinValue.Low);
+            }
+        }
+
+        [Fact]
+        public void PinValueReturnsToLowAfterDispose()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(OutputPin, PinMode.Output);
+                controller.OpenPin(InputPin, PinMode.Input);
+                controller.Write(OutputPin, PinValue.High);
+                Thread.SpinWait(100);
+                Assert.Equal(PinValue.High, controller.Read(InputPin));
+            }
+
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(OutputPin, PinMode.Output);
+                controller.OpenPin(InputPin, PinMode.Input);
+                Assert.Equal(PinValue.Low, controller.Read(InputPin));
+            }
+        }
+
+        [Fact]
+        public void PinValueReadAndWrite()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(OutputPin, PinMode.Output);
+                controller.OpenPin(InputPin, PinMode.Input);
+                controller.Write(OutputPin, PinValue.High);
+                Thread.SpinWait(100);
+                Assert.Equal(PinValue.High, controller.Read(InputPin));
+                controller.Write(OutputPin, PinValue.Low);
+                Thread.SpinWait(100);
+                Assert.Equal(PinValue.Low, controller.Read(InputPin));
+                controller.Write(OutputPin, PinValue.High);
+                Thread.SpinWait(100);
+                Assert.Equal(PinValue.High, controller.Read(InputPin));
+            }
+        }
+
+        [Fact]
+        public void ThrowsInvalidOperationExceptionWhenPinIsNotOpened()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                Assert.Throws<InvalidOperationException>(() => controller.Write(OutputPin, PinValue.High));
+                Assert.Throws<InvalidOperationException>(() => controller.Read(InputPin));
+                Assert.Throws<InvalidOperationException>(() => controller.ClosePin(OutputPin));
+                Assert.Throws<InvalidOperationException>(() => controller.SetPinMode(OutputPin, PinMode.Output));
+                Assert.Throws<InvalidOperationException>(() => controller.GetPinMode(OutputPin));
+            }
+        }
+
+        [Fact]
+        public void IsPinOpenTest()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                Assert.False(controller.IsPinOpen(LedPin));
+                controller.OpenPin(LedPin);
+                Assert.True(controller.IsPinOpen(LedPin));
+                controller.ClosePin(LedPin);
+                Assert.False(controller.IsPinOpen(LedPin));
+            }
+        }
+
+        [Fact]
+        public void ThrowsIfWritingOnInputPin()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(InputPin, PinMode.Input);
+                Assert.Throws<InvalidOperationException>(() => controller.Write(InputPin, PinValue.High));
+            }
+        }
+
+        [Fact]
+        public void ThrowsIfReadingFromOutputPin()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(OutputPin, PinMode.Output);
+                Assert.Throws<InvalidOperationException>(() => controller.Read(OutputPin));
+            }
+        }
+
+        [Fact]
+        public void OpenPinDefaultsModeToInput()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(OutputPin);
+                Assert.Equal(PinMode.Input, controller.GetPinMode(OutputPin));
+                controller.SetPinMode(OutputPin, PinMode.Output);
+                controller.ClosePin(OutputPin);
+                controller.OpenPin(OutputPin);
+                Assert.Equal(PinMode.Input, controller.GetPinMode(OutputPin));
+            }
+        }
+
+        [Fact]
+        public void AddCallbackTest()
+        {
+            while (!Debugger.IsAttached)
+                Thread.Sleep(1000);
+            Debugger.Break();
+
+            ManualResetEvent mre = new ManualResetEvent(false);
+            bool wasCalled = false;
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(InputPin, PinMode.Input);
+                controller.OpenPin(OutputPin, PinMode.Output);
+                controller.RegisterCallbackForPinValueChangedEvent(InputPin, PinEventTypes.Rising, callback);
+                controller.Write(OutputPin, PinValue.High);
+                mre.WaitOne(TimeSpan.FromSeconds(5));
+                Assert.True(wasCalled);
+            }
+
+            void callback(object sender, PinValueChangedEventArgs pinValueChangedEventArgs)
+            {
+                wasCalled = true;
+                mre.Set();
+            }
+        }
+
+        protected abstract GpioDriver GetTestDriver();
+        protected abstract PinNumberingScheme GetTestNumberingScheme();
+    }
+}

--- a/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.Linux.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.Linux.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Gpio.Drivers;
+using Xunit;
+
+namespace System.Device.Gpio.Tests
+{
+    public class RaspberryPiDriverTests : GpioControllerTestBase
+    {
+        protected override GpioDriver GetTestDriver() => new RaspberryPi3Driver();
+
+        protected override PinNumberingScheme GetTestNumberingScheme() => PinNumberingScheme.Logical;
+    }
+}

--- a/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
+++ b/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeIdentifiers>win-arm;linux-arm</RuntimeIdentifiers>
+    <IsPackable>false</IsPackable>
+    <Configurations>Debug;Release;Windows-Debug;Linux-Debug</Configurations>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)../System.Device.Gpio/System.Device.Gpio.csproj">
+      <AdditionalProperties Condition="'$(RuntimeIdentifier)' != ''">RuntimeIdentifier=$(RuntimeIdentifier.SubString(0, $(RuntimeIdentifier.IndexOf('-'))))</AdditionalProperties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
+    <!--Excluding Windows implementations-->
+    <Compile Remove="**\*.Windows.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <!--Excluding Linux implementations-->
+    <Compile Remove="**\*.Linux.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/System.Device.Gpio.Tests/UnixDriverTests.Linux.cs
+++ b/src/System.Device.Gpio.Tests/UnixDriverTests.Linux.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Gpio.Drivers;
+
+namespace System.Device.Gpio.Tests
+{
+    public class UnixDriverTests : GpioControllerTestBase
+    {
+        protected override GpioDriver GetTestDriver() => new UnixDriver();
+
+        protected override PinNumberingScheme GetTestNumberingScheme() => PinNumberingScheme.Logical;
+    }
+}

--- a/src/System.Device.Gpio.Tests/WindowsDriverTests.Windows.cs
+++ b/src/System.Device.Gpio.Tests/WindowsDriverTests.Windows.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Gpio.Drivers;
+
+namespace System.Device.Gpio.Tests
+{
+    public class WindowsDriverTests : GpioControllerTestBase
+    {
+        protected override GpioDriver GetTestDriver() => new Windows10Driver();
+
+        protected override PinNumberingScheme GetTestNumberingScheme() => PinNumberingScheme.Logical;
+    }
+}

--- a/src/System.Device.Gpio/System.Device.Gpio.sln
+++ b/src/System.Device.Gpio/System.Device.Gpio.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.106
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28509.92
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Device.Gpio", "System.Device.Gpio.csproj", "{35DCDFB2-150C-4ED9-B63F-22B3CEC87D54}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Device.Gpio.Tests", "..\System.Device.Gpio.Tests\System.Device.Gpio.Tests.csproj", "{B8423DF8-9DD2-40FE-990D-2B6543EB7F82}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,14 @@ Global
 		{35DCDFB2-150C-4ED9-B63F-22B3CEC87D54}.Release|Any CPU.Build.0 = Release|Any CPU
 		{35DCDFB2-150C-4ED9-B63F-22B3CEC87D54}.Windows-Debug|Any CPU.ActiveCfg = Windows-Debug|Any CPU
 		{35DCDFB2-150C-4ED9-B63F-22B3CEC87D54}.Windows-Debug|Any CPU.Build.0 = Windows-Debug|Any CPU
+		{B8423DF8-9DD2-40FE-990D-2B6543EB7F82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8423DF8-9DD2-40FE-990D-2B6543EB7F82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8423DF8-9DD2-40FE-990D-2B6543EB7F82}.Linux-Debug|Any CPU.ActiveCfg = Linux-Debug|Any CPU
+		{B8423DF8-9DD2-40FE-990D-2B6543EB7F82}.Linux-Debug|Any CPU.Build.0 = Linux-Debug|Any CPU
+		{B8423DF8-9DD2-40FE-990D-2B6543EB7F82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8423DF8-9DD2-40FE-990D-2B6543EB7F82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8423DF8-9DD2-40FE-990D-2B6543EB7F82}.Windows-Debug|Any CPU.ActiveCfg = Windows-Debug|Any CPU
+		{B8423DF8-9DD2-40FE-990D-2B6543EB7F82}.Windows-Debug|Any CPU.Build.0 = Windows-Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
cc: @joshfree @shaggygi @tarekgh @buyaa-n 

This will add a Xunit project in order to be able to add tests and run them on development boards. This change on its own won't actually start running these tests yet, but the idea is to get this project in, and then submit a PR that will do the work to submit to Helix the outputs of this build in order to run the tests on the actual devices.