### PR TITLE
Adding System.Device.Gpio.Native to the package

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -49,8 +49,8 @@ phases:
     - task: PublishBuildArtifacts@1
       displayName: Publish Windows managed assets
       inputs:
-        pathToPublish: $(Build.SourcesDirectory)/artifacts
-        artifactName: artifacts
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/bin
+        artifactName: bin
         artifactType: container
       condition: eq(variables['_BuildConfig'], 'Release')
     variables:
@@ -170,8 +170,8 @@ phases:
     - task: DownloadBuildArtifacts@0
       displayName: Download Built Managed Assets
       inputs:
-        artifactName: artifacts
-        downloadPath: $(Build.SourcesDirectory)
+        artifactName: bin
+        downloadPath: $(Build.SourcesDirectory)/artifacts
     - task: DownloadBuildArtifacts@0
       displayName: Download Built Native Assets
       inputs:
@@ -188,13 +188,14 @@ phases:
       name: Build
       displayName: Build
       condition: succeeded()
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Windows package assets
-      inputs:
-        pathToPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping
-        artifactName: BuiltPackageOutputs
-        artifactType: container
-      condition: eq(variables['_BuildConfig'], 'Release')
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Windows package assets
+        inputs:
+          pathToPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping
+          artifactName: BuiltPackageOutputs
+          artifactType: container
+        condition: eq(variables['_BuildConfig'], 'Release')
     variables:
       _HelixBuildConfig: $(_BuildConfig)
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -40,7 +40,7 @@ phases:
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       enableMicrobuild: true
     steps:
-    - script: build.cmd -ci -sign
+    - script: build.cmd -ci
         -configuration $(_BuildConfig)
         -prepareMachine
       name: Build

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -40,20 +40,19 @@ phases:
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       enableMicrobuild: true
     steps:
-    - script: eng\common\cibuild.cmd
+    - script: build.cmd -ci -sign
         -configuration $(_BuildConfig)
         -prepareMachine
       name: Build
       displayName: Build
       condition: succeeded()
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Publish Windows package assets
-        inputs:
-          pathToPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping
-          artifactName: BuiltPackageOutputs
-          artifactType: container
-        condition: eq(variables['_BuildConfig'], 'Release')
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Windows managed assets
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts
+        artifactName: artifacts
+        artifactType: container
+      condition: eq(variables['_BuildConfig'], 'Release')
     variables:
       _HelixBuildConfig: $(_BuildConfig)
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -74,7 +73,7 @@ phases:
         release_configuration:
           _BuildConfig: Release
     steps:
-    - script: eng/common/cibuild.sh
+    - script: ./build.sh --ci
         --configuration $(_BuildConfig)
         --prepareMachine
       name: Build
@@ -130,23 +129,83 @@ phases:
       name: MoveLibgpiod
       displayName: Move Libgpiod into crossrootfs
       condition: succeeded()
-    - script: ROOTFS_DIR=/crossrootfs/arm eng/common/cibuild.sh
+    - script: ROOTFS_DIR=/crossrootfs/arm ./build.sh --ci
         --configuration $(_BuildConfig)
         --prepareMachine
         /p:BuildNative=true
       name: Build
       displayName: Build
       condition: succeeded()
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Linux native assets
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/bin/Native
+        artifactName: Native
+        artifactType: container
+      condition: eq(variables['_BuildConfig'], 'Release')
     variables:
       _HelixBuildConfig: $(_BuildConfig)
+
+- template: /eng/common/templates/phases/base.yml
+  parameters:
+    dependsOn:
+    - Windows_NT
+    - OSX
+    - Linux
+    agentOs: Windows_NT
+    name: BuildPackages
+    enableTelemetry: $(_enableTelemetry)
+    queue:
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        name: dotnet-internal-temp
+      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        name: dotnet-external-temp
+      parallel: 99
+      matrix:
+        release_configuration:
+          _BuildConfig: Release
+    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      enableMicrobuild: true
+    steps:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Built Managed Assets
+      inputs:
+        artifactName: artifacts
+        downloadPath: $(Build.SourcesDirectory)
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Built Native Assets
+      inputs:
+        artifactName: Native
+        downloadPath: $(Build.SourcesDirectory)/artifacts/bin
+    - script: build.cmd -ci -sign
+        -configuration $(_BuildConfig)
+        -prepareMachine
+        /p:ProductBuild=false
+        /p:ToolsBuild=false
+        /p:SampleBuild=false
+        /p:BuildTests=false
+        /p:BuildPackages=true
+      name: Build
+      displayName: Build
+      condition: succeeded()
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Windows package assets
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping
+        artifactName: BuiltPackageOutputs
+        artifactType: container
+      condition: eq(variables['_BuildConfig'], 'Release')
+    variables:
+      _HelixBuildConfig: $(_BuildConfig)
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        _TeamName: DotNetCore
+        _SignType: real
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/phases/base.yml
     parameters:
       dependsOn:
-        - Windows_NT
-        - OSX
-        - Linux
+      - BuildPackages
       agentOs: Windows_NT
       name: PublishToMyGet
       enableTelemetry: $(_enableTelemetry)

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,7 +18,7 @@
   <!-- Packaging Targets -->
   <PropertyGroup>
     <IncludeRIDSpecificBuildOutput Condition="'$(IncludeRIDSpecificBuildOutput)' == '' And '$(RuntimeIdentifiers)' != ''">true</IncludeRIDSpecificBuildOutput>
