### PR TITLE
I2C/SPI Read should not allow empty reads

### DIFF
--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/UnixI2cDevice.Linux.cs
@@ -174,6 +174,9 @@ namespace System.Device.I2c.Drivers
         /// </param>
         public override unsafe void Read(Span<byte> buffer)
         {
+            if (buffer.Length == 0)
+                throw new ArgumentException($"{nameof(buffer)} cannot be empty.");
+
             Initialize();
 
             fixed (byte* bufferPointer = buffer)

--- a/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Windows.cs
@@ -65,6 +65,9 @@ namespace System.Device.I2c.Drivers
         /// </param>
         public override void Read(Span<byte> buffer)
         {
+            if (buffer.Length == 0)
+                throw new ArgumentException($"{nameof(buffer)} cannot be empty.");
+
             byte[] byteArray = new byte[buffer.Length];
             _winI2cDevice.Read(byteArray);
             new Span<byte>(byteArray).CopyTo(buffer);

--- a/src/System.Device.Gpio/System/Device/Spi/Drivers/UnixSpiDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Drivers/UnixSpiDevice.Linux.cs
@@ -129,6 +129,9 @@ namespace System.Device.Spi.Drivers
         /// </param>
         public override unsafe void Read(Span<byte> buffer)
         {
+            if (buffer.Length == 0)
+                throw new ArgumentException($"{nameof(buffer)} cannot be empty.");
+                
             Initialize();
 
             fixed (byte* bufferPtr = buffer)

--- a/src/System.Device.Gpio/System/Device/Spi/Drivers/Windows10SpiDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Drivers/Windows10SpiDevice.Windows.cs
@@ -68,6 +68,9 @@ namespace System.Device.Spi.Drivers
         /// </param>
         public override void Read(Span<byte> buffer)
         {
+            if (buffer.Length == 0)
+                throw new ArgumentException($"{nameof(buffer)} cannot be empty.");
+
             byte[] byteArray = new byte[buffer.Length];
             _winDevice.Read(byteArray);
             new Span<byte>(byteArray).CopyTo(buffer);


### PR DESCRIPTION
Fixes https://github.com/dotnet/iot/issues/111

Making experience better when empty buffer is accidentally passed to Read