### PR TITLE
Onboarding on auto-updates of System.Device.Gpio with darc instead of wildcards

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
+    <add key="dotnet-iot" value="https://dotnetfeed.blob.core.windows.net/dotnet-iot/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="myget.org" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="System.Device.Gpio" Version="0.1.0-prerelease.19215.5">
+      <Uri>https://github.com/dotnet/iot</Uri>
+      <Sha>909d6dd81bfdf35a2ab02f48ac54c5f30821ea8b</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19214.2">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,6 +5,10 @@
       <Uri>https://github.com/dotnet/iot</Uri>
       <Sha>909d6dd81bfdf35a2ab02f48ac54c5f30821ea8b</Sha>
     </Dependency>
+    <Dependency Name="Iot.Device.Bindings" Version="0.1.0-prerelease.19215.5">
+      <Uri>https://github.com/dotnet/iot</Uri>
+      <Sha>909d6dd81bfdf35a2ab02f48ac54c5f30821ea8b</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19214.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,5 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
+    <SystemDeviceGpioPackageVersion>0.1.0-prerelease.19215.5</SystemDeviceGpioPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
     <SystemDeviceGpioPackageVersion>0.1.0-prerelease.19215.5</SystemDeviceGpioPackageVersion>
+    <IotDeviceBindingsPackageVersion>0.1.0-prerelease.19215.5</IotDeviceBindingsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="../eng/Compilers.props" />
+  <Import Project="../eng/Versions.props" />
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS8321</NoWarn>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>

--- a/samples/force-sensitive-resistor/force-sensitive-resistor.csproj
+++ b/samples/force-sensitive-resistor/force-sensitive-resistor.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Iot.Device.Bindings" Version="0.1.0-prerelease.19078.2" />
+    <PackageReference Include="Iot.Device.Bindings" Version="$(IotDeviceBindingsPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/samples/led-blink/led-blink.csproj
+++ b/samples/led-blink/led-blink.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease.19078.2" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/samples/led-more-blinking-lights/led-more-blinking-lights.csproj
+++ b/samples/led-more-blinking-lights/led-more-blinking-lights.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Iot.Device.Bindings" Version="0.1.0-prerelease.19078.2" />
+    <PackageReference Include="Iot.Device.Bindings" Version="$(IotDeviceBindingsPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Ads1115/Ads1115.csproj
+++ b/src/devices/Ads1115/Ads1115.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="I2cAddress.cs" />
     <Compile Include="ComparatorLatching.cs" />
     <Compile Include="ComparatorMode.cs" />

--- a/src/devices/Adxl345/Adxl345.csproj
+++ b/src/devices/Adxl345/Adxl345.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="GravityRange.cs" />
     <Compile Include="Register.cs" />
     <Compile Include="Adxl345.cs" />

--- a/src/devices/Ags01db/Ags01db.csproj
+++ b/src/devices/Ags01db/Ags01db.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="Register.cs" />
     <Compile Include="Ags01db.cs" />
   </ItemGroup>

--- a/src/devices/Bmx280/Bmx280.csproj
+++ b/src/devices/Bmx280/Bmx280.csproj
@@ -13,7 +13,7 @@
     <Compile Include="PowerMode.cs" />
     <Compile Include="Register.cs" />
     <Compile Include="Sampling.cs" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Units\Units.csproj" />
   </ItemGroup>
 

--- a/src/devices/Bno055/Bno055.csproj
+++ b/src/devices/Bno055/Bno055.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="Models/*.cs" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease.19078.2" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
     <ProjectReference Include="..\Units\Units.csproj" />
   </ItemGroup>

--- a/src/devices/Bno055/samples/Bno055.sample.csproj
+++ b/src/devices/Bno055/samples/Bno055.sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease.19078.2" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/BrickPi3/BrickPi3.csproj
+++ b/src/devices/BrickPi3/BrickPi3.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease.19078.2" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>
 

