### PR TITLE
Remove explicit compiler version

### DIFF
--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
     <IsPackable>true</IsPackable>
     <DeviceRoot>$(MSBuildThisFileDirectory)../devices/</DeviceRoot>

--- a/src/devices/Ads1115/Ads1115.csproj
+++ b/src/devices/Ads1115/Ads1115.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +20,7 @@
     <Compile Include="Ads1115.cs" />
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>

--- a/src/devices/Adxl345/Adxl345.csproj
+++ b/src/devices/Adxl345/Adxl345.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -13,7 +12,7 @@
     <Compile Include="Adxl345.cs" />
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>

--- a/src/devices/Adxl345/samples/Adxl345.Samples.csproj
+++ b/src/devices/Adxl345/samples/Adxl345.Samples.csproj
@@ -3,14 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Adxl345.csproj" />
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="ADXL345_circuit.fzz" />
     <None Remove="ADXL345_circuit_bb.png" />
     <None Remove="README.md" />

--- a/src/devices/Ags01db/Ags01db.csproj
+++ b/src/devices/Ags01db/Ags01db.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -12,7 +11,7 @@
     <Compile Include="Ags01db.cs" />
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>

--- a/src/devices/Ags01db/samples/Ags01db.Samples.csproj
+++ b/src/devices/Ags01db/samples/Ags01db.Samples.csproj
@@ -3,14 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Ags01db.csproj" />
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="AGS01DB_circuit.fzz" />
     <None Remove="AGS01DB_circuit_bb.png" />
     <None Remove="README.md" />

--- a/src/devices/Bmx280/Bmx280.csproj
+++ b/src/devices/Bmx280/Bmx280.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Bmx280/samples/Bme280.sample.csproj
+++ b/src/devices/Bmx280/samples/Bme280.sample.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Bmx280/samples/Bmp280.sample.csproj
+++ b/src/devices/Bmx280/samples/Bmp280.sample.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Bno055/Bno055.csproj
+++ b/src/devices/Bno055/Bno055.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Bno055/samples/Bno055.sample.csproj
+++ b/src/devices/Bno055/samples/Bno055.sample.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Buzzer/Buzzer.csproj
+++ b/src/devices/Buzzer/Buzzer.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/CharacterLcd/CharacterLcd.csproj
+++ b/src/devices/CharacterLcd/CharacterLcd.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,5 +22,5 @@
     <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
     <None Include="README.md" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/devices/CharacterLcd/samples/CharacterLcd.Samples.csproj
+++ b/src/devices/CharacterLcd/samples/CharacterLcd.Samples.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Ds3231/Ds3231.csproj
+++ b/src/devices/Ds3231/Ds3231.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Ds3231/samples/Ds3231.Samples.csproj
+++ b/src/devices/Ds3231/samples/Ds3231.Samples.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup> 

--- a/src/devices/Hmc5883l/Hmc5883l.csproj
+++ b/src/devices/Hmc5883l/Hmc5883l.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -16,10 +15,10 @@
     <Compile Include="Hmc5883l.cs" />
     <Compile Include="SamplesAmount.cs" />
     <Compile Include="Status.cs" />
-    
+
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>

--- a/src/devices/Hmc5883l/samples/Hmc5883l.Samples.csproj
+++ b/src/devices/Hmc5883l/samples/Hmc5883l.Samples.csproj
@@ -3,14 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Hmc5883l.csproj" />
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="HMC5883L_circuit.fzz" />
     <None Remove="HMC5883L_circuit_bb.png" />
     <None Remove="README.md" />

--- a/src/devices/Hts221/Hts221.csproj
+++ b/src/devices/Hts221/Hts221.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Lm75/Lm75.csproj
+++ b/src/devices/Lm75/Lm75.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Lm75/samples/Lm75.Samples.csproj
+++ b/src/devices/Lm75/samples/Lm75.Samples.csproj
@@ -3,14 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Lm75.csproj" />
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="LM75_circuit.fzz" />
     <None Remove="LM75_circuit_bb.png" />
     <None Remove="README.md" />

--- a/src/devices/Lps25h/Lps25h.csproj
+++ b/src/devices/Lps25h/Lps25h.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Lsm9Ds1/Lsm9Ds1.csproj
+++ b/src/devices/Lsm9Ds1/Lsm9Ds1.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Max44009/Max44009.csproj
+++ b/src/devices/Max44009/Max44009.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +13,7 @@
     <Compile Include="WorkingMode.cs" />
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>

--- a/src/devices/Mcp23xxx/Mcp23xxx.csproj
+++ b/src/devices/Mcp23xxx/Mcp23xxx.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Mcp23xxx/tests/Mcp23xxx.Tests.csproj
+++ b/src/devices/Mcp23xxx/tests/Mcp23xxx.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Mpr121/Mpr121.csproj
+++ b/src/devices/Mpr121/Mpr121.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Mpr121/samples/Mpr121.Samples.csproj
+++ b/src/devices/Mpr121/samples/Mpr121.Samples.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Nrf24l01/Nrf24l01.csproj
+++ b/src/devices/Nrf24l01/Nrf24l01.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Nrf24l01/samples/Nrf24l01.Samples.csproj
+++ b/src/devices/Nrf24l01/samples/Nrf24l01.Samples.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Pca9685/Pca9685.csproj
+++ b/src/devices/Pca9685/Pca9685.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Pca9685/samples/Pca9685.Sample.csproj
+++ b/src/devices/Pca9685/samples/Pca9685.Sample.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Pcx857x/Pcx857x.csproj
+++ b/src/devices/Pcx857x/Pcx857x.csproj
@@ -4,11 +4,10 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RootNamespace>Iot.Device.Pcx857x</RootNamespace>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" /> 
+    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
     <Compile Include="..\Common\System\Device\Gpio\PinVector32.cs" Link="PinVector32.cs" />
     <Compile Include="..\Common\System\Device\Gpio\PinVector64.cs" Link="PinVector64.cs" />
     <Compile Include="Pca8574.cs" />

--- a/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
+++ b/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/SenseHat/SenseHat.csproj
+++ b/src/devices/SenseHat/SenseHat.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Sht3x/Sht3x.csproj
+++ b/src/devices/Sht3x/Sht3x.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Sht3x/samples/Sht3x.Samples.csproj
+++ b/src/devices/Sht3x/samples/Sht3x.Samples.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Si7021/Si7021.csproj
+++ b/src/devices/Si7021/Si7021.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Ssd1306/Ssd1306.csproj
+++ b/src/devices/Ssd1306/Ssd1306.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>7.2</LangVersion>
     <!--Disabling default items so samples source won't get build by the main library-->
   </PropertyGroup>
 
@@ -19,5 +18,5 @@
   <ItemGroup>
     <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/devices/Units/tests/Units.Tests.csproj
+++ b/src/devices/Units/tests/Units.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Ws28xx/Ws28xx.csproj
+++ b/src/devices/Ws28xx/Ws28xx.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.csproj
+++ b/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes: #300 

We already use https://github.com/dotnet/iot/blob/master/Directory.Build.props#L16 so no need to redefine. Also unifying projects with explicit version

cc: @shaggygi 