### PR TITLE
BME280 - Humidity Support

### DIFF
--- a/src/devices/Bmx280/Bme280.cs
+++ b/src/devices/Bmx280/Bme280.cs
@@ -11,7 +11,7 @@ namespace Iot.Device.Bmx280
     public class Bme280 : BmxBase
     {
         private const byte DeviceId = 0x60;
-        public const byte DefaultI2cAddress = 0x76;
+        public const byte DefaultI2cAddress = 0x77;
 
         public Bme280(I2cDevice i2cDevice)
         {

--- a/src/devices/Bmx280/Bme280.cs
+++ b/src/devices/Bmx280/Bme280.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Device.I2c;
+using System.Threading.Tasks;
 
 namespace Iot.Device.Bmx280
 {
@@ -15,8 +17,115 @@ namespace Iot.Device.Bmx280
         {
             _i2cDevice = i2cDevice;
             _deviceId = DeviceId;
-            _calibrationData = new CalibrationData();
             _communicationProtocol = CommunicationProtocol.I2c;
+        }
+
+        /// <summary>
+        /// Get the current sample rate for humidity measurements.
+        /// </summary>
+        /// <returns></returns>
+        public Sampling ReadHumiditySampling()
+        {
+            byte status = Read8BitsFromRegister((byte)Register.CTRL_HUM);
+            status = (byte)(status & 0b0000_0111);
+            return ByteToSampling(status);
+        }
+
+        /// <summary>
+        /// Sets the humidity sampling to the given value.
+        /// </summary>
+        /// <param name="sampling"></param>
+        public void SetHumiditySampling(Sampling sampling)
+        {
+            byte status = Read8BitsFromRegister((byte)Register.CTRL_HUM);
+            status = (byte)(status & 0b1111_1000);
+            status = (byte)(status | (byte)sampling);
+            _i2cDevice.Write(new[] { (byte)Register.CTRL_HUM, status });
+        }
+
+        /// <summary>
+        /// Reads the Humidity from the sensor as %rH.
+        /// </summary>
+        /// <returns>
+        /// Returns a percentage from 0 to 100.
+        /// </returns>
+        public async Task<double> ReadHumidityAsync()
+        {
+            // Make sure the I2C device is initialized
+            if (!_initialized)
+            {
+                Begin();
+            }
+
+            if (ReadPowerMode() == PowerMode.Forced)
+            {
+                await Task.Delay(GetMeasurementTimeForForcedMode(ReadHumiditySampling()));
+            }
+
+            // Read the temperature first to load the t_fine value for compensation
+            if (TemperatureFine == int.MinValue)
+            {
+                await ReadTemperatureAsync();
+            }
+
+            byte msb = Read8BitsFromRegister((byte)Register.HUMIDDATA_MSB);
+            byte lsb = Read8BitsFromRegister((byte)Register.HUMIDDATA_LSB);
+
+            // Combine the values into a 32-bit integer
+            int t = (msb << 8) | lsb;
+
+            return CompensateHumidity(t);
+        }
+
+        private double CompensateHumidity(int adcHumidity)
+        {
+            // The humidity is calculated using the compensation formula in the BME280 datasheet
+            double varH = TemperatureFine - 76800.0;
+            varH = (adcHumidity - (CalibrationData.DigH4 * 64.0 + CalibrationData.DigH5 / 16384.0 * varH)) *
+                (CalibrationData.DigH2 / 65536.0 * (1.0 + CalibrationData.DigH6 / 67108864.0 * varH *
+                                               (1.0 + CalibrationData.DigH3 / 67108864.0 * varH)));
+            varH *= 1.0 - CalibrationData.DigH1 * varH / 524288.0;
+
+            if (varH > 100)
+            {
+                varH = 100;
+            }
+            else if (varH < 0)
+            {
+                varH = 0;
+            }
+
+            return varH;
+        }
+
+        internal override CalibrationData ReadCalibrationData()
+        {
+            return new CalibrationData
+            {
+                // Read temperature calibration data
+                DigT1 = Read16BitsFromRegister((byte)Register.DIG_T1),
+                DigT2 = (short)Read16BitsFromRegister((byte)Register.DIG_T2),
+                DigT3 = (short)Read16BitsFromRegister((byte)Register.DIG_T3),
+
+                // Read pressure calibration data
+                DigP1 = Read16BitsFromRegister((byte)Register.DIG_P1),
+                DigP2 = (short)Read16BitsFromRegister((byte)Register.DIG_P2),
+                DigP3 = (short)Read16BitsFromRegister((byte)Register.DIG_P3),
+                DigP4 = (short)Read16BitsFromRegister((byte)Register.DIG_P4),
+                DigP5 = (short)Read16BitsFromRegister((byte)Register.DIG_P5),
+                DigP6 = (short)Read16BitsFromRegister((byte)Register.DIG_P6),
+                DigP7 = (short)Read16BitsFromRegister((byte)Register.DIG_P7),
+                DigP8 = (short)Read16BitsFromRegister((byte)Register.DIG_P8),
+                DigP9 = (short)Read16BitsFromRegister((byte)Register.DIG_P9),
+
+                // Read humidity calibration data
+                DigH1 = Read8BitsFromRegister((byte)Register.DIG_H1),
+                DigH2 = (short)Read16BitsFromRegister((byte)Register.DIG_H2),
+                DigH3 = Read8BitsFromRegister((byte)Register.DIG_H3),
+                DigH4 = (short)((Read8BitsFromRegister((byte)Register.DIG_H4) << 4) | (Read8BitsFromRegister((byte)Register.DIG_H4 + 1) & 0xF)),
+                DigH5 = (short)((Read8BitsFromRegister((byte)Register.DIG_H5 + 1) << 4) | (Read8BitsFromRegister((byte)Register.DIG_H5) >> 4)),
+                DigH6 = (sbyte)Read8BitsFromRegister((byte)Register.DIG_H6)
+            };
         }
     }
 }

--- a/src/devices/Bmx280/Bme280.cs
+++ b/src/devices/Bmx280/Bme280.cs
@@ -41,6 +41,10 @@ namespace Iot.Device.Bmx280
             status = (byte)(status & 0b1111_1000);
             status = (byte)(status | (byte)sampling);
             _i2cDevice.Write(new[] { (byte)Register.CTRL_HUM, status });
+
+            // Changes to the above register only become effective after a write operation to "CTRL_MEAS".
+            byte measureState = Read8BitsFromRegister((byte)Register.CTRL_MEAS);
+            _i2cDevice.Write(new[] { (byte)Register.CTRL_MEAS, measureState });
         }
 
         /// <summary>

