### PR TITLE
Updated parameter naming for PinEventTypes

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.Linux.cs
@@ -25,7 +25,7 @@ namespace System.Device.Gpio.Drivers
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
-        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
             throw new NotImplementedException();
         }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.Linux.cs
@@ -35,7 +35,7 @@ namespace System.Device.Gpio.Drivers
             _pinNumberToSafeLineHandle = new Dictionary<int, SafeLineHandle>(PinCount);
         }
 
-        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
             throw new NotImplementedException();
         }
@@ -120,7 +120,7 @@ namespace System.Device.Gpio.Drivers
             } 
         }
 
-        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -59,7 +59,7 @@ namespace System.Device.Gpio.Drivers
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
-        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
             ValidatePinNumber(pinNumber);
             InitializeSysFS();
@@ -67,7 +67,7 @@ namespace System.Device.Gpio.Drivers
             _sysFSDriver.OpenPin(pinNumber);
             _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
 
-            _sysFSDriver.AddCallbackForPinValueChangedEvent(pinNumber, eventType, callback);
+            _sysFSDriver.AddCallbackForPinValueChangedEvent(pinNumber, eventTypes, callback);
         }
 
         /// <summary>

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFSDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFSDriver.Linux.cs
@@ -251,14 +251,14 @@ namespace System.Device.Gpio.Drivers
             return new WaitForEventResult
             {
                 TimedOut = !eventDetected,
-                EventType = eventTypes
+                EventTypes = eventTypes
             };
         }
 
-        private void SetPinEventsToDetect(int pinNumber, PinEventTypes eventType)
+        private void SetPinEventsToDetect(int pinNumber, PinEventTypes eventTypes)
         {
             string edgePath = Path.Combine(GpioBasePath, $"gpio{pinNumber}", "edge");
-            string stringValue = PinEventTypeToStringValue(eventType);
+            string stringValue = PinEventTypeToStringValue(eventTypes);
             File.WriteAllText(edgePath, stringValue);
         }
 
@@ -460,7 +460,7 @@ namespace System.Device.Gpio.Drivers
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
-        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
             if (!_devicePins.ContainsKey(pinNumber))
             {
@@ -468,15 +468,15 @@ namespace System.Device.Gpio.Drivers
                 _pinsToDetectEventsCount++;
                 AddPinToPoll(pinNumber, ref _devicePins[pinNumber].FileDescriptor, ref _pollFileDescriptor, out _);
             }
-            if (eventType.HasFlag(PinEventTypes.Rising))
+            if (eventTypes.HasFlag(PinEventTypes.Rising))
             {
                 _devicePins[pinNumber].ValueRising += callback;
             }
-            if (eventType.HasFlag(PinEventTypes.Falling))
+            if (eventTypes.HasFlag(PinEventTypes.Falling))
             {
                 _devicePins[pinNumber].ValueFalling += callback;
             }
-            SetPinEventsToDetect(pinNumber, (GetPinEventsToDetect(pinNumber) | eventType));
+            SetPinEventsToDetect(pinNumber, (GetPinEventsToDetect(pinNumber) | eventTypes));
             InitializeEventDetectionThread();
         }
 
@@ -499,8 +499,8 @@ namespace System.Device.Gpio.Drivers
                 bool eventDetected = WasEventDetected(_pollFileDescriptor, -1, out int pinNumber, s_eventThreadCancellationTokenSource.Token);
                 if (eventDetected)
                 {
-                    PinEventTypes eventType = (Read(pinNumber) == PinValue.High) ? PinEventTypes.Rising : PinEventTypes.Falling;
-                    var args = new PinValueChangedEventArgs(eventType, pinNumber);
+                    PinEventTypes eventTypes = (Read(pinNumber) == PinValue.High) ? PinEventTypes.Rising : PinEventTypes.Falling;
+                    var args = new PinValueChangedEventArgs(eventTypes, pinNumber);
                     _devicePins[pinNumber]?.OnPinValueChanged(args, GetPinEventsToDetect(pinNumber));
                 }
             }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.Windows.cs
