### PR TITLE
Changes in order to make windows implementation Api compatible with Linux

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.Windows.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+
+namespace System.Device.Gpio.Drivers
+{
+    public class LibGpiodDriver : UnixDriver
+    {
+        public LibGpiodDriver()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public LibGpiodDriver(int gpioChip = 0)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override int PinCount => throw new PlatformNotSupportedException();
+
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override void ClosePin(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override PinMode GetPinMode(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override void OpenPin(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override PinValue Read(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override void SetPinMode(int pinNumber, PinMode mode)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override void Write(int pinNumber, PinValue value)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Windows.cs
@@ -6,5 +6,16 @@ namespace System.Device.Gpio.Drivers
 {
     public partial class RaspberryPi3Driver : Windows10Driver
     {
+        protected ulong ClearRegister
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        protected ulong SetRegister
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.Windows.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+
+namespace System.Device.Gpio.Drivers
+{
+    public class SysFsDriver : UnixDriver
+    {
+        public SysFsDriver()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override int PinCount => throw new PlatformNotSupportedException();
+
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override void ClosePin(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override PinMode GetPinMode(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override void OpenPin(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override PinValue Read(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override void SetPinMode(int pinNumber, PinMode mode)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected internal override void Write(int pinNumber, PinValue value)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.Windows.cs
@@ -14,6 +14,11 @@ namespace System.Device.Gpio.Drivers
             throw new PlatformNotSupportedException();
         }
 
+        public static UnixDriver Create()
+        {
+            return new UnixDriver();
+        }
+
         protected internal override int PinCount => throw new PlatformNotSupportedException();
 
         protected override void Dispose(bool disposing)

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.Windows.cs
@@ -16,7 +16,7 @@ namespace System.Device.Gpio.Drivers
 
         public static UnixDriver Create()
         {
-            return new UnixDriver();
+            throw new PlatformNotSupportedException();
         }
 
         protected internal override int PinCount => throw new PlatformNotSupportedException();

--- a/src/System.Device.Gpio/System/Device/Pwm/Drivers/Windows10PwmDriver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Drivers/Windows10PwmDriver.Windows.cs
@@ -10,7 +10,7 @@ namespace System.Device.Pwm.Drivers
     /// <summary>
     /// A PWM driver for Windows 10 IoT.
     /// </summary>
-    internal class Windows10PwmDriver : PwmDriver
+    public class Windows10PwmDriver : PwmDriver
     {
         private readonly Dictionary<int, Windows10PwmDriverChip> _chipMap = new Dictionary<int, Windows10PwmDriverChip>();
         private readonly bool _useDefaultChip;


### PR DESCRIPTION
cc: @buyaa-n @tarekgh @krwq 

We are not currently running ApiCompat as part of the build. Because of this, we did check in some changes in the Linux side that exposed API not present in the Windows side of the implementation. This would lead to runtime errors since we build the reference assembly out of the Linux implementation. These changes will make the Windows and Linux side ApiCompatible. After this is in, I'll make sure to add an ApiCompat check on the WIndows implementation build so that we don't go out of sync any longer.