--- a/src/devices/Bmx280/Bmp280.cs
+++ b/src/devices/Bmx280/Bmp280.cs
@@ -15,8 +15,29 @@ namespace Iot.Device.Bmx280
         {
             _i2cDevice = i2cDevice;
             _deviceId = DeviceId;
-            _calibrationData = new CalibrationData();
-            _communicationProtocol = CommunicationProtocol.I2c;            
-        }                   
+            _communicationProtocol = CommunicationProtocol.I2c;
+        }
+
+        internal override CalibrationData ReadCalibrationData()
+        {
+            return new CalibrationData
+            {
+                // Read temperature calibration data
+                DigT1 = Read16BitsFromRegister((byte)Register.DIG_T1),
+                DigT2 = (short)Read16BitsFromRegister((byte)Register.DIG_T2),
+                DigT3 = (short)Read16BitsFromRegister((byte)Register.DIG_T3),
+
+                // Read pressure calibration data
+                DigP1 = Read16BitsFromRegister((byte)Register.DIG_P1),
+                DigP2 = (short)Read16BitsFromRegister((byte)Register.DIG_P2),
+                DigP3 = (short)Read16BitsFromRegister((byte)Register.DIG_P3),
+                DigP4 = (short)Read16BitsFromRegister((byte)Register.DIG_P4),
+                DigP5 = (short)Read16BitsFromRegister((byte)Register.DIG_P5),
+                DigP6 = (short)Read16BitsFromRegister((byte)Register.DIG_P6),
+                DigP7 = (short)Read16BitsFromRegister((byte)Register.DIG_P7),
+                DigP8 = (short)Read16BitsFromRegister((byte)Register.DIG_P8),
+                DigP9 = (short)Read16BitsFromRegister((byte)Register.DIG_P9)
+            };
+        }
     }
 }

--- a/src/devices/Bmx280/Bmx280.csproj
+++ b/src/devices/Bmx280/Bmx280.csproj
@@ -11,6 +11,7 @@
     <Compile Include="Bmp280.cs" />
     <Compile Include="BmxBase.cs" />
     <Compile Include="CalibrationData.cs" />
+    <Compile Include="FilteringMode.cs" />
     <Compile Include="PowerMode.cs" />
     <Compile Include="Register.cs" />
     <Compile Include="Sampling.cs" />

--- a/src/devices/Bmx280/Bmx280.csproj
+++ b/src/devices/Bmx280/Bmx280.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <RootNamespace>Iot.Device.Bmx280</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Bmx280/Bmx280.csproj
+++ b/src/devices/Bmx280/Bmx280.csproj
@@ -16,6 +16,7 @@
     <Compile Include="Register.cs" />
     <Compile Include="Sampling.cs" />
     <Compile Include="DeviceStatus.cs" />
+    <Compile Include="StandbyTime.cs" />
     <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Units\Units.csproj" />
   </ItemGroup>

--- a/src/devices/Bmx280/Bmx280.csproj
+++ b/src/devices/Bmx280/Bmx280.csproj
@@ -14,6 +14,7 @@
     <Compile Include="PowerMode.cs" />
     <Compile Include="Register.cs" />
     <Compile Include="Sampling.cs" />
+    <Compile Include="DeviceStatus.cs" />
     <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\Units\Units.csproj" />
   </ItemGroup>

--- a/src/devices/Bmx280/BmxBase.cs
+++ b/src/devices/Bmx280/BmxBase.cs
@@ -61,7 +61,6 @@ namespace Iot.Device.Bmx280
             status = (byte)(status & 0b1111_1100);
             status = (byte)(status | (byte)powerMode);
             _i2cDevice.Write(new[] { (byte)Register.CTRL_MEAS, status });