--- a/src/devices/Buzzer/Buzzer.csproj
+++ b/src/devices/Buzzer/Buzzer.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <Compile Include="Buzzer.cs" />
     <None Include="README.md" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/CharacterLcd/CharacterLcd.csproj
+++ b/src/devices/CharacterLcd/CharacterLcd.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>
 

--- a/src/devices/CharacterLcd/samples/CharacterLcd.Samples.csproj
+++ b/src/devices/CharacterLcd/samples/CharacterLcd.Samples.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../Mcp23xxx/Mcp23xxx.csproj" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\CharacterLcd.csproj" />
   </ItemGroup>
 

--- a/src/devices/DCMotor/DCMotor.csproj
+++ b/src/devices/DCMotor/DCMotor.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\SoftPwm\SoftPwm.csproj" />
     <Compile Include="DCMotor.cs" />
     <Compile Include="DCMotor3Pin.cs" />

--- a/src/devices/DCMotor/samples/samples.csproj
+++ b/src/devices/DCMotor/samples/samples.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <!-- Normally you will use following package reference instead  -->
-    <!-- <PackageReference Include="IoT.Device.Bindings" Version="0.1.0-prerelease*" /> -->
+    <!-- <PackageReference Include="IoT.Device.Bindings" Version="$(IotDeviceBindingsPackageVersion)" /> -->
     <ProjectReference Include="..\..\SoftPwm\SoftPwm.csproj" />
     <ProjectReference Include="..\DCMotor.csproj" />
   </ItemGroup>

--- a/src/devices/DCMotor/samples/samples.csproj
+++ b/src/devices/DCMotor/samples/samples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <!-- Normally you will use following package reference instead  -->
     <!-- <PackageReference Include="IoT.Device.Bindings" Version="0.1.0-prerelease*" /> -->
     <ProjectReference Include="..\..\SoftPwm\SoftPwm.csproj" />

--- a/src/devices/Dhtxx/Dhtxx.csproj
+++ b/src/devices/Dhtxx/Dhtxx.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Units\Units.csproj" />
     <None Include="README.md" />
   </ItemGroup>

--- a/src/devices/Dhtxx/samples/DhtSensor.sample.csproj
+++ b/src/devices/Dhtxx/samples/DhtSensor.sample.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>
 

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <Import Project="../../eng/Compilers.props" />
+  <Import Project="../../eng/Versions.props" />
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS8321</NoWarn>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>

--- a/src/devices/Ds3231/Ds3231.csproj
+++ b/src/devices/Ds3231/Ds3231.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Units\Units.csproj" />
     <Compile Include="Ds3231.cs" />
     <Compile Include="Ds3231Data.cs" />

--- a/src/devices/Ds3231/samples/Ds3231.Samples.csproj
+++ b/src/devices/Ds3231/samples/Ds3231.Samples.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Ds3231.csproj" />
   </ItemGroup>
 

--- a/src/devices/GoPiGo3/GoPiGo3.csproj
+++ b/src/devices/GoPiGo3/GoPiGo3.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease.19078.2" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
     <None Include="README.md" />
   </ItemGroup>

--- a/src/devices/GoPiGo3/samples/GoPiGo3.sample.csproj
+++ b/src/devices/GoPiGo3/samples/GoPiGo3.sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease.19078.2" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Hcsr04/Hcsr04.csproj
+++ b/src/devices/Hcsr04/Hcsr04.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="Hcsr04.cs" />
     <None Include="README.md" />
   </ItemGroup>

--- a/src/devices/Hcsr04/samples/Hcsr04.Samples.csproj
+++ b/src/devices/Hcsr04/samples/Hcsr04.Samples.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Hcsr04.csproj" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Hcsr501/Hcsr501.csproj
+++ b/src/devices/Hcsr501/Hcsr501.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease.19078.2" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="Hcsr501.cs" />
     <Compile Include="Hcsr501ValueChangedEventArgs.cs" />
   </ItemGroup>

