### PR TITLE
Change PinValue to struct

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.Linux.cs
@@ -213,21 +213,8 @@ namespace System.Device.Gpio.Drivers
         }
 
         private string ConvertPinValueToSysFs(PinValue value)
-        {
-            string result = string.Empty;
-            switch (value)
-            {
-                case PinValue.High:
-                    result = "1";
-                    break;
-                case PinValue.Low:
-                    result = "0";
-                    break;
-                default:
-                    throw new ArgumentException($"Invalid pin value {value}.");
-            }
-            return result;
-        }
+
+            => value == PinValue.High ? "1" : "0";
 
         /// <summary>
         /// Checks if a pin supports a specific mode.

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10DriverPin.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10DriverPin.Windows.cs
@@ -198,17 +198,7 @@ namespace System.Device.Gpio.Drivers
         }
 
         private static WinGpio.GpioPinValue PinValueToGpioPinValue(PinValue value)
-        {
-            switch (value)
-            {
-                case PinValue.Low:
-                    return WinGpio.GpioPinValue.Low;
-                case PinValue.High:
-                    return WinGpio.GpioPinValue.High;
-                default:
-                    throw new ArgumentException($"GPIO pin value {value} not supported.", nameof(value));
-            }
-        }
+            => value == PinValue.High ? WinGpio.GpioPinValue.High : WinGpio.GpioPinValue.Low;
 
         private static PinEventTypes GpioEdgeToPinEventType(WinGpio.GpioPinEdge edge)
         {

--- a/src/System.Device.Gpio/System/Device/Gpio/PinValue.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinValue.cs
@@ -7,15 +7,35 @@ namespace System.Device.Gpio
     /// <summary>
     /// Represents a value for a pin.
     /// </summary>
-    public enum PinValue
+    public readonly struct PinValue : IEquatable<PinValue>
     {
-        /// <summary>
-        /// The value of the pin is low.
-        /// </summary>
-        Low = 0,
+        // This isn't bool so the struct will retain blittable. This
+        // allows arrays of PinValue and structs that contain PinValue to
+        // be stack allocated.
+        private readonly byte _value;
+
+        private PinValue(byte value) => _value = value;
+
         /// <summary>
         /// The value of the pin is high.
         /// </summary>
-        High = 1
+        public static PinValue High => new PinValue(1);
+
+        /// <summary>
+        /// The value of the pin is low.
+        /// </summary>
+        public static PinValue Low => new PinValue(0);
+
+        public static implicit operator PinValue(int value) => value == 0 ? Low : High;
+        public static implicit operator PinValue(bool value) => value ? High : Low;
+        public static explicit operator int(PinValue value) => value._value;
+        public static explicit operator bool(PinValue value) => value._value == 0 ? false : true;
+
+        public bool Equals(PinValue other) => other._value == _value;
+        public static bool operator ==(PinValue a, PinValue b) => a.Equals(b);
+        public static bool operator !=(PinValue a, PinValue b) => !a.Equals(b);
+        public override int GetHashCode() => _value.GetHashCode();
+
+        public override string ToString() => _value == 0 ? "Low" : "High";
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/PinValue.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinValue.cs
@@ -28,10 +28,20 @@ namespace System.Device.Gpio
 
         public static implicit operator PinValue(int value) => value == 0 ? Low : High;
         public static implicit operator PinValue(bool value) => value ? High : Low;
+        public static explicit operator byte(PinValue value) => value._value;
         public static explicit operator int(PinValue value) => value._value;
         public static explicit operator bool(PinValue value) => value._value == 0 ? false : true;
 
         public bool Equals(PinValue other) => other._value == _value;
+        public override bool Equals(object obj)
+        {
+            if (obj is PinValue)
+            {
+                return Equals((PinValue)obj);
+            }
+            return false;
+        }
+
         public static bool operator ==(PinValue a, PinValue b) => a.Equals(b);
         public static bool operator !=(PinValue a, PinValue b) => !a.Equals(b);
         public override int GetHashCode() => _value.GetHashCode();


### PR DESCRIPTION
Allows easier interop with raw data and enables us to extend with additional functionality. This will avoid having to add additional APIs for convenience and repeated typing of `PinValue == PinValue.High ? 1 :  0`.

Doesn't impact existing enum usage.

Sample usage:

``` C#
    class Program
    {
        static void Main(string[] args)
        {
            PinValue value = true;
            Console.WriteLine($"True is {value}");
            TestApi(0);
            Console.WriteLine($"Equality is {PinValue.High == true}");
        }

        public static void TestApi(PinValue value)
        {
            Console.WriteLine($"PinValue is {value}");
        }
    }
```