-
         }
 
         /// <summary>
@@ -325,6 +324,15 @@ namespace Iot.Device.Bmx280
             var2 = ((long)CalibrationData.DigP8 * p) >> 19;
             p = ((p + var1 + var2) >> 8) + ((long)CalibrationData.DigP7 << 4);
             return p;
+        }
+
+        /// <summary>
+        /// When called, the device is reset using the complete power-on-reset procedure.
+        /// </summary>
+        public void Reset()
+        {
+            const byte resetCommand = 0xb6;
+            _i2cDevice.Write(new[] { (byte)Register.RESET, resetCommand });
         }
 
         /// <summary>

--- a/src/devices/Bmx280/BmxBase.cs
+++ b/src/devices/Bmx280/BmxBase.cs
@@ -356,6 +356,40 @@ namespace Iot.Device.Bmx280
         }
 
         /// <summary>
+        /// Sets the IIR filter mode.
+        /// </summary>
+        /// <param name="filteringMode"></param>
+        public void SetFilterMode(FilteringMode filteringMode)
+        {
+            byte current = Read8BitsFromRegister((byte)Register.CONFIG);
+            current = (byte)((current & 0b1110_0011) | (byte)filteringMode << 2);
+            _i2cDevice.Write(new[] { (byte)Register.CONFIG, current });
+        }
+
+        /// <summary>
+        /// Reads the current IIR filter mode the device is running in.
+        /// </summary>
+        /// <returns></returns>
+        public FilteringMode ReadFilterMode()
+        {
+            byte current = Read8BitsFromRegister((byte)Register.CONFIG);
+            var mode = (byte)((current & 0b0001_1100) >> 2);
+            switch (mode)
+            {
+                case 0b000:
+                    return FilteringMode.Off;
+                case 0b001:
+                    return FilteringMode.X2;
+                case 0b010:
+                    return FilteringMode.X4;
+                case 0b011:
+                    return FilteringMode.X8;
+                default:
+                    return FilteringMode.X16;
+            }
+        }
+
+        /// <summary>
         ///  Reads an 8 bit value from a register
         /// </summary>
         /// <param name="register">

--- a/src/devices/Bmx280/BmxBase.cs
+++ b/src/devices/Bmx280/BmxBase.cs
@@ -390,6 +390,48 @@ namespace Iot.Device.Bmx280
         }
 
         /// <summary>
+        /// Sets the standby time mode the device will used when operating in normal mode.
+        /// </summary>
+        /// <param name="standbyTime"></param>
+        public void SetStandbyTime(StandbyTime standbyTime)
+        {
+            byte current = Read8BitsFromRegister((byte)Register.CONFIG);
+            current = (byte)((current & 0b0001_1111) | (byte)standbyTime << 5);
+            _i2cDevice.Write(new[] { (byte)Register.CONFIG, current });
+        }
+
+        /// <summary>
+        /// Reads the currently configured standby time mode the device will used when operating in normal mode.
+        /// </summary>
+        /// <returns></returns>
+        public StandbyTime ReadStandbyTime()
+        {
+            byte current = Read8BitsFromRegister((byte)Register.CONFIG);
+            var time = (byte)((current & 0b1110_0000) >> 5);
+            switch (time)
+            {
+                case 0b000:
+                    return StandbyTime.Ms0_5;
+                case 0b001:
+                    return StandbyTime.Ms62_5;
+                case 0b010:
+                    return StandbyTime.Ms125;
+                case 0b011:
+                    return StandbyTime.Ms250;
+                case 0b100:
+                    return StandbyTime.Ms500;
+                case 0b101:
+                    return StandbyTime.Ms1000;
+                case 0b110:
+                    return StandbyTime.Ms10;
+                case 0b111:
+                    return StandbyTime.Ms20;
+                default:
+                    throw new NotImplementedException($"Value read from registers {time:x2} was not defined by specifications.");
+            }
+        }
+
+        /// <summary>
         ///  Reads an 8 bit value from a register
         /// </summary>
         /// <param name="register">

--- a/src/devices/Bmx280/BmxBase.cs
+++ b/src/devices/Bmx280/BmxBase.cs
@@ -241,7 +241,7 @@ namespace Iot.Device.Bmx280
             long pres = CompensatePressure(t);
 
             //Return the temperature as a float value
-            return (pres) / 256;
+            return (double)pres / 256;
         }
 
         /// <summary>