--- a/src/devices/Hcsr501/samples/Hcsr501.Samples.csproj
+++ b/src/devices/Hcsr501/samples/Hcsr501.Samples.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease.19078.2" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Hmc5883l/Hmc5883l.csproj
+++ b/src/devices/Hmc5883l/Hmc5883l.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="Gain.cs" />
     <Compile Include="MeasurementConfiguration.cs" />
     <Compile Include="MeasuringMode.cs" />

--- a/src/devices/Hts221/Hts221.csproj
+++ b/src/devices/Hts221/Hts221.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Units\Units.csproj" />
   </ItemGroup>
 

--- a/src/devices/Lm75/Lm75.csproj
+++ b/src/devices/Lm75/Lm75.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Units\Units.csproj" />
     <Compile Include="Register.cs" />
     <Compile Include="Lm75.cs" />

--- a/src/devices/Lps25h/Lps25h.csproj
+++ b/src/devices/Lps25h/Lps25h.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Units\Units.csproj" />
   </ItemGroup>
 

--- a/src/devices/Lsm9Ds1/Lsm9Ds1.csproj
+++ b/src/devices/Lsm9Ds1/Lsm9Ds1.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Max44009/Max44009.csproj
+++ b/src/devices/Max44009/Max44009.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="IntegrationTime.cs" />
     <Compile Include="Max44009.cs" />
     <Compile Include="Register.cs" />

--- a/src/devices/Max7219/Max7219.csproj
+++ b/src/devices/Max7219/Max7219.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="Max7219.cs" />
     <Compile Include="MatrixGraphics.cs" />
     <Compile Include="IFont.cs" />

--- a/src/devices/Max7219/samples/Max7219.sample.csproj
+++ b/src/devices/Max7219/samples/Max7219.sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Mcp23xxx/Mcp23xxx.csproj
+++ b/src/devices/Mcp23xxx/Mcp23xxx.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="..\Common\System\Device\Gpio\PinVector32.cs" Link="PinVector32.cs" />
     <Compile Include="BankStyle.cs" />
     <Compile Include="I2cAdapter.cs" />

--- a/src/devices/Mcp23xxx/tests/Mcp23xxx.Tests.csproj
+++ b/src/devices/Mcp23xxx/tests/Mcp23xxx.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Mcp3008/Mcp3008.csproj
+++ b/src/devices/Mcp3008/Mcp3008.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="Mcp3008.cs" />
     <None Include="README.md" />
   </ItemGroup>

--- a/src/devices/Mcp3008/samples/Mcp3008.Sample.csproj
+++ b/src/devices/Mcp3008/samples/Mcp3008.Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Mpr121/Mpr121.csproj
+++ b/src/devices/Mpr121/Mpr121.csproj
@@ -13,7 +13,7 @@
     <Compile Include="Mpr121Configuration.cs" />
     <Compile Include="Registers.cs" />
     <None Include="README.md" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Nrf24l01/Nrf24l01.csproj
+++ b/src/devices/Nrf24l01/Nrf24l01.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="Command.cs" />
     <Compile Include="DataRate.cs" />
     <Compile Include="DataReceivedEventArgs.cs" />

--- a/src/devices/Pca95x4/Pca95x4.csproj
+++ b/src/devices/Pca95x4/Pca95x4.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Pca95x4/samples/Pca95x4.Samples.csproj
+++ b/src/devices/Pca95x4/samples/Pca95x4.Samples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Pca9685/Pca9685.csproj
+++ b/src/devices/Pca9685/Pca9685.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Pca9685/samples/Pca9685.Sample.csproj
+++ b/src/devices/Pca9685/samples/Pca9685.Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Pcx857x/Pcx857x.csproj
+++ b/src/devices/Pcx857x/Pcx857x.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="..\Common\System\Device\Gpio\PinVector32.cs" Link="PinVector32.cs" />
     <Compile Include="..\Common\System\Device\Gpio\PinVector64.cs" Link="PinVector64.cs" />
     <Compile Include="Pca8574.cs" />

--- a/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
+++ b/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
+++ b/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="4.6.0-preview4.19164.7" />
   </ItemGroup>
 

