### PR TITLE
Include error code when throwing errors.

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -345,13 +346,13 @@ namespace System.Device.Gpio.Drivers
                 int fileDescriptor = Interop.open(GpioMemoryFilePath, FileOpenFlags.O_RDWR | FileOpenFlags.O_SYNC);
                 if (fileDescriptor < 0)
                 {
-                    throw new IOException("Error initializing the Gpio driver.");
+                    throw new IOException($"Error {Marshal.GetLastWin32Error()} initializing the Gpio driver.");
                 }
 
                 IntPtr mapPointer = Interop.mmap(IntPtr.Zero, Environment.SystemPageSize, (MemoryMappedProtections.PROT_READ | MemoryMappedProtections.PROT_WRITE), MemoryMappedFlags.MAP_SHARED, fileDescriptor, GpioRegisterOffset);
                 if (mapPointer.ToInt32() < 0)
                 {
-                    throw new IOException("Error initializing the Gpio driver.");
+                    throw new IOException($"Error {Marshal.GetLastWin32Error()} initializing the Gpio driver.");
                 }
 
                 Interop.close(fileDescriptor);

--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Linux.cs
@@ -58,7 +58,7 @@ namespace System.Device.I2c.Drivers
 
                 if (_deviceFileDescriptor < 0)
                 {
-                    throw new IOException($"Can not open I2C device file '{deviceFileName}'.");
+                    throw new IOException($"Error {Marshal.GetLastWin32Error()}. Can not open I2C device file '{deviceFileName}'.");
                 }
 
                 I2cFunctionalityFlags tempFlags;
@@ -120,7 +120,7 @@ namespace System.Device.I2c.Drivers
             int result = Interop.ioctl(_deviceFileDescriptor, (uint)I2cSettings.I2C_RDWR, new IntPtr(&msgset));
             if (result < 0)
             {
-                throw new IOException("Error performing I2C data transfer.");
+                throw new IOException($"Error {Marshal.GetLastWin32Error()} performing I2C data transfer.");
             }
         }
 
@@ -129,7 +129,7 @@ namespace System.Device.I2c.Drivers
             int result = Interop.ioctl(_deviceFileDescriptor, (uint)I2cSettings.I2C_SLAVE_FORCE, (ulong)_settings.DeviceAddress);
             if (result < 0)
             {
-                throw new IOException("Error performing I2C data transfer.");
+                throw new IOException($"Error {Marshal.GetLastWin32Error()} performing I2C data transfer.");
             }
 
             if (writeBuffer != null)
@@ -137,7 +137,7 @@ namespace System.Device.I2c.Drivers
                 result = Interop.write(_deviceFileDescriptor, new IntPtr(writeBuffer), writeBufferLength);
                 if (result < 0)
                 {
-                    throw new IOException("Error performing I2C data transfer.");
+                    throw new IOException($"Error {Marshal.GetLastWin32Error()} performing I2C data transfer.");
                 }
             }
 
@@ -146,7 +146,7 @@ namespace System.Device.I2c.Drivers
                 result = Interop.read(_deviceFileDescriptor, new IntPtr(readBuffer), readBufferLength);
                 if (result < 0)
                 {
-                    throw new IOException("Error performing I2C data transfer.");
+                    throw new IOException($"Error {Marshal.GetLastWin32Error()} performing I2C data transfer.");
                 }
             }
         }

--- a/src/System.Device.Gpio/System/Device/Spi/Drivers/UnixSpiDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Drivers/UnixSpiDevice.Linux.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace System.Device.Spi.Drivers
 {
@@ -55,7 +56,7 @@ namespace System.Device.Spi.Drivers
                 _deviceFileDescriptor = Interop.open(deviceFileName, FileOpenFlags.O_RDWR);
                 if (_deviceFileDescriptor < 0)
                 {
-                    throw new IOException($"Can not open SPI device file '{deviceFileName}'.");
+                    throw new IOException($"Error {Marshal.GetLastWin32Error()}. Can not open SPI device file '{deviceFileName}'.");
                 }
 
                 UnixSpiMode mode = SpiModeToUnixSpiMode(_settings.Mode);
@@ -64,7 +65,7 @@ namespace System.Device.Spi.Drivers
                 int result = Interop.ioctl(_deviceFileDescriptor, (uint)SpiSettings.SPI_IOC_WR_MODE, nativePtr);
                 if (result == -1)
                 {
-                    throw new IOException($"Can not set SPI mode to {_settings.Mode}.");
+                    throw new IOException($"Error {Marshal.GetLastWin32Error()}. Can not set SPI mode to {_settings.Mode}.");
                 }
 
                 byte dataLengthInBits = (byte)_settings.DataBitLength;
@@ -73,7 +74,7 @@ namespace System.Device.Spi.Drivers
                 result = Interop.ioctl(_deviceFileDescriptor, (uint)SpiSettings.SPI_IOC_WR_BITS_PER_WORD, nativePtr);
                 if (result == -1)
                 {
-                    throw new IOException($"Can not set SPI data bit length to {_settings.DataBitLength}.");
+                    throw new IOException($"Error {Marshal.GetLastWin32Error()}. Can not set SPI data bit length to {_settings.DataBitLength}.");
                 }
 
                 int clockFrequency = _settings.ClockFrequency;
@@ -82,7 +83,7 @@ namespace System.Device.Spi.Drivers
                 result = Interop.ioctl(_deviceFileDescriptor, (uint)SpiSettings.SPI_IOC_WR_MAX_SPEED_HZ, nativePtr);
                 if (result == -1)
                 {
-                    throw new IOException($"Can not set SPI clock frequency to {_settings.ClockFrequency}.");
+                    throw new IOException($"Error {Marshal.GetLastWin32Error()}. Can not set SPI clock frequency to {_settings.ClockFrequency}.");
                 }
             }
         }
@@ -202,7 +203,7 @@ namespace System.Device.Spi.Drivers
             int result = Interop.ioctl(_deviceFileDescriptor, SPI_IOC_MESSAGE_1, new IntPtr(&tr));
             if (result < 1)
             {
-                throw new IOException("Error performing SPI data transfer.");
+                throw new IOException($"Error {Marshal.GetLastWin32Error()} performing SPI data transfer.");
             }
         }
 


### PR DESCRIPTION
Without at least the code it is crazy difficult to diagnose what is going on. We should also consider writing a helper class here to provide readable error messages for codes we expect to be common.