### PR TITLE
Updated type for PinValues and related description

### DIFF
--- a/tools/DevicesApiTester/Commands/Gpio/GpioBlinkLed.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioBlinkLed.cs
@@ -25,8 +25,8 @@ namespace DeviceApiTester.Commands.Gpio
         [Option("time-off", HelpText = "The number of milliseconds to keep the LED off for each blink.", Required = false, Default = 200)]
         public int TimeOff { get; set; }
 
-        [Option("on-value", HelpText = "The value that turns the LED on: { true | false }", Required = false, Default = true)]
-        public bool OnValue { get; set; }
+        [Option("on-value", HelpText = "The value that turns the LED on: { 0 | 1 }", Required = false, Default = 1)]
+        public int OnValue { get; set; }
 
         /// <summary>Executes the command asynchronously.</summary>
         /// <returns>The command's exit code.</returns>
@@ -59,6 +59,6 @@ namespace DeviceApiTester.Commands.Gpio
             return 0;
         }
 
-        private bool OffValue => !OnValue;
+        private int OffValue => OnValue == 0 ? 1 : 0;
     }
 }

--- a/tools/DevicesApiTester/Commands/Gpio/GpioBlinkLed.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioBlinkLed.cs
@@ -37,6 +37,11 @@ namespace DeviceApiTester.Commands.Gpio
         /// </remarks>
         public async Task<int> ExecuteAsync()
         {
+            if (OnValue != 0)
+            {
+                OnValue = 1;
+            }
+
             Console.WriteLine($"Driver={Driver}, Scheme={Scheme}, LedPin ={LedPin}, Count={Count}, TimeOn={TimeOn} ms, TimeOff={TimeOff} ms");
 
             using (GpioController controller = CreateGpioController())
@@ -59,6 +64,6 @@ namespace DeviceApiTester.Commands.Gpio
             return 0;
         }
 
-        private int OffValue => OnValue == 0 ? 1 : 0;
+        private int OffValue => 1 - OnValue;
     }
 }

--- a/tools/DevicesApiTester/Commands/Gpio/GpioButtonEvent.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioButtonEvent.cs
@@ -23,8 +23,8 @@ namespace DeviceApiTester.Commands.Gpio
         [Option('p', "pressed-value", HelpText = "The value of the GPIO pin when the button is pressed: { Rising | Falling }", Required = false, Default = PinEventTypes.Rising)]
         public PinEventTypes PressedValue { get; set; }
 
-        [Option("on-value", HelpText = "The value that turns the LED on: { true | false }", Required = false, Default = true)]
-        public bool OnValue { get; set; }
+        [Option("on-value", HelpText = "The value that turns the LED on: { 0 | 1 }", Required = false, Default = 1)]
+        public int OnValue { get; set; }
 
         /// <summary>Executes the command asynchronously.</summary>
         /// <returns>The command's exit code.</returns>
@@ -111,6 +111,6 @@ namespace DeviceApiTester.Commands.Gpio
             }
         }
 
-        private bool OffValue => !OnValue;
+        private int OffValue => OnValue == 0 ? 1 : 0;
     }
 }

--- a/tools/DevicesApiTester/Commands/Gpio/GpioButtonEvent.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioButtonEvent.cs
@@ -35,6 +35,11 @@ namespace DeviceApiTester.Commands.Gpio
         /// </remarks>
         public Task<int> ExecuteAsync()
         {
+            if (OnValue != 0)
+            {
+                OnValue = 1;
+            }
+
             if (LedPin != null)
             {
                 Console.WriteLine($"Driver={Driver}, Scheme={Scheme}, ButtonPin={ButtonPin}, LedPin={LedPin}, PressedValue={PressedValue}, OnValue={OnValue}");
@@ -111,6 +116,6 @@ namespace DeviceApiTester.Commands.Gpio
             }
         }
 
-        private int OffValue => OnValue == 0 ? 1 : 0;
+        private int OffValue => 1 - OnValue;
     }
 }

--- a/tools/DevicesApiTester/Commands/Gpio/GpioButtonWait.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioButtonWait.cs
@@ -23,8 +23,8 @@ namespace DeviceApiTester.Commands.Gpio
         [Option('p', "pressed-value", HelpText = "The value of the GPIO pin when the button is pressed: { Rising | Falling }", Required = false, Default = PinEventTypes.Rising)]
         public PinEventTypes PressedValue { get; set; }
 
-        [Option("on-value", HelpText = "The value that turns the LED on: { High | Low }", Required = false, Default = true)]
-        public bool OnValue { get; set; }
+        [Option("on-value", HelpText = "The value that turns the LED on: { 0 | 1 }", Required = false, Default = 1)]
+        public int OnValue { get; set; }
 
         /// <summary>Executes the command asynchronously.</summary>
         /// <returns>The command's exit code.</returns>
@@ -106,6 +106,6 @@ namespace DeviceApiTester.Commands.Gpio
             }
         }
 
-        private bool OffValue => !OnValue;
+        private int OffValue => OnValue == 0 ? 1 : 0;
     }
 }

--- a/tools/DevicesApiTester/Commands/Gpio/GpioButtonWait.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioButtonWait.cs
@@ -106,6 +106,6 @@ namespace DeviceApiTester.Commands.Gpio
             }
         }
 
-        private int OffValue => OnValue == 0 ? 1 : 0;
+        private int OffValue => 1 - OnValue;
     }
 }

--- a/tools/DevicesApiTester/Commands/Gpio/GpioWritePin.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioWritePin.cs
@@ -15,8 +15,8 @@ namespace DeviceApiTester.Commands.Gpio
         [Option('p', "pin", HelpText = "The GPIO pin to write to. The number is based on the --scheme argument.", Required = true)]
         public int Pin { get; set; }
 
-        [Option('v', "value", HelpText = "The value to write to pin: { High | Low }", Required = true)]
-        public PinValue Value { get; set; }
+        [Option('v', "value", HelpText = "The value to write to pin: { 0 | 1 }", Required = true)]
+        public int Value { get; set; }
 
         /// <summary>Executes the command asynchronously.</summary>
         /// <returns>The command's exit code.</returns>


### PR DESCRIPTION
There is a current issue with the CommandLineParser that we use with DeviceApiTester.

It appears when you have a `bool` type, it will always be `true` no matter what text you add.  There are some workarounds, but doesn't seem like it will work for us as we use the Required attribute in some cases.

This PR changes the type for options from `bool` to `int` for now. 

**References**:
https://github.com/commandlineparser/commandline/issues/290
https://stackoverflow.com/questions/35873835/command-line-parser-library-boolean-parameter