### PR TITLE
Add enter in device listing to fix bullet point

### DIFF
--- a/src/devices/README.md
+++ b/src/devices/README.md
@@ -7,6 +7,7 @@ Our vision: the majority of .NET bindings are written completely in .NET languag
 ## Binding Index
 
 <devices>
+
 * [Pca95x4 - I2C GPIO Expander](Pca95x4/README.md)
 * [Using MCP3008 (10-bit Analog to Digital Converter)](Mcp3008/README.md)
 * [BMO055 Sensors](Bno055/README.md)

--- a/tools/device-listing/device-listing.cs
+++ b/tools/device-listing/device-listing.cs
@@ -128,6 +128,8 @@ namespace Iot.Tools.DeviceListing
                 filePath,
                 fileContent.Substring(0, startIdx) +
                 Environment.NewLine +
+                // Extra empty line is needed so that github does not break bullet points
+                Environment.NewLine +
                 newContent +
                 fileContent.Substring(endIdx));
         }


### PR DESCRIPTION
Seems that when you use custom tags and don't put extra enter then github treats is specially and bullet points are broken.