### PR TITLE
Initial implementation of NXP/TI PCX857X GPIO expanders.

### DIFF
--- a/src/devices/Mcp23xxx/Mcp23S08.cs
+++ b/src/devices/Mcp23xxx/Mcp23S08.cs
@@ -14,7 +14,7 @@ namespace Iot.Device.Mcp23xxx
     public class Mcp23s08 : Mcp23x0x
     {
         /// <summary>
-        /// Initializes s new instance of the Mcp23s08 device.
+        /// Initializes a new instance of the Mcp23s08 device.
         /// </summary>
         /// <param name="spiDevice">The SPI device used for communication.</param>
         /// <param name="deviceAddress">The device address for the connection on the SPI bus.</param>

--- a/src/devices/Mcp23xxx/Mcp23xxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23xxx.cs
@@ -280,6 +280,10 @@ namespace Iot.Device.Mcp23xxx
 
             ValidatePin(pinNumber);
 
+            byte SetBit(byte data, int bitNumber) => (byte)(data | (1 << bitNumber));
+
+            byte ClearBit(byte data, int bitNumber) => (byte)(data & ~(1 << bitNumber));
+
             if (pinNumber < 8)
             {
                 byte value = mode == PinMode.Output
@@ -383,10 +387,6 @@ namespace Iot.Device.Mcp23xxx
 
             _gpioCache = newValue;
         }
-
-        private byte SetBit(byte data, int bitNumber) => data |= (byte)(1 << bitNumber);
-
-        private byte ClearBit(byte data, int bitNumber) => data &= (byte)~(1 << bitNumber);
 
         private ushort SetBits(ushort current, ushort bits, ushort mask)
         {

--- a/src/devices/Mcp23xxx/README.md
+++ b/src/devices/Mcp23xxx/README.md
@@ -6,20 +6,20 @@ The MCP23XXX device family provides 8/16-bit, general purpose parallel I/O expan
 ## Device Family
 MCP23XXX devices contain different markings to distinguish features like interfacing, packaging, and temperature ratings.  For example, MCP23017 contains an I2C interface and MCP23S17 contains a SPI interface.  Please review specific datasheet for more information.
 
-**MCP23X08**: http://ww1.microchip.com/downloads/en/DeviceDoc/21919e.pdf  
-**MCP23X09**: http://ww1.microchip.com/downloads/en/DeviceDoc/20002121C.pdf  
-**MCP23X17**: http://ww1.microchip.com/downloads/en/DeviceDoc/20001952C.pdf  
-**MCP23X18**: http://ww1.microchip.com/downloads/en/DeviceDoc/22103a.pdf  
+**MCP23X08**: http://ww1.microchip.com/downloads/en/DeviceDoc/21919e.pdf
+**MCP23X09**: http://ww1.microchip.com/downloads/en/DeviceDoc/20002121C.pdf
+**MCP23X17**: http://ww1.microchip.com/downloads/en/DeviceDoc/20001952C.pdf
+**MCP23X18**: http://ww1.microchip.com/downloads/en/DeviceDoc/22103a.pdf
 
 **NOTE**: MCP23X16 contains different internal circuitry and is not compatible with this binding.
 
 ## Binding Notes
 
-This binding includes an `Mcp23xxx` abstract class and implementations for both I2C (`Mcp230xx`) and SPI (`Mcp23Sxx`) interfaces.  You can create either one by passing in the respective communication driver.
+This binding includes an `Mcp23xxx` abstract class and derived abstract classes for 8-bit `Mcp23x0x` and 16-bit `Mcp23x1x` variants.
 
 #### Mcp230xx I2C
 ```csharp
- // 0x20 is the device address in this example.
+// 0x20 is the device address in this example.
 var connectionSettings = new I2cConnectionSettings(1, 0x20);
 var i2cDevice = new UnixI2cDevice(connectionSettings);
 var mcp23S17 = new Mcp23017(i2cDevice);
@@ -36,30 +36,28 @@ var connectionSettings = new SpiConnectionSettings(0, 0)
 var spiDevice = new UnixSpiDevice(connectionSettings);
 
 // 0x20 is the device address in this example.
-var mcp23S17 = new Mcp23S17(0x20, spiDevice);
+var mcp23S17 = new Mcp23S17(spiDevice, 0x20);
 ```
-  
-### Register Banking
-The number of ports vary between MCP23XXX devices depending if it is 8-bit (1 port) or 16-bit (2 ports) expander.  The internal circuitry has a banking concept to group by port registers or by register type.  This enables different configurations for reading/writing schemes.  
 
-To allow this binding to work across the device family, you must use the provided arguments when using Reading/Writing methods.
+### Register Banking and Ports
+On 16-bit expanders the GPIO ports are grouped into 2 "ports". Via the `IGpioController` interface we expose the pins logically as 0-15, with the first bank being 0-7 and the second being 8-15.
+
+When using `ReadByte()` or `WriteByte()` on the 16-bit chips you can specify `PortA` or `PortB` to write to respective registers. The default is `PortA`. Reading and writing `ushort` writes to both ports.
+
+The internal circuitry has a banking concept to group by port registers or by register type.  This enables different configurations for reading/writing schemes. While we have some support for the bank styles it is not exposed directly. There is no safe way to detect the mode and most other drivers do not support anything but the defaults. You need to derive from `Mcp23xxx` directly.
 
 #### Example for 16-bit device
-The MCP23X17 has registers defaulted to Bank 1, which group port registers by type.  It is recommended to use the optional arguments for port and bank when addressing the correct register.
 
 ``` csharp
 // Read Port B's Input Polarity Port Register (IPOL).
-byte data = mcp23S17.Read(Register.Address.IPOL, Port.PortB, Bank.Bank0);
-
-// If the device is configured for Bank 1, you can ignore the optional argument.
-byte data = mcp23S17.Read(Register.Address.IPOL, Port.PortB);
+byte data = mcp23S17.Read(Register.IPOL, Port.PortB);
 ```
 #### Example for 8-bit device
-The MCP23X08 only contains 1 port so there is not choice for port and bank when addressing the register.
+The MCP23X08 only contains 1 port so there is not a choice for port when addressing the register.
 
 ``` csharp
 // Read port A's GPIO Pull-Up Resistor Register (GPPU).
-byte data = mcp23S08.Read(Register.Address.GPPU);
+byte data = mcp23S08.ReadByte(Register.GPPU);
 ```
 
 ### Controller Pins
@@ -69,13 +67,13 @@ The `Mcp23xxx` has overloaded pin options when instantiating the device.  This i
 // Pin 10: Reset; Output to Mcp23xxx
 // Pin 25: INTA;  Input from Mcp23xxx
 // Pin 17: INTB;  Input from Mcp23xxx
-var mcp23S17 = new Mcp23S17(0x20, spiDevice, 10, 25, 17);
+var mcp23S17 = new Mcp23S17(spiDevice, 0x20, 10, 25, 17);
 ```
 
 The MCP23XXX will be in the reset/disabled state by default if you use the reset pin.  You must call the `Enable()` method to activate the device.
 
 ```csharp
-var mcp23S17 = new Mcp23S17(0x20, spiDevice, 10, 25, 17);
+var mcp23S17 = new Mcp23S17(spiDevice, 0x20, 10, 25, 17);
 mcp23S17.Enable();
 // Can now communicate with device.
 
@@ -85,11 +83,11 @@ mcp23S17.Disable();
 
 **TODO**: Interrupt pins can only be read for now.  Events are coming in a future PR.
 ```csharp
-var mcp23S17 = new Mcp23S17(0x20, spiDevice, 10, 25, 17);
+var mcp23S17 = new Mcp23S17(spiDevice, 0x20, 10, 25, 17);
 PinValue interruptA = mcp23S17.ReadInterruptA();
 PinValue interruptB = mcp23S17.ReadInterruptB();
 ```
 
 ## References 
-https://www.adafruit.com/product/732  
+https://www.adafruit.com/product/732
 https://learn.adafruit.com/using-mcp23008-mcp23017-with-circuitpython/overview

--- a/src/devices/Pcx857x/Pca8574.cs
+++ b/src/devices/Pcx857x/Pca8574.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Gpio;
+using System.Device.I2c;
+
+namespace Iot.Device.Pcx857x
+{
+    /// <summary>
+    /// Remote 8-bit I/O expander for I2C-bus with interrupt.
+    /// </summary>
+    /// <remarks>
+    /// Fast mode I2C variant of the Pcf8574.
+    /// </remarks>
+    public class Pca8574 : Pcx8574
+    {
+        /// <summary>
+        /// Initializes a new instance of the Pca8574 device.
+        /// </summary>
+        /// <param name="device">The I2C device.</param>
+        /// <param name="interrupt">The interrupt pin number, if present.</param>
+        /// <param name="gpioController">
+        /// The GPIO controller for the <paramref name="interrupt"/>.
+        /// If not specified, the default controller will be used.
+        /// </param>
+        public Pca8574(I2cDevice device, int interrupt = -1, IGpioController gpioController = null)
+            : base(device, interrupt, gpioController)
+        {
+        }
+    }
+}

--- a/src/devices/Pcx857x/Pca8575.cs
+++ b/src/devices/Pcx857x/Pca8575.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Gpio;
+using System.Device.I2c;
+
+namespace Iot.Device.Pcx857x
+{
+    /// <summary>
+    /// Remote 16-bit I/O expander for I2C-bus with interrupt.
+    /// </summary>
+    /// <remarks>
+    /// Fast mode I2C variant of the Pcf8575.
+    /// </remarks>
+    public class Pca8575 : Pcx8575
+    {
+        /// <summary>
+        /// Initializes a new instance of the Pca8575 device.
+        /// </summary>
+        /// <param name="device">The I2C device.</param>
+        /// <param name="interrupt">The interrupt pin number, if present.</param>
+        /// <param name="gpioController">
+        /// The GPIO controller for the <paramref name="interrupt"/>.
+        /// If not specified, the default controller will be used.
+        /// </param>
+        public Pca8575(I2cDevice device, int interrupt = -1, IGpioController gpioController = null)
+            : base(device, interrupt, gpioController)
+        {
+        }
+    }
+}

--- a/src/devices/Pcx857x/Pcf8574.cs
+++ b/src/devices/Pcx857x/Pcf8574.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Gpio;
+using System.Device.I2c;
+
+namespace Iot.Device.Pcx857x
+{
+    /// <summary>
+    /// Remote 8-bit I/O expander for I2C-bus with interrupt.
+    /// </summary>
+    public class Pcf8574 : Pcx8574
+    {
+        /// <summary>
+        /// Initializes a new instance of the Pca8574 device.
+        /// </summary>
+        /// <param name="device">The I2C device.</param>
+        /// <param name="interrupt">The interrupt pin number, if present.</param>
+        /// <param name="gpioController">
+        /// The GPIO controller for the <paramref name="interrupt"/>.
+        /// If not specified, the default controller will be used.
+        /// </param>
+        public Pcf8574(I2cDevice device, int interrupt = -1, IGpioController gpioController = null)
+            : base (device, interrupt, gpioController)
+        {
+        }
+    }
+}

--- a/src/devices/Pcx857x/Pcf8575.cs
+++ b/src/devices/Pcx857x/Pcf8575.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Gpio;
+using System.Device.I2c;
+
+namespace Iot.Device.Pcx857x
+{
+    /// <summary>
+    /// Remote 16-bit I/O expander for I2C-bus with interrupt.
+    /// </summary>
+    public class Pcf8575 : Pcx8575
+    {
+        /// <summary>
+        /// /// Initializes a new instance of the Pcf8575 device.
+        /// </summary>
+        /// <param name="device">The I2C device.</param>
+        /// <param name="interrupt">The interrupt pin number, if present.</param>
+        /// <param name="gpioController">
+        /// The GPIO controller for the <paramref name="interrupt"/>.
+        /// If not specified, the default controller will be used.
+        /// </param>
+        public Pcf8575(I2cDevice device, int interrupt = -1, IGpioController gpioController = null)
+            : base(device, interrupt, gpioController)
+        {
+        }
+    }
+}

--- a/src/devices/Pcx857x/Pcx8574.cs
+++ b/src/devices/Pcx857x/Pcx8574.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Gpio;
+using System.Device.I2c;
+
+namespace Iot.Device.Pcx857x
+{
+    /// <summary>
+    /// Base class for 8 bit I/O expanders.
+    /// </summary>
+    public abstract class Pcx8574 : Pcx857x
+    {
+        public Pcx8574(I2cDevice device, int interrupt = -1, IGpioController gpioController = null)
+            : base(device, interrupt, gpioController)
+        {
+        }
+
+        public override int PinCount => 8;
+    }
+}

--- a/src/devices/Pcx857x/Pcx8575.cs
+++ b/src/devices/Pcx857x/Pcx8575.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Gpio;
+using System.Device.I2c;
+
+namespace Iot.Device.Pcx857x
+{
+    /// <summary>
+    /// Base class for 16 bit I/O expanders.
+    /// </summary>
+    public abstract class Pcx8575 : Pcx857x
+    {
+        public Pcx8575(I2cDevice device, int interrupt = -1, IGpioController gpioController = null)
+            : base(device, interrupt, gpioController)
+        {
+        }
+
+        public override int PinCount => 16;
+
+        public void WriteUInt16(ushort value) => InternalWriteUInt16(value);
+
+        public ushort ReadUInt16() => InternalReadUInt16();
+    }
+}

--- a/src/devices/Pcx857x/Pcx857x.cs
+++ b/src/devices/Pcx857x/Pcx857x.cs
@@ -1,0 +1,204 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Device.Gpio;
+using System.Device.I2c;
+using System.Runtime.CompilerServices;
+
+namespace Iot.Device.Pcx857x
+{
+    public abstract class Pcx857x : IGpioController
+    {
+        protected I2cDevice Device { get; }
+        private readonly IGpioController _masterGpioController;
+        private readonly int _interrupt;
+
+        // Pin mode bits- 0 for input, 1 for output to match PinMode
+        private ushort _pinModes;
+
+        // Pin value bits, 1 for high
+        private ushort _pinValues;
+
+        /// <summary>
+        /// Remote I/O expander for I2C-bus with interrupt.
+        /// </summary>
+        /// <param name="device">The I2C device.</param>
+        /// <param name="interrupt">The interrupt pin number, if present.</param>
+        /// <param name="gpioController">
+        /// The GPIO controller for the <paramref name="interrupt"/>.
+        /// If not specified, the default controller will be used.
+        /// </param>
+        public Pcx857x(I2cDevice device, int interrupt = -1, IGpioController gpioController = null)
+        {
+            Device = device ?? throw new ArgumentNullException(nameof(device));
+            _interrupt = interrupt;
+
+            if (_interrupt != -1)
+            {
+                _masterGpioController = gpioController ?? new GpioController();
+                _masterGpioController.OpenPin(_interrupt, PinMode.Input);
+            }
+
+            // These controllers do not have commands, setting the pins to high designates
+            // them as able to recieve input. As we don't want to set high on pins intended
+            // for output we'll set all of the pins to low for our initial state.
+            if (PinCount == 8)
+            {
+                WriteByte(0x00);
+            }
+            else
+            {
+                InternalWriteUInt16(0x0000);
+            }
+
+            _pinModes = 0xFFFF;
+        }
+
+        public byte ReadByte() => Device.ReadByte();
+
+        public void WriteByte(byte value) => Device.WriteByte(value);
+
+        protected ushort InternalReadUInt16()
+        {
+            Span<byte> buffer = stackalloc byte[2];
+            Device.Read(buffer);
+            return (ushort)(buffer[0] | buffer[1] << 8);
+        }
+
+        protected void InternalWriteUInt16(ushort value)
+        {
+            Span<byte> buffer = stackalloc byte[2];
+            buffer[0] = (byte)value;
+            buffer[1] = (byte)(value >> 8);
+            Device.Write(buffer);
+        }
+
+        /// <summary>
+        /// The I/O pin count of the device.
+        /// </summary>
+        public abstract int PinCount { get; }
+
+        public void ClosePin(int pinNumber)
+        {
+            // No-op
+        }
+
+        public void Dispose()
+        {
+            Device.Dispose();
+        }
+
+        public void OpenPin(int pinNumber, PinMode mode) => SetPinMode(pinNumber, mode);
+
+        public PinValue Read(int pinNumber)
+        {
+            Span<PinValuePair> values = stackalloc PinValuePair[]{ new PinValuePair(pinNumber, default) };
+            Read(values);
+            return values[0].PinValue;
+        }
+
+        public void Read(Span<PinValuePair> pinValues)
+        {
+            (uint pins, _) = new PinVector32(pinValues);
+            if (pins >> PinCount > 0)
+                ThrowInvalidPin(nameof(pinValues));
+
+            if ((pins & _pinModes) != 0)
+            {
+                // One of the specified pins was set to output (1)
+                throw new InvalidOperationException("Cannot read from output pins.");
+            }
+
+            ushort data = PinCount == 8 ? ReadByte() : InternalReadUInt16();
+
+            for (int i = 0; i < pinValues.Length; i++)
+            {
+                int pin = pinValues[i].PinNumber;
+                pinValues[i] = new PinValuePair(pin, (data >> pin) & 1);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowInvalidPin(string argumentName)
+        {
+            // This is a helper to allow the JIT to inline calling methods.
+            // (Methods with throws cannot be inlined.)
+            throw new ArgumentOutOfRangeException(argumentName, $"Pin numbers must be in the range of 0 to {PinCount - 1}.");
+        }
+
+        private void ValidatePinNumber(int pinNumber)
+        {
+            if (pinNumber < 0 || pinNumber >= PinCount)
+                ThrowInvalidPin(nameof(pinNumber));
+        }
+
+        public void SetPinMode(int pinNumber, PinMode mode)
+        {
+            ValidatePinNumber(pinNumber);
+            if (mode == PinMode.Input)
+            {
+                _pinModes = ClearBit(_pinModes, pinNumber);
+            }
+            else if (mode == PinMode.Output)
+            {
+                _pinModes = SetBit(_pinModes, pinNumber);
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(mode), "Only Input and Output modes are supported.");
+            }
+
+            WritePins(_pinValues);
+        }
+
+        private void WritePins(ushort value)
+        {
+            // We need to set all input pins to high
+            _pinValues = (ushort)(value | ~_pinModes);
+
+            if (PinCount == 8)
+            {
+                WriteByte((byte)_pinValues);
+            }
+            else
+            {
+                InternalWriteUInt16(_pinValues);
+            }
+        }
+
+        private ushort SetBit(ushort data, int bitNumber) => data |= (ushort)(1 << bitNumber);
+
+        private ushort ClearBit(ushort data, int bitNumber) => data &= (ushort)~(1 << bitNumber);
+
+        private ushort SetBits(ushort current, ushort bits, ushort mask)
+        {
+            current &= (ushort)~mask;
+            current |= bits;
+            return current;
+        }
+
+
+        public void Write(int pinNumber, PinValue value)
+        {
+            Span<PinValuePair> values = stackalloc PinValuePair[] { new PinValuePair(pinNumber, value) };
+            Write(values);
+        }
+
+        public void Write(ReadOnlySpan<PinValuePair> pinValues)
+        {
+            (uint pins, uint values) = new PinVector32(pinValues);
+            if (pins >> PinCount > 0)
+                ThrowInvalidPin(nameof(pinValues));
+
+            if ((pins & ~_pinModes) != 0)
+            {
+                // One of the specified pins was set to input (0)
+                throw new InvalidOperationException("Cannot write to input pins.");
+            }
+
+            WritePins(SetBits(_pinValues, (ushort)values, (ushort)pins));
+        }
+    }
+}

--- a/src/devices/Pcx857x/Pcx857x.cs
+++ b/src/devices/Pcx857x/Pcx857x.cs
@@ -137,6 +137,10 @@ namespace Iot.Device.Pcx857x
         public void SetPinMode(int pinNumber, PinMode mode)
         {
             ValidatePinNumber(pinNumber);
+
+            ushort SetBit(ushort data, int bitNumber) => (ushort)(data | (1 << bitNumber));
+            ushort ClearBit(ushort data, int bitNumber) => (ushort)(data & ~(1 << bitNumber));
+
             if (mode == PinMode.Input)
             {
                 _pinModes = ClearBit(_pinModes, pinNumber);
@@ -168,18 +172,6 @@ namespace Iot.Device.Pcx857x
             }
         }
 
-        private ushort SetBit(ushort data, int bitNumber) => data |= (ushort)(1 << bitNumber);
-
-        private ushort ClearBit(ushort data, int bitNumber) => data &= (ushort)~(1 << bitNumber);
-
-        private ushort SetBits(ushort current, ushort bits, ushort mask)
-        {
-            current &= (ushort)~mask;
-            current |= bits;
-            return current;
-        }
-
-
         public void Write(int pinNumber, PinValue value)
         {
             Span<PinValuePair> values = stackalloc PinValuePair[] { new PinValuePair(pinNumber, value) };
@@ -196,6 +188,13 @@ namespace Iot.Device.Pcx857x
             {
                 // One of the specified pins was set to input (0)
                 throw new InvalidOperationException("Cannot write to input pins.");
+            }
+
+            ushort SetBits(ushort current, ushort bits, ushort mask)
+            {
+                current &= (ushort)~mask;
+                current |= bits;
+                return current;
             }
 
             WritePins(SetBits(_pinValues, (ushort)values, (ushort)pins));

--- a/src/devices/Pcx857x/Pcx857x.csproj
+++ b/src/devices/Pcx857x/Pcx857x.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <EnableDefaultItems>false</EnableDefaultItems> <!--Disabling default items so samples source won't get build by the main library-->
+    <RootNamespace>Iot.Device.Pcx857x</RootNamespace>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Temporarily making a project reference until the daily has IGpioController
+      <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" /> 
+    -->
+    <ProjectReference Include="..\..\System.Device.Gpio\System.Device.Gpio.csproj">
+      <AdditionalProperties>Configuration=Linux-Debug;RuntimeIdentifier=linux</AdditionalProperties>
+    </ProjectReference>
+    <Compile Include="..\Common\System\Device\Gpio\PinVector32.cs" Link="PinVector32.cs" />
+    <Compile Include="..\Common\System\Device\Gpio\PinVector64.cs" Link="PinVector64.cs" />
+    <Compile Include="Pca8574.cs" />
+    <Compile Include="Pca8575.cs" />
+    <Compile Include="Pcf8574.cs" />
+    <Compile Include="Pcf8575.cs" />
+    <Compile Include="Pcx8574.cs" />
+    <Compile Include="Pcx8575.cs" />
+    <Compile Include="Pcx857x.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+
+</Project>

--- a/src/devices/Pcx857x/README.md
+++ b/src/devices/Pcx857x/README.md
@@ -1,0 +1,25 @@
+﻿# NXP/TI PCx857x
+
+## Summary
+The PCX857X device family provides 8/16-bit, general purpose parallel I/O expansion for I2C SPI applications. These chips provide simple I/O expansion with reduced bus traffic as they don't take command bytes.
+
+## Device Family
+PCX857X devices contain different markings to distinguish features like packaging, bus speed support, and address space.  Please review specific datasheet for more information.
+
+**PCF8574**: https://www.nxp.com/docs/en/data-sheet/PCF8574_PCF8574A.pdf
+**PCF8575**: https://www.nxp.com/docs/en/data-sheet/PCF8575.pdf
+**PCA8574**: https://www.nxp.com/docs/en/data-sheet/PCA8574_PCA8574A.pdf
+**PCA8575**: https://www.nxp.com/docs/en/data-sheet/PCA8575.pdf
+
+## Binding Notes
+
+This binding includes an `Pcx857x` abstract base class and derived abstract classes for both 8-bit (`Pcx8574`) and 16-bit (`Pcx8575`) variants.
+
+#### Pcf8574
+```csharp
+ // 0x20 is the device address in this example.
+var connectionSettings = new I2cConnectionSettings(1, 0x20);
+var i2cDevice = new UnixI2cDevice(connectionSettings);
+var pcf8574 = new Pcf8574(i2cDevice);
+```
+

--- a/src/devices/Pcx857x/tests/ConstructionTests.cs
+++ b/src/devices/Pcx857x/tests/ConstructionTests.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Iot.Device.Pcx857x.Tests
+{
+    public class ConstructionTests : Pcx857xTest
+    {
+        [Theory]
+        [MemberData(nameof(TestDevices))]
+        public void RegisterInitialization(TestDevice testDevice)
+        {
+            // All pins should be set to output.
+            Pcx857x device = testDevice.Device;
+            if (device.PinCount == 8)
+            {
+                Assert.Equal(0x00, device.ReadByte());
+            }
+            else
+            {
+                Pcx8575 device16 = (Pcx8575)device;
+                Assert.Equal(0x0000, device16.ReadUInt16());
+            }
+        }
+    }
+}

--- a/src/devices/Pcx857x/tests/ConstructionTests.cs
+++ b/src/devices/Pcx857x/tests/ConstructionTests.cs
@@ -20,6 +20,7 @@ namespace Iot.Device.Pcx857x.Tests
             }
             else
             {
+                Assert.Equal(16, device.PinCount);
                 Pcx8575 device16 = (Pcx8575)device;
                 Assert.Equal(0x0000, device16.ReadUInt16());
             }

--- a/src/devices/Pcx857x/tests/GpioReadTests.cs
+++ b/src/devices/Pcx857x/tests/GpioReadTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Device.Gpio;
+using Xunit;
+
+namespace Iot.Device.Pcx857x.Tests
+{
+    public class GpioReadTests : Pcx857xTest
+    {
+        [Theory]
+        [MemberData(nameof(TestDevices))]
+        public void Read_InvalidPin(TestDevice testDevice)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => testDevice.Device.Read(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => testDevice.Device.Read(testDevice.Device.PinCount));
+            Assert.Throws<ArgumentOutOfRangeException>(() => testDevice.Device.Read(testDevice.Device.PinCount + 1));
+        }
+
+        [Theory]
+        [MemberData(nameof(TestDevices))]
+        public void Read_GoodPin(TestDevice testDevice)
+        {
+            Pcx857x device = testDevice.Device;
+            for (int pin = 0; pin < testDevice.Device.PinCount; pin++)
+            {
+                // Set pin to input
+                device.SetPinMode(pin, PinMode.Input);
+
+                bool first = pin < 8;
+                int register = first ? 0x00 : 0x01;
+
+                // Flip the bit on (set the backing buffer directly to simulate incoming data)
+                testDevice.ChipMock.Registers[register] = (byte)(1 << (first ? pin : pin - 8));
+                Assert.Equal(PinValue.High, device.Read(pin));
+
+                // Clear the register
+                testDevice.ChipMock.Registers[register] = 0x00;
+                Assert.Equal(PinValue.Low, device.Read(pin));
+            }
+        }
+    }
+}

--- a/src/devices/Pcx857x/tests/GpioWriteTests.cs
+++ b/src/devices/Pcx857x/tests/GpioWriteTests.cs
@@ -6,14 +6,17 @@ using System;
 using System.Device.Gpio;
 using Xunit;
 
-namespace Iot.Device.Mcp23xxx.Tests
+namespace Iot.Device.Pcx857x.Tests
 {
-    public class GpioWriteTests : Mcp23xxxTest
+    public class GpioWriteTests : Pcx857xTest
     {
         [Theory]
         [MemberData(nameof(TestDevices))]
         public void Write_InvalidPin(TestDevice testDevice)
         {
+            // Set all pins to output
+            for (int pin = 0; pin < testDevice.Device.PinCount; pin++)
+
             Assert.Throws<ArgumentOutOfRangeException>(() => testDevice.Device.Write(-1, PinValue.High));
             Assert.Throws<ArgumentOutOfRangeException>(() => testDevice.Device.Write(testDevice.Device.PinCount, PinValue.Low));
             Assert.Throws<ArgumentOutOfRangeException>(() => testDevice.Device.Write(testDevice.Device.PinCount + 1, PinValue.High));
@@ -23,7 +26,7 @@ namespace Iot.Device.Mcp23xxx.Tests
         [MemberData(nameof(TestDevices))]
         public void Write_GoodPin(TestDevice testDevice)
         {
-            Mcp23xxx device = testDevice.Device;
+            Pcx857x device = testDevice.Device;
             for (int pin = 0; pin < testDevice.Device.PinCount; pin++)
             {
                 bool first = pin < 8;
@@ -32,11 +35,11 @@ namespace Iot.Device.Mcp23xxx.Tests
                 byte expected = (byte)(1 << (first ? pin : pin - 8));
 
                 Assert.Equal(expected,
-                    first ? device.ReadByte(Register.OLAT) : ((Mcp23x1x)device).ReadByte(Register.OLAT, Port.PortB));
+                    first ? device.ReadByte() : (byte)(((Pcx8575)device).ReadUInt16() >> 8));
 
                 device.Write(pin, PinValue.Low);
                 Assert.Equal(0,
-                    first ? device.ReadByte(Register.OLAT) : ((Mcp23x1x)device).ReadByte(Register.OLAT, Port.PortB));
+                    first ? device.ReadByte() : (byte)(((Pcx8575)device).ReadUInt16() >> 8));
             }
         }
     }

--- a/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
+++ b/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <!--
+      Temporarily making a project reference until the daily has IGpioController
+      <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" /> 
+    -->
+    <ProjectReference Include="..\..\..\System.Device.Gpio\System.Device.Gpio.csproj">
+      <AdditionalProperties>Configuration=Linux-Debug;RuntimeIdentifier=linux</AdditionalProperties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pcx857x.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/devices/Pcx857x/tests/Pcx857xTest.cs
+++ b/src/devices/Pcx857x/tests/Pcx857xTest.cs
@@ -1,0 +1,177 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Device.Gpio;
+using System.Device.I2c;
+using Xunit;
+
+namespace Iot.Device.Pcx857x.Tests
+{
+    public class Pcx857xTest
+    {
+        public static TheoryData<TestDevice> TestDevices
+        {
+            get
+            {
+                TheoryData<TestDevice> devices = new TheoryData<TestDevice>();
+
+                // Don't want to use the same bus mock for each
+                I2cDeviceMock i2c = new I2cDeviceMock(1);
+                devices.Add(new TestDevice(new Pcf8574(i2c), i2c.DeviceMock));
+                i2c = new I2cDeviceMock(1);
+                devices.Add(new TestDevice(new Pca8574(i2c), i2c.DeviceMock));
+                i2c = new I2cDeviceMock(2);
+                devices.Add(new TestDevice(new Pcf8575(i2c), i2c.DeviceMock));
+                i2c = new I2cDeviceMock(2);
+                devices.Add(new TestDevice(new Pca8575(i2c), i2c.DeviceMock));
+                return devices;
+            }
+        }
+
+        public struct TestDevice
+        {
+            public Pcx857x Device { get; }
+            public Pcx857xChipMock ChipMock { get; }
+
+            public TestDevice(Pcx857x device, Pcx857xChipMock chipMock)
+            {
+                Device = device;
+                ChipMock = chipMock;
+            }
+        }
+
+        protected class I2cDeviceMock : I2cDevice
+        {
+            private I2cConnectionSettings _settings;
+            public Pcx857xChipMock DeviceMock { get; private set; }
+
+            public I2cDeviceMock(int ports, I2cConnectionSettings settings = null)
+            {
+                DeviceMock = new Pcx857xChipMock(ports);
+                _settings = settings ?? new I2cConnectionSettings(0, 0x20);
+            }
+
+            public override I2cConnectionSettings ConnectionSettings => _settings;
+
+            public override void Read(Span<byte> buffer) => DeviceMock.Read(buffer);
+            public override void Write(Span<byte> data) => DeviceMock.Write(data);
+
+            // Don't need these
+            public override void WriteByte(byte data) => DeviceMock.WriteByte(data);
+            public override byte ReadByte() => DeviceMock.ReadByte();
+        }
+
+        /// <summary>
+        /// Mock the behavior of the chip
+        /// </summary>
+        public class Pcx857xChipMock
+        {
+            private int _ports;
+            private byte[] _registers;
+            private byte[] _lastReadBuffer;
+            private byte[] _lastWriteBuffer;
+
+            public Pcx857xChipMock(int ports)
+            {
+                _ports = ports;
+                _registers = new byte[ports];
+            }
+
+            public Span<byte> Registers => _registers;
+
+            // Can't coalesce here https://github.com/dotnet/roslyn/issues/29927
+            public ReadOnlySpan<byte> LastReadBuffer => _lastReadBuffer == null ? ReadOnlySpan<byte>.Empty : _lastReadBuffer;
+            public ReadOnlySpan<byte> LastWriteBuffer => _lastWriteBuffer == null ? ReadOnlySpan<byte>.Empty : _lastWriteBuffer;
+
+            public void Read(Span<byte> buffer)
+            {
+                _lastReadBuffer = buffer.ToArray();
+
+                for (int i = 0; i < buffer.Length; i++)
+                {
+                    buffer[i] = _registers[i];
+                }
+            }
+
+            public void Write(Span<byte> data)
+            {
+                _lastWriteBuffer = data.ToArray();
+
+                for (int i = 0; i < data.Length; i++)
+                {
+                    _registers[i] = data[i];
+                }
+            }
+
+            public byte ReadByte()
+            {
+                Span<byte> buffer = stackalloc byte[1];
+                Read(buffer);
+                return buffer[0];
+            }
+
+            public void WriteByte(byte value)
+            {
+                Span<byte> buffer = stackalloc byte[] { value };
+                Write(buffer);
+            }
+        }
+
+
+        public class GpioControllerMock : IGpioController
+        {
+            private Dictionary<int, PinValue> _pinValues = new Dictionary<int, PinValue>();
+
+            public void Reset() => _pinValues = new Dictionary<int, PinValue>();
+
+            public void ClosePin(int pinNumber)
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public void OpenPin(int pinNumber, PinMode mode)
+            {
+            }
+
+            public PinValue Read(int pinNumber)
+            {
+                if (_pinValues.TryGetValue(pinNumber, out PinValue value))
+                    return value;
+
+                return PinValue.Low;
+            }
+
+            public void Read(Span<PinValuePair> pinValues)
+            {
+                for (int i = 0; i < pinValues.Length; i++)
+                {
+                    int pin = pinValues[i].PinNumber;
+                    pinValues[i] = new PinValuePair(pin, Read(pin));
+                }
+            }
+
+            public void SetPinMode(int pinNumber, PinMode mode)
+            {
+            }
+
+            public void Write(int pinNumber, PinValue value)
+            {
+                _pinValues[pinNumber] = value;
+            }
+
+            public void Write(ReadOnlySpan<PinValuePair> pinValues)
+            {
+                foreach ((int pin, PinValue value) in pinValues)
+                {
+                    Write(pin, value);
+                }
+            }
+        }
+    }
+}

--- a/src/devices/README.md
+++ b/src/devices/README.md
@@ -21,6 +21,7 @@ Our vision: the majority of .NET bindings are written completely in .NET languag
 * [Mcp23xxx -- I/O Expander](Mcp23xxx/README.md)
 * [Mcp3008 -- Analog-to-Digital Converter](Mcp3008/README.md)
 * [Pca95x4 -- I2C GPIO Expander](Pca95x4/README.md)
+* [Pcx857x -- I2C GPIO Expander](Pcx857x/README.md)
 * [Servo -- Servomotor Controller](Servo/README.md)
 * [Si7021 -- Temperature & Humidity Sensor](Si7021/README.md)
 * [SoftPwm -- Software PWM](SoftPwm/README.md)


### PR DESCRIPTION
Tested on PCX8574A with a 1602LCD.

This does not include the readme, sample app, etc. I'll be following up with those. Getting this up pending #222 (which this includes) to illustrate GPIO API consumption.

See the most recent commit https://github.com/dotnet/iot/commit/c1721a47d040e0157b1bf90b0e8cc46932bb6bf1 for this change. I'll rebase once #222 is in.