### PR TITLE
Updated parameter name for PinNumberingScheme

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
@@ -18,9 +18,9 @@ namespace System.Device.Gpio
         /// Initializes new instance of GpioController that will use the specified numbering scheme.
         /// The controller will default to use the driver that best applies given the platform the program is executing on.
         /// </summary>
-        /// <param name="pinNumberingScheme">The numbering scheme used to represent pins provided by the controller.</param>
-        public GpioController(PinNumberingScheme pinNumberingScheme)
-            : this(pinNumberingScheme, GetBestDriverForBoard())
+        /// <param name="numberingScheme">The numbering scheme used to represent pins provided by the controller.</param>
+        public GpioController(PinNumberingScheme numberingScheme)
+            : this(numberingScheme, GetBestDriverForBoard())
         {
         }
 

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.Windows.cs
@@ -18,9 +18,9 @@ namespace System.Device.Gpio
         /// Initializes new instance of GpioController that will use the specified numbering scheme.
         /// The controller will default to use the driver that best applies given the platform the program is executing on.
         /// </summary>
-        /// <param name="pinNumberingScheme">The numbering scheme used to represent pins provided by the controller.</param>
-        public GpioController(PinNumberingScheme pinNumberingScheme)
-            : this(pinNumberingScheme, GetBestDriverForBoard())
+        /// <param name="numberingScheme">The numbering scheme used to represent pins provided by the controller.</param>
+        public GpioController(PinNumberingScheme numberingScheme)
+            : this(numberingScheme, GetBestDriverForBoard())
         {
         }
 


### PR DESCRIPTION
Fixes #137

I went ahead and removed 'pin' from the parameters where named to make consistent where it wasn't.  This appears to fit in with what we're doing for making parameters less wordy in #295, as well.