--- a/src/devices/SenseHat/SenseHat.csproj
+++ b/src/devices/SenseHat/SenseHat.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Lsm9Ds1\Lsm9Ds1.csproj" />
     <ProjectReference Include="..\Hts221\Hts221.csproj" />
     <ProjectReference Include="..\Lps25h\Lps25h.csproj" />

--- a/src/devices/Servo/Servo.csproj
+++ b/src/devices/Servo/Servo.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>
 

--- a/src/devices/Servo/samples/Servo.sample.csproj
+++ b/src/devices/Servo/samples/Servo.sample.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>
 

--- a/src/devices/Sht3x/Sht3x.csproj
+++ b/src/devices/Sht3x/Sht3x.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Units\Units.csproj" />
     <Compile Include="I2cAddress.cs" />
     <Compile Include="Resolution.cs" />

--- a/src/devices/Si7021/Si7021.csproj
+++ b/src/devices/Si7021/Si7021.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Units\Units.csproj" />
     <Compile Include="Si7021.cs" />
     <Compile Include="Register.cs" />

--- a/src/devices/SoftPwm/SoftPwm.csproj
+++ b/src/devices/SoftPwm/SoftPwm.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>
 

--- a/src/devices/SoftPwm/samples/SoftPwm.sample.csproj
+++ b/src/devices/SoftPwm/samples/SoftPwm.sample.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>
 

--- a/src/devices/Ssd1306/Ssd1306.csproj
+++ b/src/devices/Ssd1306/Ssd1306.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Ssd1306/samples/Ssd1306.Samples.csproj
+++ b/src/devices/Ssd1306/samples/Ssd1306.Samples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-*" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-*" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-*" />

--- a/src/devices/Ssd1306/tests/Ssd1306.Tests.csproj
+++ b/src/devices/Ssd1306/tests/Ssd1306.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/src/devices/Tcs3472x/Tcs3472x.csproj
+++ b/src/devices/Tcs3472x/Tcs3472x.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <Compile Include="*.cs" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 

--- a/src/devices/Tcs3472x/samples/Tcs3472x.sample.csproj
+++ b/src/devices/Tcs3472x/samples/Tcs3472x.sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Uln2003/Uln2003.csproj
+++ b/src/devices/Uln2003/Uln2003.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <Compile Include="Uln2003.cs" />
     <Compile Include="StepperMode.cs" />
   </ItemGroup>

--- a/src/devices/Vl53L0X/Vl53L0X.csproj
+++ b/src/devices/Vl53L0X/Vl53L0X.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <Compile Include="*.cs" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 

--- a/src/devices/Vl53L0X/samples/Vl53L0X.sample.csproj
+++ b/src/devices/Vl53L0X/samples/Vl53L0X.sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Ws28xx/Ws28xx.csproj
+++ b/src/devices/Ws28xx/Ws28xx.csproj
@@ -10,7 +10,7 @@
     <Compile Include="*.cs" />
     <Compile Include="../Common/Iot/Device/Graphics/BitmapImage.cs" />
     <None Include="README.md" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/tools/DevicesApiTester/DeviceApiTester.csproj
+++ b/tools/DevicesApiTester/DeviceApiTester.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.10.0" />
     <!-- Normally package reference should be used: -->
-    <!-- <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" /> -->
+    <!-- <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" /> -->
     <!-- We use project reference in our repository -->
     <!-- so that our build breaks immediately and not on the next day when the official build happens -->
     <ProjectReference Include="..\..\src\System.Device.Gpio\System.Device.Gpio.csproj">

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="../eng/Compilers.props" />
+  <Import Project="../eng/Versions.props" />
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS8321</NoWarn>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>

--- a/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.csproj
+++ b/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Currently we were getting updates for the System.Device.Gpio package by using wildcards, which is not a great model since you can't ensure where your dependencies are comming from or which version are they. This PR will move to instead use arcade auto-update model so that our samples will now depend on the daily build produced by our official pipelines.

cc: @safern @krwq 