### PR TITLE
Make it less likely to break build next time

### DIFF
--- a/tools/DevicesApiTester/DeviceApiTester.csproj
+++ b/tools/DevicesApiTester/DeviceApiTester.csproj
@@ -12,7 +12,13 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.10.0" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <!-- Normally package reference should be used: -->
+    <!-- <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" /> -->
+    <!-- We use project reference in our repository -->
+    <!-- so that our build breaks immediately and not on the next day when the official build happens -->
+    <ProjectReference Include="..\..\src\System.Device.Gpio\System.Device.Gpio.csproj">
+      <AdditionalProperties>RuntimeIdentifier=linux</AdditionalProperties>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fix build break and try to make it happen less frequently.

Current issue is that we use PackageReference in many projects. This is causing that the build is green locally and on the CI but when the official build produces new package it may delay break the build


Ref: https://github.com/dotnet/iot/issues/218