@@ -21,7 +21,7 @@ namespace System.Device.Gpio.Drivers
             throw new PlatformNotSupportedException();
         }
 
-        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
             throw new PlatformNotSupportedException();
         }
@@ -66,12 +66,12 @@ namespace System.Device.Gpio.Drivers
             throw new PlatformNotSupportedException();
         }
 
-        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             throw new PlatformNotSupportedException();
         }
 
-        protected internal override ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        protected internal override ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.Linux.cs
@@ -15,7 +15,7 @@ namespace System.Device.Gpio.Drivers
 
         protected internal override int PinCount => throw new PlatformNotSupportedException();
 
-        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventType, PinChangeEventHandler callback)
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
             throw new PlatformNotSupportedException();
         }
@@ -60,7 +60,7 @@ namespace System.Device.Gpio.Drivers
             throw new PlatformNotSupportedException();
         }
 
-        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventType, CancellationToken cancellationToken)
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10DriverPin.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10DriverPin.Windows.cs
@@ -48,21 +48,21 @@ namespace System.Device.Gpio.Drivers
             GC.SuppressFinalize(this);
         }
 
-        public void AddCallbackForPinValueChangedEvent(PinEventTypes eventType, PinChangeEventHandler callback)
+        public void AddCallbackForPinValueChangedEvent(PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
-            if (eventType == PinEventTypes.None)
+            if (eventTypes == PinEventTypes.None)
             {
-                throw new ArgumentException($"{PinEventTypes.None} is an invalid value.", nameof(eventType));
+                throw new ArgumentException($"{PinEventTypes.None} is an invalid value.", nameof(eventTypes));
             }
 
             bool isFirstCallback = _risingCallbacks == null && _fallingCallbacks == null;
 
-            if (eventType.HasFlag(PinEventTypes.Rising))
+            if (eventTypes.HasFlag(PinEventTypes.Rising))
             {
                 _risingCallbacks += callback;
             }
 
-            if (eventType.HasFlag(PinEventTypes.Falling))
+            if (eventTypes.HasFlag(PinEventTypes.Falling))
             {
                 _fallingCallbacks += callback;
             }
@@ -113,16 +113,16 @@ namespace System.Device.Gpio.Drivers
 
         public PinMode GetPinMode() => GpioDriveModeToPinMode(_pin.GetDriveMode());
 
-        public WaitForEventResult WaitForEvent(PinEventTypes eventType, CancellationToken cancellationToken)
+        public WaitForEventResult WaitForEvent(PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             using (ManualResetEvent completionEvent = new ManualResetEvent(false))
             {
-                PinEventTypes pinEventType = PinEventTypes.None;
+                PinEventTypes pinEventTypes = PinEventTypes.None;
                 void handler(WinGpio.GpioPin s, WinGpio.GpioPinValueChangedEventArgs a)
                 {
-                    pinEventType = GpioEdgeToPinEventType(a.Edge);
+                    pinEventTypes = GpioEdgeToPinEventType(a.Edge);
 
-                    if ((pinEventType & eventType) != 0)
+                    if ((pinEventTypes & eventTypes) != 0)
                     {
                         completionEvent.Set();
                     }
@@ -140,7 +140,7 @@ namespace System.Device.Gpio.Drivers
 
                 return new WaitForEventResult
                 {
-                    EventType = pinEventType,
+                    EventTypes = pinEventTypes,
                     TimedOut = !eventOccurred
                 };
             }

--- a/src/System.Device.Gpio/System/Device/Gpio/WaitForEventResult.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/WaitForEventResult.cs
@@ -12,7 +12,7 @@ namespace System.Device.Gpio
         /// <summary>
         /// The event types to wait for.
         /// </summary>
-        public PinEventTypes EventType;
+        public PinEventTypes EventTypes;
         /// <summary>
         /// True if waiting for the event timed out. False if an event was triggered before the timeout expired.
         /// </summary>


### PR DESCRIPTION
This is based on #140 where we decided to use plural for PinEventTypes.

This PR updates some of the method arguments where they didn't include the ending 's' compared to some that already included.