### PR TITLE
Add support for SPI data flow and chip select active state on linux

### DIFF
--- a/src/System.Device.Gpio/System/Device/Spi/DataFlow.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/DataFlow.cs
@@ -5,7 +5,7 @@
 namespace System.Device.Spi
 {
     /// <summary>
-    /// Defines order in which data is send over the wire.
+    /// Specifies order in which bits are transferred first on the SPI bus.
     /// </summary>
     public enum DataFlow
     {

--- a/src/System.Device.Gpio/System/Device/Spi/DataFlow.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/DataFlow.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Device.Spi
+{
+    /// <summary>
+    /// Defines order in which data is send over the wire.
+    /// </summary>
+    public enum DataFlow
+    {
+        MsbFirst,
+        LsbFirst,
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Spi/DataFlow.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/DataFlow.cs
@@ -9,7 +9,13 @@ namespace System.Device.Spi
     /// </summary>
     public enum DataFlow
     {
+        /// <summary>
+        /// Most significant bit will be sent first (most of the devices use this value).
+        /// </summary>
         MsbFirst,
+        /// <summary>
+        /// Least significant bit will be sent first.
+        /// </summary>
         LsbFirst,
     }
 }

--- a/src/System.Device.Gpio/System/Device/Spi/Drivers/UnixSpiDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Drivers/UnixSpiDevice.Linux.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Device.Gpio;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -59,7 +60,7 @@ namespace System.Device.Spi.Drivers
                     throw new IOException($"Error {Marshal.GetLastWin32Error()}. Can not open SPI device file '{deviceFileName}'.");
                 }
 
-                UnixSpiMode mode = SpiModeToUnixSpiMode(_settings.Mode);
+                UnixSpiMode mode = SpiSettingsToUnixSpiMode();
                 IntPtr nativePtr = new IntPtr(&mode);
 
                 int result = Interop.ioctl(_deviceFileDescriptor, (uint)SpiSettings.SPI_IOC_WR_MODE, nativePtr);
@@ -86,6 +87,23 @@ namespace System.Device.Spi.Drivers
                     throw new IOException($"Error {Marshal.GetLastWin32Error()}. Can not set SPI clock frequency to {_settings.ClockFrequency}.");
                 }
             }
+        }
+
+        private UnixSpiMode SpiSettingsToUnixSpiMode()
+        {
+            UnixSpiMode mode = SpiModeToUnixSpiMode(_settings.Mode);
+
+            if (_settings.ChipSelectLineActiveState == PinValue.High)
+            {
+                mode |= UnixSpiMode.SPI_CS_HIGH;
+            }
+
+            if (_settings.DataFlow == DataFlow.LsbFirst)
+            {
+                mode |= UnixSpiMode.SPI_LSB_FIRST;
+            }
+
+            return mode;
         }
 
         private UnixSpiMode SpiModeToUnixSpiMode(SpiMode mode)

--- a/src/System.Device.Gpio/System/Device/Spi/Drivers/Windows10SpiDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Drivers/Windows10SpiDevice.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Device.Gpio;
 using Windows.Devices.Enumeration;
 using WinSpi = Windows.Devices.Spi;
 
@@ -23,6 +24,11 @@ namespace System.Device.Spi.Drivers
         /// </param>
         public Windows10SpiDevice(SpiConnectionSettings settings)
         {
+            if (settings.DataFlow != DataFlow.MsbFirst || settings.ChipSelectLineActiveState != PinValue.Low)
+            {
+                throw new PlatformNotSupportedException($"Changing {nameof(settings.DataFlow)} or {nameof(settings.ChipSelectLineActiveState)} options is not supported on the current platform.");
+            }
+
             _settings = settings;
             var winSettings = new WinSpi.SpiConnectionSettings(_settings.ChipSelectLine)
             {

--- a/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Device.Gpio;
+
 namespace System.Device.Spi
 {
     /// <summary>
@@ -49,5 +51,13 @@ namespace System.Device.Spi
         /// The frequency in which the data will be transfered.
         /// </summary>
         public int ClockFrequency { get; set; }
+        /// <summary>
+        /// Specifies which bits will be transfered first over the wire.
+        /// </summary>
+        public DataFlow DataFlow { get; set; } = DataFlow.MsbFirst;
+        /// <summary>
+        /// Specifies which value on chip select pin means "active".
+        /// </summary>
+        public PinValue ChipSelectLineActiveState { get; set; } = PinValue.Low;
     }
 }

--- a/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
@@ -52,7 +52,7 @@ namespace System.Device.Spi
         /// </summary>
         public int ClockFrequency { get; set; }
         /// <summary>
-        /// Specifies which bits will be transfered first over the wire.
+        /// Specifies order in which bits are transferred first on the SPI bus.
         /// </summary>
         public DataFlow DataFlow { get; set; } = DataFlow.MsbFirst;
         /// <summary>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/iot/issues/201
Fixes: https://github.com/dotnet/iot/issues/202

cc: @tarekgh @JeremyKuhne @shaggygi @ZhangGaoxing

This enables using devices which define CS active as high and makes it much easier to use devices which use LSB data flow (no need to invert bits)