-    <TargetsForTfmSpecificContentInPackage Condition="'$(IncludeRIDSpecificBuildOutput)' == 'true'">$(TargetsForTfmSpecificContentInPackage);_WalkEachRIDForBuildOutput;_GetReferenceAssemblyForPackage</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage Condition="'$(IncludeRIDSpecificBuildOutput)' == 'true'">$(TargetsForTfmSpecificContentInPackage);_WalkEachRIDForBuildOutput;_GetReferenceAssemblyForPackage;_GetNativeAssetsForPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,6 +42,14 @@
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(TargetRefPath)">
         <PackagePath>ref/$(TargetFramework)</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_GetNativeAssetsForPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(BaseOutputPath)../Native/Release/*.so">
+        <PackagePath>runtimes/linux/native/</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -49,6 +49,9 @@
   <Target Name="_GetNativeAssetsForPackage">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(BaseOutputPath)../Native/Release/*.so">
+        <!-- For now, we are only building native assets for linux-arm so we can hardcode the package path.
+             Once we start producing arm64 native assets then we will have to change this so it is not hardcoded
+             and instead is calculated depending on where the assets are located. -->
         <PackagePath>runtimes/linux-arm/native/</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -48,13 +48,18 @@
 
   <Target Name="_GetNativeAssetsForPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(BaseOutputPath)../Native/Release/*.so">
+      <_nativeAssetsToPackage Include="$(BaseOutputPath)../Native/Release/*.so" />
+      <TfmSpecificPackageFile Include="@(_nativeAssetsToPackage)">
         <!-- For now, we are only building native assets for linux-arm so we can hardcode the package path.
              Once we start producing arm64 native assets then we will have to change this so it is not hardcoded
              and instead is calculated depending on where the assets are located. -->
         <PackagePath>runtimes/linux-arm/native/</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
+
+    <!-- During CI or an official build, we should fail if there where no native assets to package -->
+    <Error Condition="'$(ContinuousIntegrationBuild)' == 'true' And '@(_nativeAssetsToPackage)' == ''" 
+           Text="Unable to find native assets to include in the package" />
   </Target>
 
   <Target Name="_GetBuildOutputWithRID" Returns="@(RIDSpecificPackageFile)">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -49,7 +49,7 @@
   <Target Name="_GetNativeAssetsForPackage">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(BaseOutputPath)../Native/Release/*.so">
-        <PackagePath>runtimes/linux/native/</PackagePath>
+        <PackagePath>runtimes/linux-arm/native/</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>

--- a/build.proj
+++ b/build.proj
@@ -9,7 +9,7 @@
     <ToolsBuild Condition="'$(ToolsBuild)'==''">true</ToolsBuild>
     <SampleBuild Condition="'$(SampleBuild)'==''">true</SampleBuild>
     <BuildTests Condition="'$(BuildTests)'==''">true</BuildTests>
-    <BuildPackages Condition="'$(BuildPackages)'==''">true</BuildPackages>
+    <BuildPackages Condition="'$(BuildPackages)'==''">false</BuildPackages>
 
     <BuildDependsOn Condition="'$(BuildRestore)'=='true'">$(BuildDependsOn);Restore</BuildDependsOn>
     <BuildDependsOn Condition="'$(BuildNative)'=='true'">$(BuildDependsOn);NativeBuild</BuildDependsOn>

--- a/src/Native/build-native.proj
+++ b/src/Native/build-native.proj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
   <PropertyGroup>
-    <_BuildNativeArgs>arm $(ConfigurationGroup)</_BuildNativeArgs>
+    <_BuildNativeArgs>arm $(Configuration)</_BuildNativeArgs>
   </PropertyGroup>
 
   <Target Name="BuildNativeUnix"

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -128,7 +128,7 @@ build_native()
 
     make install -j $__NumProc $__MakeExtraArgs
     if [ $? != 0 ]; then
-        echo "Failed to build corefx native components."
+        echo "Failed to build iot native components."
         exit 1
     fi
 }
@@ -263,6 +263,6 @@ initTargetDistroRid
 
     prepare_native_build
 
-    # Build the corefx native components.
+    # Build the iot native components.
 
     build_native

--- a/src/Native/gen-buildsys-clang.sh
+++ b/src/Native/gen-buildsys-clang.sh
@@ -7,7 +7,7 @@ if [ $# -lt 4 -o $# -gt 6 ]
 then
   echo "Usage..."
   echo "gen-buildsys-clang.sh <path to top level CMakeLists.txt> <ClangMajorVersion> <ClangMinorVersion> <Architecture> [build flavor] [cmakeargs]"
-  echo "Specify the path to the top level CMake file - <corefx>/src/Native/Unix"
+  echo "Specify the path to the top level CMake file - <iot>/src/Native/Unix"
   echo "Specify the clang version to use, split into major and minor version"
   echo "Specify the target architecture." 
   echo "Optionally specify the build configuration (flavor.) Defaults to DEBUG." 


### PR DESCRIPTION
cc: @safern @ericstj @krwq @buyaa-n

Adding the native shim into the System.Device.Gpio package. I had to separate the build of the libraries from the build of the packages, so that I could aggregate all of the output (managed and native) and then gather everything in one single package.