--- a/src/devices/Bmx280/BmxBase.cs
+++ b/src/devices/Bmx280/BmxBase.cs
@@ -13,13 +13,14 @@ using Iot.Units;
 
 namespace Iot.Device.Bmx280
 {
-    public class BmxBase : IDisposable
+    public abstract class BmxBase : IDisposable
     {
         internal I2cDevice _i2cDevice;
         internal byte _deviceId;
         internal bool _initialized = false;
         internal CommunicationProtocol _communicationProtocol;
-        internal CalibrationData _calibrationData;
+
+        internal CalibrationData CalibrationData { get; private set; }
 
         /// <summary>
         /// The variable _temperatureFine carries a fine resolution temperature value over to the
@@ -31,6 +32,8 @@ namespace Iot.Device.Bmx280
         {
             I2c
         }
+
+        internal abstract CalibrationData ReadCalibrationData();
 
         internal void Begin()
         {
@@ -44,7 +47,7 @@ namespace Iot.Device.Bmx280
             _initialized = true;
 
             //Read the coefficients table
-            _calibrationData.ReadFromDevice(this);
+            CalibrationData = ReadCalibrationData();
         }
 
         /// <summary>
@@ -53,11 +56,11 @@ namespace Iot.Device.Bmx280
         /// <param name="powerMode"></param>
         public void SetPowerMode(PowerMode powerMode)
         {
-            byte status = Read8BitsFromRegister((byte)Register.CONTROL);
+            byte status = Read8BitsFromRegister((byte)Register.CTRL_MEAS);
             //clear last two bits
             status = (byte)(status & 0b1111_1100);
             status = (byte)(status | (byte)powerMode);
-            _i2cDevice.Write(new[] { (byte)Register.CONTROL, status });
+            _i2cDevice.Write(new[] { (byte)Register.CTRL_MEAS, status });
 
         }
 
@@ -67,7 +70,7 @@ namespace Iot.Device.Bmx280
         /// <returns></returns>
         public PowerMode ReadPowerMode()
         {
-            byte status = Read8BitsFromRegister((byte)Register.CONTROL);
+            byte status = Read8BitsFromRegister((byte)Register.CTRL_MEAS);
             status = (byte)(status & 0b000_00011);
             if (status == (byte)PowerMode.Normal)
             {
@@ -89,10 +92,10 @@ namespace Iot.Device.Bmx280
         /// <param name="sampling"></param>
         public void SetTemperatureSampling(Sampling sampling)
         {
-            byte status = Read8BitsFromRegister((byte)Register.CONTROL);
+            byte status = Read8BitsFromRegister((byte)Register.CTRL_MEAS);
             status = (byte)(status & 0b0001_1111);
             status = (byte)(status | (byte)sampling << 5);
-            _i2cDevice.Write(new[] { (byte)Register.CONTROL, status });
+            _i2cDevice.Write(new[] { (byte)Register.CTRL_MEAS, status });
         }
 
         /// <summary>
@@ -101,14 +104,14 @@ namespace Iot.Device.Bmx280
         /// <returns></returns>
         public Sampling ReadTemperatureSampling()
         {
-            byte status = Read8BitsFromRegister((byte)Register.CONTROL);
+            byte status = Read8BitsFromRegister((byte)Register.CTRL_MEAS);
             status = (byte)((status & 0b1110_0000) >> 5);
             return ByteToSampling(status);
         }
 
-        private Sampling ByteToSampling(byte value)
+        internal Sampling ByteToSampling(byte value)
         {
-            //Values >=5 equals UltraHighResolution
+            //Values >=5 equals UltraHighResolution (others)
             if (value >= 5)
             {
                 return Sampling.UltraHighResolution;
@@ -122,7 +125,7 @@ namespace Iot.Device.Bmx280
         /// <returns></returns>
         public Sampling ReadPressureSampling()
         {
-            byte status = Read8BitsFromRegister((byte)Register.CONTROL);
+            byte status = Read8BitsFromRegister((byte)Register.CTRL_MEAS);
             status = (byte)((status & 0b0001_1100) >> 2);
             return ByteToSampling(status);
         }
@@ -133,10 +136,10 @@ namespace Iot.Device.Bmx280
         /// <param name="sampling"></param>
         public void SetPressureSampling(Sampling sampling)
         {
-            byte status = Read8BitsFromRegister((byte)Register.CONTROL);
+            byte status = Read8BitsFromRegister((byte)Register.CTRL_MEAS);
             status = (byte)(status & 0b1110_0011);
             status = (byte)(status | (byte)sampling << 2);
-            _i2cDevice.Write(new[] { (byte)Register.CONTROL, status });
+            _i2cDevice.Write(new[] { (byte)Register.CTRL_MEAS, status });
         }
 
         /// <summary>
@@ -177,7 +180,7 @@ namespace Iot.Device.Bmx280
         /// <returns>
         /// The time it takes for the chip to read data in milliseconds rounded up
         /// </returns>
-        private int GetMeasurementTimeForForcedMode(Sampling sampleMode)
+        internal int GetMeasurementTimeForForcedMode(Sampling sampleMode)
         {
             if (sampleMode == Sampling.UltraLowPower)
             {
@@ -281,9 +284,9 @@ namespace Iot.Device.Bmx280
         {
             //Formula from the datasheet
             //The temperature is calculated using the compensation formula in the BMP280 datasheet
-            double var1 = ((adcTemperature / 16384.0) - (_calibrationData.DigT1 / 1024.0)) * _calibrationData.DigT2;
-            double var2 = ((adcTemperature / 131072.0) - (_calibrationData.DigT1 / 8192.0));
-            var2 *= var2 * _calibrationData.DigT3;
+            double var1 = ((adcTemperature / 16384.0) - (CalibrationData.DigT1 / 1024.0)) * CalibrationData.DigT2;
+            double var2 = ((adcTemperature / 131072.0) - (CalibrationData.DigT1 / 8192.0));
+            var2 *= var2 * CalibrationData.DigT3;
 
             TemperatureFine = (int)(var1 + var2);
 
@@ -306,11 +309,11 @@ namespace Iot.Device.Bmx280
             //Formula from the datasheet
             //The pressure is calculated using the compensation formula in the BMP280 datasheet
             long var1 = TemperatureFine - 128000;
-            long var2 = var1 * var1 * (long)_calibrationData.DigP6;
-            var2 = var2 + ((var1 * (long)_calibrationData.DigP5) << 17);
-            var2 = var2 + ((long)_calibrationData.DigP4 << 35);
-            var1 = ((var1 * var1 * (long)_calibrationData.DigP3) >> 8) + ((var1 * (long)_calibrationData.DigP2) << 12);
-            var1 = (((((long)1 << 47) + var1)) * (long)_calibrationData.DigP1) >> 33;
+            long var2 = var1 * var1 * (long)CalibrationData.DigP6;
+            var2 = var2 + ((var1 * (long)CalibrationData.DigP5) << 17);
+            var2 = var2 + ((long)CalibrationData.DigP4 << 35);
+            var1 = ((var1 * var1 * (long)CalibrationData.DigP3) >> 8) + ((var1 * (long)CalibrationData.DigP2) << 12);
+            var1 = (((((long)1 << 47) + var1)) * (long)CalibrationData.DigP1) >> 33;
             if (var1 == 0)
             {
                 return 0; //Avoid exception caused by division by zero
@@ -318,9 +321,9 @@ namespace Iot.Device.Bmx280
             //Perform calibration operations
             long p = 1048576 - adcPressure;
             p = (((p << 31) - var2) * 3125) / var1;
-            var1 = ((long)_calibrationData.DigP9 * (p >> 13) * (p >> 13)) >> 25;
-            var2 = ((long)_calibrationData.DigP8 * p) >> 19;
-            p = ((p + var1 + var2) >> 8) + ((long)_calibrationData.DigP7 << 4);
+            var1 = ((long)CalibrationData.DigP9 * (p >> 13) * (p >> 13)) >> 25;
+            var2 = ((long)CalibrationData.DigP8 * p) >> 19;
+            p = ((p + var1 + var2) >> 8) + ((long)CalibrationData.DigP7 << 4);
             return p;
         }
 

--- a/src/devices/Bmx280/BmxBase.cs
+++ b/src/devices/Bmx280/BmxBase.cs
@@ -336,6 +336,26 @@ namespace Iot.Device.Bmx280
         }
 
         /// <summary>
+        /// Get the current status of the device.
+        /// </summary>
+        /// <returns></returns>
+        public DeviceStatus ReadStatus()
+        {
+            var status = Read8BitsFromRegister((byte)Register.STATUS);
+
+            // Bit 3
+            var measuring = ((status >> 3) & 1) == 1;
+            // Bit 0
+            var imUpdate = (status & 1) == 1;
+
+            return new DeviceStatus
+            {
+                ImageUpdating = imUpdate,
+                Measuring = measuring
+            };
+        }
+
+        /// <summary>
         ///  Reads an 8 bit value from a register
         /// </summary>
         /// <param name="register">

--- a/src/devices/Bmx280/CalibrationData.cs
+++ b/src/devices/Bmx280/CalibrationData.cs
@@ -6,10 +6,12 @@ namespace Iot.Device.Bmx280
 {
     internal class CalibrationData
     {
+        // Temperature calibration data
         public ushort DigT1 { get; set; }
         public short DigT2 { get; set; }
         public short DigT3 { get; set; }
 
+        // Pressure calibration data
         public ushort DigP1 { get; set; }
         public short DigP2 { get; set; }
         public short DigP3 { get; set; }
@@ -20,23 +22,12 @@ namespace Iot.Device.Bmx280
         public short DigP8 { get; set; }
         public short DigP9 { get; set; }
 
-        internal void ReadFromDevice(BmxBase bmp280)
-        {
-            // Read temperature calibration data
-            DigT1 = bmp280.Read16BitsFromRegister((byte)Register.DIG_T1);
-            DigT2 = (short)bmp280.Read16BitsFromRegister((byte)Register.DIG_T2);
-            DigT3 = (short)bmp280.Read16BitsFromRegister((byte)Register.DIG_T3);
-
-            // Read pressure calibration data
-            DigP1 = bmp280.Read16BitsFromRegister((byte)Register.DIG_P1);
-            DigP2 = (short)bmp280.Read16BitsFromRegister((byte)Register.DIG_P2);
-            DigP3 = (short)bmp280.Read16BitsFromRegister((byte)Register.DIG_P3);
-            DigP4 = (short)bmp280.Read16BitsFromRegister((byte)Register.DIG_P4);
-            DigP5 = (short)bmp280.Read16BitsFromRegister((byte)Register.DIG_P5);
-            DigP6 = (short)bmp280.Read16BitsFromRegister((byte)Register.DIG_P6);
-            DigP7 = (short)bmp280.Read16BitsFromRegister((byte)Register.DIG_P7);
-            DigP8 = (short)bmp280.Read16BitsFromRegister((byte)Register.DIG_P8);
-            DigP9 = (short)bmp280.Read16BitsFromRegister((byte)Register.DIG_P9);
-        }
+        // Humidity calibration data (BME280 Only)
+        public byte DigH1 { get; set; }
+        public short DigH2 { get; set; }
+        public ushort DigH3 { get; set; }
+        public short DigH4 { get; set; }
+        public short DigH5 { get; set; }
+        public sbyte DigH6 { get; set; }
     }
 }

--- a/src/devices/Bmx280/DeviceStatus.cs
+++ b/src/devices/Bmx280/DeviceStatus.cs
@@ -1,0 +1,16 @@
+﻿namespace Iot.Device.Bmx280
+{
+    public class DeviceStatus
+    {
+        /// <summary>
+        /// True whenever a conversion is running and False when the results have been transferred to the data registers.
+        /// </summary>
+        public bool Measuring { get; set; }
+
+        /// <summary>
+        /// True when the NVM data is being copied to images registers and False whe the copying is done.
+        /// The data is copied at power-on-reset and before every conversion.
+        /// </summary>
+        public bool ImageUpdating { get; set; }
+    }
+}

--- a/src/devices/Bmx280/DeviceStatus.cs
+++ b/src/devices/Bmx280/DeviceStatus.cs
@@ -1,5 +1,12 @@
-﻿namespace Iot.Device.Bmx280
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Iot.Device.Bmx280
 {
+    /// <summary>
+    /// Indicates the status of the device.
+    /// </summary>
     public class DeviceStatus
     {
         /// <summary>

--- a/src/devices/Bmx280/FilteringMode.cs
+++ b/src/devices/Bmx280/FilteringMode.cs
@@ -1,0 +1,26 @@
+﻿namespace Iot.Device.Bmx280
+{
+    public enum FilteringMode : byte
+    {
+        /// <summary>
+        /// Filter off
+        /// </summary>
+        Off = 0b000,
+        /// <summary>
+        /// Coefficient x2
+        /// </summary>
+        X2 = 0b001,
+        /// <summary>
+        /// Coefficient x4
+        /// </summary>
+        X4 = 0b010,
+        /// <summary>
+        /// Coefficient x8
+        /// </summary>
+        X8 = 0b011,
+        /// <summary>
+        /// Coefficient x16
+        /// </summary>
+        X16 = 0b100,
+    }
+}

--- a/src/devices/Bmx280/FilteringMode.cs
+++ b/src/devices/Bmx280/FilteringMode.cs
@@ -1,5 +1,18 @@
-﻿namespace Iot.Device.Bmx280
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Iot.Device.Bmx280
 {
+    /// <summary>
+    /// Bmx280 devices feature an internal IIR filter.
+    /// This filter effectively reduces the bandwidth of the temperature and pressure output signals
+    /// and increases the resolution of the pressure and temperature output data to 20 bits.
+    ///
+    /// The higher the coefficient, the slower the sensors respond to external inputs.
+    ///
+    /// See the data sheet with recommended settings for different scenarios.
+    /// </summary>
     public enum FilteringMode : byte
     {
         /// <summary>
@@ -21,6 +34,6 @@
         /// <summary>
         /// Coefficient x16
         /// </summary>
-        X16 = 0b100,
+        X16 = 0b100
     }
 }

--- a/src/devices/Bmx280/PowerMode.cs
+++ b/src/devices/Bmx280/PowerMode.cs
@@ -5,20 +5,21 @@
 namespace Iot.Device.Bmx280
 {
     /// <summary>
-    /// BMP280s power modes
+    /// Bmx280s power modes.
     /// </summary>
     public enum PowerMode : byte
     {
         /// <summary>
-        /// Power saving mode, does not do new measurements
+        /// No operations, all registers accessible, lowest power mode, selected after startup.
         /// </summary>
         Sleep = 0b00,
         /// <summary>
-        /// Device goes to sleep mode after one measurement
+        /// Perform one measurement, store results, and return to sleep mode.
         /// </summary>
         Forced = 0b10,
         /// <summary>
-        /// Device does continuous measurements
+        /// Perpetual cycling of measurements and inactive periods.
+        /// This interval is determined by the combination of IIR filter and standby time options.
         /// </summary>
         Normal = 0b11
     }

--- a/src/devices/Bmx280/Register.cs
+++ b/src/devices/Bmx280/Register.cs
@@ -23,14 +23,25 @@ namespace Iot.Device.Bmx280
         DIG_P8 = 0x9C,
         DIG_P9 = 0x9E,
 
+        // BME280 Only
+        DIG_H1 = 0xA1,
+        DIG_H2 = 0xE1,
+        DIG_H3 = 0xE3,
+        DIG_H4 = 0xE4,
+        DIG_H5 = 0xE5,
+        DIG_H6 = 0xE7,
+
         CHIPID = 0xD0,
         VERSION = 0xD1,
         SOFTRESET = 0xE0,
 
         CAL26 = 0xE1,  // R calibration stored in 0xE1-0xF0
 
+        // BME280 Only
+        CTRL_HUM = 0xF2,
+
         STATUS = 0xF3,
-        CONTROL = 0xF4,
+        CTRL_MEAS = 0xF4,
         CONFIG = 0xF5,
 
         PRESSUREDATA_MSB = 0xF7,
@@ -40,5 +51,9 @@ namespace Iot.Device.Bmx280
         TEMPDATA_MSB = 0xFA,
         TEMPDATA_LSB = 0xFB,
         TEMPDATA_XLSB = 0xFC, // bits <7:4>=
+
+        // BME280 Only
+        HUMIDDATA_LSB = 0xFE,
+        HUMIDDATA_MSB = 0xFD
     }
 }

--- a/src/devices/Bmx280/Register.cs
+++ b/src/devices/Bmx280/Register.cs
@@ -5,7 +5,7 @@
 namespace Iot.Device.Bmx280
 {
     /// <summary>
-    ///  Register
+    /// Bmx280 registers.
     /// </summary>
     internal enum Register : byte
     {

--- a/src/devices/Bmx280/Register.cs
+++ b/src/devices/Bmx280/Register.cs
@@ -33,7 +33,7 @@ namespace Iot.Device.Bmx280
 
         CHIPID = 0xD0,
         VERSION = 0xD1,
-        SOFTRESET = 0xE0,
+        RESET = 0xE0,
 
         CAL26 = 0xE1,  // R calibration stored in 0xE1-0xF0
 

--- a/src/devices/Bmx280/Sampling.cs
+++ b/src/devices/Bmx280/Sampling.cs
@@ -14,23 +14,23 @@ namespace Iot.Device.Bmx280
         /// </summary>
         Skipped = 0b000,
         /// <summary>
-        /// oversampling x1
+        /// Oversampling x1
         /// </summary>
         UltraLowPower = 0b001,
         /// <summary>
-        /// oversampling x2
+        /// Oversampling x2
         /// </summary>
         LowPower = 0b010,
         /// <summary>
-        /// oversampling x4
+        /// Oversampling x4
         /// </summary>
         Standard = 0b011,
         /// <summary>
-        /// oversampling x8
+        /// Oversampling x8
         /// </summary>
         HighResolution = 0b100,
         /// <summary>
-        /// oversampling x16
+        /// Oversampling x16
         /// </summary>
         UltraHighResolution = 0b101,
     }

--- a/src/devices/Bmx280/StandbyTime.cs
+++ b/src/devices/Bmx280/StandbyTime.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Iot.Device.Bmx280
+{
+    /// <summary>
+    /// Controls the inactive duration in normal mode.
+    /// </summary>
+    public enum StandbyTime : byte
+    {
+        /// <summary>
+        /// 0.5 ms
+        /// </summary>
+        Ms0_5 = 0b000,
+        /// <summary>
+        /// 62.5 ms
+        /// </summary>
+        Ms62_5 = 0b001,
+        /// <summary>
+        /// 125 ms
+        /// </summary>
+        Ms125 = 0b010,
+        /// <summary>
+        /// 250 ms
+        /// </summary>
+        Ms250 = 0b011,
+        /// <summary>
+        /// 500 ms
+        /// </summary>
+        Ms500 = 0b100,
+        /// <summary>
+        /// 1,000 ms
+        /// </summary>
+        Ms1000 = 0b101,
+        /// <summary>
+        /// 10 ms
+        /// </summary>
+        Ms10 = 0b110,
+        /// <summary>
+        /// 20 ms
+        /// </summary>
+        Ms20 = 0b111,
+    }
+}

--- a/src/devices/Bmx280/samples/Bme280.sample.cs
+++ b/src/devices/Bmx280/samples/Bme280.sample.cs
@@ -58,6 +58,9 @@ namespace Iot.Device.Samples
                     i2CBmpe80.SetHumiditySampling(Sampling.Standard);
                     Console.WriteLine(i2CBmpe80.ReadHumiditySampling());
 
+                    i2CBmpe80.SetFilterMode(FilteringMode.Off);
+                    Console.WriteLine(i2CBmpe80.ReadFilterMode());
+
                     //set mode forced and read again
                     i2CBmpe80.SetPowerMode(PowerMode.Forced);
 
@@ -79,6 +82,9 @@ namespace Iot.Device.Samples
                     Console.WriteLine(i2CBmpe80.ReadPressureSampling());
                     i2CBmpe80.SetHumiditySampling(Sampling.UltraLowPower);
                     Console.WriteLine(i2CBmpe80.ReadHumiditySampling());
+
+                    i2CBmpe80.SetFilterMode(FilteringMode.X2);
+                    Console.WriteLine(i2CBmpe80.ReadFilterMode());
                 }
             }
         }

--- a/src/devices/Bmx280/samples/Bme280.sample.cs
+++ b/src/devices/Bmx280/samples/Bme280.sample.cs
@@ -23,7 +23,7 @@ namespace Iot.Device.Samples
             //set this to the current sea level pressure in the area for correct altitude readings
             const double defaultSeaLevelPressure = 1033.00;
 
-            var i2cSettings = new I2cConnectionSettings(busId, Bme280.DefaultI2cAddress);
+            var i2cSettings = new I2cConnectionSettings(busId, Bme280.DefaultI2cAddress + 1);
             var i2cDevice = new UnixI2cDevice(i2cSettings);
             var i2CBmpe80 = new Bme280(i2cDevice);
 
@@ -31,20 +31,23 @@ namespace Iot.Device.Samples
             {
                 while (true)
                 {
-                    ////set mode forced so device sleeps after read
+                    //set mode forced so device sleeps after read
                     i2CBmpe80.SetPowerMode(PowerMode.Forced);
 
                     //set samplings
                     i2CBmpe80.SetTemperatureSampling(Sampling.UltraLowPower);
                     i2CBmpe80.SetPressureSampling(Sampling.UltraLowPower);
+                    i2CBmpe80.SetHumiditySampling(Sampling.UltraLowPower);
 
                     //read values
                     Temperature tempValue = await i2CBmpe80.ReadTemperatureAsync();
-                    Console.WriteLine($"Temperature {tempValue.Celsius}");
+                    Console.WriteLine($"Temperature: {tempValue.Celsius} C");
                     double preValue = await i2CBmpe80.ReadPressureAsync();
-                    Console.WriteLine($"Pressure {preValue}");
+                    Console.WriteLine($"Pressure: {preValue} Pa");
                     double altValue = await i2CBmpe80.ReadAltitudeAsync(defaultSeaLevelPressure);
-                    Console.WriteLine($"Altitude: {altValue}");
+                    Console.WriteLine($"Altitude: {altValue} meters");
+                    double humValue = await i2CBmpe80.ReadHumidityAsync();
+                    Console.WriteLine($"Humidity: {humValue} %");
                     Thread.Sleep(1000);
 
                     //set higher sampling
@@ -52,17 +55,21 @@ namespace Iot.Device.Samples
                     Console.WriteLine(i2CBmpe80.ReadTemperatureSampling());
                     i2CBmpe80.SetPressureSampling(Sampling.UltraHighResolution);
                     Console.WriteLine(i2CBmpe80.ReadPressureSampling());
+                    i2CBmpe80.SetHumiditySampling(Sampling.Standard);
+                    Console.WriteLine(i2CBmpe80.ReadHumiditySampling());
 
                     //set mode forced and read again
                     i2CBmpe80.SetPowerMode(PowerMode.Forced);
 
                     //read values
                     tempValue = await i2CBmpe80.ReadTemperatureAsync();
-                    Console.WriteLine($"Temperature {tempValue}");
+                    Console.WriteLine($"Temperature: {tempValue.Celsius} C");
                     preValue = await i2CBmpe80.ReadPressureAsync();
-                    Console.WriteLine($"Pressure {preValue}");
+                    Console.WriteLine($"Pressure: {preValue} Pa");
                     altValue = await i2CBmpe80.ReadAltitudeAsync(defaultSeaLevelPressure);
-                    Console.WriteLine($"Altitude: {altValue}");
+                    Console.WriteLine($"Altitude: {altValue} meters");
+                    humValue = await i2CBmpe80.ReadHumidityAsync();
+                    Console.WriteLine($"Humidity: {humValue} %");
                     Thread.Sleep(5000);
 
                     //set sampling to higher
@@ -70,6 +77,8 @@ namespace Iot.Device.Samples
                     Console.WriteLine(i2CBmpe80.ReadTemperatureSampling());
                     i2CBmpe80.SetPressureSampling(Sampling.UltraLowPower);
                     Console.WriteLine(i2CBmpe80.ReadPressureSampling());
+                    i2CBmpe80.SetHumiditySampling(Sampling.UltraLowPower);
+                    Console.WriteLine(i2CBmpe80.ReadHumiditySampling());
                 }
             }
         }

--- a/src/devices/Bmx280/samples/Bme280.sample.cs
+++ b/src/devices/Bmx280/samples/Bme280.sample.cs
@@ -23,7 +23,7 @@ namespace Iot.Device.Samples
             //set this to the current sea level pressure in the area for correct altitude readings
             const double defaultSeaLevelPressure = 1033.00;
 
-            var i2cSettings = new I2cConnectionSettings(busId, Bme280.DefaultI2cAddress + 1);
+            var i2cSettings = new I2cConnectionSettings(busId, Bme280.DefaultI2cAddress);
             var i2cDevice = new UnixI2cDevice(i2cSettings);
             var i2CBmpe80 = new Bme280(i2cDevice);
 


### PR DESCRIPTION
This pr adds support for humidity for BME280 devices.

- Moved the responsibility of reading calibration data to the implemented devices, away from `CalibrationData`.
- Added additional registers.
- Added method to read humidity data and to apply calibrations.

This resolves #399.