### PR TITLE
Basic SocketCan implementation

### DIFF
--- a/src/devices/SocketCan/CanFlags.cs
+++ b/src/devices/SocketCan/CanFlags.cs
@@ -7,7 +7,7 @@ using System;
 namespace Iot.Device.SocketCan
 {
     [Flags]
-    public enum CanFlags : uint
+    internal enum CanFlags : uint
     {
         ExtendedFrameFormat = 0x80000000,
         RemoteTransmissionRequest = 0x40000000,

--- a/src/devices/SocketCan/CanFlags.cs
+++ b/src/devices/SocketCan/CanFlags.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Iot.Device.SocketCan
+{
+    [Flags]
+    public enum CanFlags : uint
+    {
+        ExtendedFrameFormat = 0x80000000,
+        RemoteTransmissionRequest = 0x40000000,
+        Error = 0x20000000,
+    }
+}

--- a/src/devices/SocketCan/CanFrame.cs
+++ b/src/devices/SocketCan/CanFrame.cs
@@ -1,0 +1,145 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Iot.Device.SocketCan
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct CanFrame
+    {
+        private const int CAN_MAX_DLEN = 8;
+
+        // RawId (can_id) includes EFF, RTR and ERR flags
+        public uint RawId { get; set; }
+
+        // data length code (can_dlc)
+        // see: ISO 11898-1 Chapter 8.4.2.4
+        private byte _length;
+        private byte _pad;
+        private byte _res0;
+        private byte _res1;
+        private fixed byte _data[CAN_MAX_DLEN];
+
+        public uint Id => ExtendedFrameFormat ? ExtendedId : StandardId;
+
+        public uint StandardId
+        {
+            get
+            {
+                if (ExtendedFrameFormat)
+                    throw new InvalidOperationException($"{nameof(StandardId)} can be obtained only when {nameof(ExtendedFrameFormat)} is not set.");
+                
+                return RawId & Interop.CAN_SFF_MASK;
+            }
+            set
+            {
+                if ((value & ~Interop.CAN_SFF_MASK) != 0)
+                    throw new InvalidOperationException($"{nameof(value)} must be 11 bit identifier.");
+
+                ExtendedFrameFormat = false;
+                RawId &= ~Interop.CAN_SFF_MASK;
+                RawId |= value;
+            }
+        }
+
+        public uint ExtendedId
+        {
+            get
+            {
+                if (!ExtendedFrameFormat)
+                    throw new InvalidOperationException($"{nameof(ExtendedId)} can be obtained only when {nameof(ExtendedFrameFormat)} is set.");
+                
+                return RawId & Interop.CAN_EFF_MASK;
+            }
+            set
+            {
+                if ((value & ~Interop.CAN_EFF_MASK) != 0)
+                    throw new InvalidOperationException($"{nameof(value)} must be 29 bit identifier.");
+
+                ExtendedFrameFormat = true;
+                RawId &= ~Interop.CAN_EFF_MASK;
+                RawId |= value;
+            }
+        }
+
+        public bool Error
+        {
+            get => ((CanFlags)RawId).HasFlag(CanFlags.Error);
+            set => SetCanFlag(CanFlags.Error, value);
+        }
+
+        public bool ExtendedFrameFormat
+        {
+            get => ((CanFlags)RawId).HasFlag(CanFlags.ExtendedFrameFormat);
+            set => SetCanFlag(CanFlags.ExtendedFrameFormat, value);
+        }
+
+        public bool RemoteTransmissionRequest
+        {
+            get => ((CanFlags)RawId).HasFlag(CanFlags.RemoteTransmissionRequest);
+            set => SetCanFlag(CanFlags.RemoteTransmissionRequest, value);
+        }
+
+        public bool IsValid
+        {
+            get
+            {
+                uint idMask = ExtendedFrameFormat ? Interop.CAN_EFF_MASK : Interop.CAN_SFF_MASK;
+                return !Error && _length <= CAN_MAX_DLEN && (RawId & ~idMask) == 0;
+            }
+        }
+
+        public ReadOnlySpan<byte> Data
+        {
+            get
+            {
+                if (_length > CAN_MAX_DLEN)
+                {
+                    throw new InvalidOperationException($"Length {_length} exceed maximum allowed: {CAN_MAX_DLEN}");
+                }
+
+                fixed (byte* d = _data)
+                {
+                    return new ReadOnlySpan<byte>(d, _length);
+                }
+            }
+            set
+            {
+                if (value.Length > CAN_MAX_DLEN)
+                    throw new InvalidOperationException($"Data length cannot exceed {CAN_MAX_DLEN} bytes");
+                
+                _length = (byte)value.Length;
+
+                fixed (byte* d = _data)
+                {
+                    var buff = new Span<byte>(d, value.Length);
+                    value.CopyTo(buff);
+
+                    // fill remainder of the buffer with zeros for sanity
+                    var remainder = new Span<byte>(d + value.Length, CAN_MAX_DLEN - value.Length);
+                    remainder.Fill(0);
+                }
+            }
+        }
+
+        private void SetCanFlag(CanFlags flag, bool value)
+        {
+            if (value)
+            {
+                RawId |= (uint)flag;
+            }
+            else
+            {
+                RawId &= ~(uint)flag;
+            }
+        }
+    }
+}

--- a/src/devices/SocketCan/CanFrame.cs
+++ b/src/devices/SocketCan/CanFrame.cs
@@ -13,132 +13,26 @@ using System.Threading;
 namespace Iot.Device.SocketCan
 {
     [StructLayout(LayoutKind.Sequential)]
-    public unsafe struct CanFrame
+    internal unsafe struct CanFrame
     {
-        private const int CAN_MAX_DLEN = 8;
+        public const int MaxLength = 8;
 
         // RawId (can_id) includes EFF, RTR and ERR flags
-        public uint RawId { get; set; }
+        public CanId Id;
 
         // data length code (can_dlc)
         // see: ISO 11898-1 Chapter 8.4.2.4
-        private byte _length;
+        public byte Length;
         private byte _pad;
         private byte _res0;
         private byte _res1;
-        private fixed byte _data[CAN_MAX_DLEN];
-
-        public uint Id => ExtendedFrameFormat ? ExtendedId : StandardId;
-
-        public uint StandardId
-        {
-            get
-            {
-                if (ExtendedFrameFormat)
-                    throw new InvalidOperationException($"{nameof(StandardId)} can be obtained only when {nameof(ExtendedFrameFormat)} is not set.");
-                
-                return RawId & Interop.CAN_SFF_MASK;
-            }
-            set
-            {
-                if ((value & ~Interop.CAN_SFF_MASK) != 0)
-                    throw new InvalidOperationException($"{nameof(value)} must be 11 bit identifier.");
-
-                ExtendedFrameFormat = false;
-                RawId &= ~Interop.CAN_SFF_MASK;
-                RawId |= value;
-            }
-        }
-
-        public uint ExtendedId
-        {
-            get
-            {
-                if (!ExtendedFrameFormat)
-                    throw new InvalidOperationException($"{nameof(ExtendedId)} can be obtained only when {nameof(ExtendedFrameFormat)} is set.");
-                
-                return RawId & Interop.CAN_EFF_MASK;
-            }
-            set
-            {
-                if ((value & ~Interop.CAN_EFF_MASK) != 0)
-                    throw new InvalidOperationException($"{nameof(value)} must be 29 bit identifier.");
-
-                ExtendedFrameFormat = true;
-                RawId &= ~Interop.CAN_EFF_MASK;
-                RawId |= value;
-            }
-        }
-
-        public bool Error
-        {
-            get => ((CanFlags)RawId).HasFlag(CanFlags.Error);
-            set => SetCanFlag(CanFlags.Error, value);
-        }
-
-        public bool ExtendedFrameFormat
-        {
-            get => ((CanFlags)RawId).HasFlag(CanFlags.ExtendedFrameFormat);
-            set => SetCanFlag(CanFlags.ExtendedFrameFormat, value);
-        }
-
-        public bool RemoteTransmissionRequest
-        {
-            get => ((CanFlags)RawId).HasFlag(CanFlags.RemoteTransmissionRequest);
-            set => SetCanFlag(CanFlags.RemoteTransmissionRequest, value);
-        }
+        public fixed byte Data[MaxLength];
 
         public bool IsValid
         {
             get
             {
-                uint idMask = ExtendedFrameFormat ? Interop.CAN_EFF_MASK : Interop.CAN_SFF_MASK;
-                return !Error && _length <= CAN_MAX_DLEN && (RawId & ~idMask) == 0;
-            }
-        }
-
-        public ReadOnlySpan<byte> Data
-        {
-            get
-            {
-                if (_length > CAN_MAX_DLEN)
-                {
-                    throw new InvalidOperationException($"Length {_length} exceed maximum allowed: {CAN_MAX_DLEN}");
-                }
-
-                fixed (byte* d = _data)
-                {
-                    return new ReadOnlySpan<byte>(d, _length);
-                }
-            }
-            set
-            {
-                if (value.Length > CAN_MAX_DLEN)
-                    throw new InvalidOperationException($"Data length cannot exceed {CAN_MAX_DLEN} bytes");
-                
-                _length = (byte)value.Length;
-
-                fixed (byte* d = _data)
-                {
-                    var buff = new Span<byte>(d, value.Length);
-                    value.CopyTo(buff);
-
-                    // fill remainder of the buffer with zeros for sanity
-                    var remainder = new Span<byte>(d + value.Length, CAN_MAX_DLEN - value.Length);
-                    remainder.Fill(0);
-                }
-            }
-        }
-
-        private void SetCanFlag(CanFlags flag, bool value)
-        {
-            if (value)
-            {
-                RawId |= (uint)flag;
-            }
-            else
-            {
-                RawId &= ~(uint)flag;
+                return Length <= MaxLength && Id.IsValid;
             }
         }
     }

--- a/src/devices/SocketCan/CanId.cs
+++ b/src/devices/SocketCan/CanId.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Iot.Device.SocketCan
+{
+    public struct CanId
+    {
+        // Raw (can_id) includes EFF, RTR and ERR flags
+        public uint Raw { get; set; }
+        public uint Value => ExtendedFrameFormat ? Extended : Standard;
+
+        public uint Standard
+        {
+            get
+            {
+                if (ExtendedFrameFormat)
+                    throw new InvalidOperationException($"{nameof(Standard)} can be obtained only when {nameof(ExtendedFrameFormat)} is not set.");
+                
+                return Raw & Interop.CAN_SFF_MASK;
+            }
+            set
+            {
+                if ((value & ~Interop.CAN_SFF_MASK) != 0)
+                    throw new InvalidOperationException($"{nameof(value)} must be 11 bit identifier.");
+
+                ExtendedFrameFormat = false;
+                // note: we clear all bits, not just SFF
+                Raw &= ~Interop.CAN_EFF_MASK;
+                Raw |= value;
+            }
+        }
+
+        public uint Extended
+        {
+            get
+            {
+                if (!ExtendedFrameFormat)
+                    throw new InvalidOperationException($"{nameof(Extended)} can be obtained only when {nameof(ExtendedFrameFormat)} is set.");
+                
+                return Raw & Interop.CAN_EFF_MASK;
+            }
+            set
+            {
+                if ((value & ~Interop.CAN_EFF_MASK) != 0)
+                    throw new InvalidOperationException($"{nameof(value)} must be 29 bit identifier.");
+
+                ExtendedFrameFormat = true;
+                Raw &= ~Interop.CAN_EFF_MASK;
+                Raw |= value;
+            }
+        }
+
+        public bool Error
+        {
+            get => ((CanFlags)Raw).HasFlag(CanFlags.Error);
+            set => SetCanFlag(CanFlags.Error, value);
+        }
+
+        public bool ExtendedFrameFormat
+        {
+            get => ((CanFlags)Raw).HasFlag(CanFlags.ExtendedFrameFormat);
+            set => SetCanFlag(CanFlags.ExtendedFrameFormat, value);
+        }
+
+        public bool RemoteTransmissionRequest
+        {
+            get => ((CanFlags)Raw).HasFlag(CanFlags.RemoteTransmissionRequest);
+            set => SetCanFlag(CanFlags.RemoteTransmissionRequest, value);
+        }
+
+        public bool IsValid
+        {
+            get
+            {
+                uint idMask = ExtendedFrameFormat ? Interop.CAN_EFF_MASK : Interop.CAN_SFF_MASK;
+                return !Error && (Raw & idMask) == (Raw & Interop.CAN_EFF_MASK);
+            }
+        }
+
+        private void SetCanFlag(CanFlags flag, bool value)
+        {
+            if (value)
+            {
+                Raw |= (uint)flag;
+            }
+            else
+            {
+                Raw &= ~(uint)flag;
+            }
+        }
+    }
+}

--- a/src/devices/SocketCan/CanId.cs
+++ b/src/devices/SocketCan/CanId.cs
@@ -15,7 +15,8 @@ namespace Iot.Device.SocketCan
     public struct CanId
     {
         // Raw (can_id) includes EFF, RTR and ERR flags
-        public uint Raw { get; set; }
+        internal uint Raw { get; set; }
+
         public uint Value => ExtendedFrameFormat ? Extended : Standard;
 
         public uint Standard

--- a/src/devices/SocketCan/CanRaw.cs
+++ b/src/devices/SocketCan/CanRaw.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Iot.Device.SocketCan
+{
+    public class CanRaw : IDisposable
+    {
+        private SafeCanRawSocketHandle _handle;
+
+        public CanRaw(string networkInterface = "can0")
+        {
+            _handle = new SafeCanRawSocketHandle(networkInterface);
+        }
+
+        public void WriteFrame(ref CanFrame frame)
+        {
+            ReadOnlySpan<CanFrame> frameSpan = MemoryMarshal.CreateReadOnlySpan(ref frame, 1);
+            ReadOnlySpan<byte> buff = MemoryMarshal.AsBytes(frameSpan);
+            Interop.Write(_handle, buff);
+        }
+
+        public void ReadFrame(ref CanFrame frame)
+        {
+            Span<CanFrame> frameSpan = MemoryMarshal.CreateSpan(ref frame, 1);
+            Span<byte> buff = MemoryMarshal.AsBytes(frameSpan);
+
+            while (buff.Length > 0)
+            {
+                int read = Interop.Read(_handle, buff);
+                buff = buff.Slice(read);
+            }
+        }
+
+        public void Filter(bool extendedFrameFormat, uint id)
+        {
+            uint idMask = extendedFrameFormat ? Interop.CAN_EFF_MASK : Interop.CAN_SFF_MASK;
+
+            if ((id & idMask) != id)
+                throw new ArgumentOutOfRangeException($"{nameof(id)} must not be {(extendedFrameFormat ? 29 : 11)} bit identifier");
+
+            if (extendedFrameFormat)
+            {
+                id |= (uint)CanFlags.ExtendedFrameFormat;
+            }
+
+            Span<Interop.CanFilter> filters = stackalloc Interop.CanFilter[1];
+            filters[0].can_id = id;
+            filters[0].can_mask = idMask | (uint)CanFlags.ExtendedFrameFormat | (uint)CanFlags.RemoteTransmissionRequest;
+
+            Interop.SetCanRawSocketOption<Interop.CanFilter>(_handle, Interop.CanSocketOption.CAN_RAW_FILTER, filters);
+        }
+
+        private static bool IsEff(uint address)
+        {
+            // has explicit flag or address does not fit in SFF addressing mode
+            return (address & (uint)CanFlags.ExtendedFrameFormat) != 0
+                || (address & Interop.CAN_EFF_MASK) != (address & Interop.CAN_SFF_MASK);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
+        }
+    }
+}

--- a/src/devices/SocketCan/Interop.cs
+++ b/src/devices/SocketCan/Interop.cs
@@ -39,10 +39,10 @@ namespace Iot.Device.SocketCan
         [DllImport("libc", EntryPoint = "close", CallingConvention = CallingConvention.Cdecl)]
         private static extern int CloseSocket(int fd);
 
-        [DllImport("libc", EntryPoint = "write", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        [DllImport("libc", EntryPoint = "write", CallingConvention = CallingConvention.Cdecl)]
         private static unsafe extern int SocketWrite(int fd, byte* buffer, int size);
 
-        [DllImport("libc", EntryPoint = "read", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        [DllImport("libc", EntryPoint = "read", CallingConvention = CallingConvention.Cdecl)]
         private static unsafe extern int SocketRead(int fd, byte* buffer, int size);
 
         [DllImport("libc", EntryPoint = "setsockopt", CallingConvention = CallingConvention.Cdecl)]

--- a/src/devices/SocketCan/Interop.cs
+++ b/src/devices/SocketCan/Interop.cs
@@ -133,7 +133,7 @@ namespace Iot.Device.SocketCan
             const uint SIOCGIFINDEX = 0x8933;
             const int MaxLen = ifreq.IFNAMSIZ - 1;
 
-            if (Encoding.ASCII.GetByteCount(name) >= MaxLen)
+            if (name.Length >= MaxLen)
             {
                 throw new ArgumentException($"`{name}` exceeds maximum allowed length of {MaxLen} size", nameof(name));
             }
@@ -154,7 +154,6 @@ namespace Iot.Device.SocketCan
             return ifr.ifr_ifindex;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
         internal unsafe struct ifreq
         {
             internal const int IFNAMSIZ = 16;
@@ -164,7 +163,6 @@ namespace Iot.Device.SocketCan
 
         }
 
-        [StructLayout(LayoutKind.Sequential)]
         internal struct CanSocketAddress
         {
             public short can_family;
@@ -173,7 +171,6 @@ namespace Iot.Device.SocketCan
             public uint tx_id;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
         internal struct CanFilter
         {
             public uint can_id;

--- a/src/devices/SocketCan/Interop.cs
+++ b/src/devices/SocketCan/Interop.cs
@@ -1,0 +1,235 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Iot.Device.SocketCan
+{
+    internal class Interop
+    {
+        private const int PF_CAN = 29;
+
+        // SFF = Standard Frame Format - 11 bit
+        public const uint CAN_SFF_MASK = 0x000007FF;
+
+        // EFF = Extended Frame Format - 29 bit
+        public const uint CAN_EFF_MASK = 0x1FFFFFFF;
+        public const uint CAN_ERR_MASK = 0x1FFFFFFF;
+
+        public const int SOL_CAN_BASE = 100;
+        public const int SOL_CAN_RAW = SOL_CAN_BASE + (int)CanProtocol.CAN_RAW;
+
+
+        [DllImport("libc", EntryPoint = "socket", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int CreateNativeSocket(int domain, int type, CanProtocol protocol);
+
+        [DllImport("libc", EntryPoint = "ioctl", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int Ioctl3(int fd, uint request, ref ifreq ifr);
+
+        [DllImport("libc", EntryPoint = "bind", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BindSocket(int fd, ref CanSocketAddress addr, uint addrlen);
+
+        [DllImport("libc", EntryPoint = "close", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int CloseSocket(int fd);
+
+        [DllImport("libc", EntryPoint = "write", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        private static unsafe extern int SocketWrite(int fd, byte* buffer, int size);
+
+        [DllImport("libc", EntryPoint = "read", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        private static unsafe extern int SocketRead(int fd, byte* buffer, int size);
+
+        [DllImport("libc", EntryPoint = "setsockopt", CallingConvention = CallingConvention.Cdecl)]
+        private static unsafe extern int SetSocketOpt(int fd, int level, int optName, byte* optVal, int optlen);
+
+        public static unsafe void Write(SafeHandle handle, ReadOnlySpan<byte> buffer)
+        {
+            fixed (byte* b = buffer)
+            {
+                int totalBytesWritten = 0;
+                while (totalBytesWritten < buffer.Length)
+                {
+                    int bytesWritten = Interop.SocketWrite((int)handle.DangerousGetHandle(), b, buffer.Length);
+                    if (bytesWritten < 0)
+                    {
+                        throw new IOException("`write` operation failed");
+                    }
+
+                    totalBytesWritten += bytesWritten;
+                }
+            }
+        }
+
+        public static unsafe int Read(SafeHandle handle, Span<byte> buffer)
+        {
+            fixed (byte* b = buffer)
+            {
+                int bytesRead = Interop.SocketRead((int)handle.DangerousGetHandle(), b, buffer.Length);
+                if (bytesRead < 0)
+                {
+                    throw new IOException("`read` operation failed");
+                }
+
+                return bytesRead;
+            }
+        }
+
+        public static void CloseSocket(IntPtr fd)
+        {
+            CloseSocket((int)fd);
+        }
+
+        public static IntPtr CreateCanRawSocket(string networkInterface)
+        {
+            const int SOCK_RAW = 3;
+            int socket = CreateNativeSocket(PF_CAN, SOCK_RAW, CanProtocol.CAN_RAW);
+
+            if (socket == -1)
+                throw new IOException("CAN socket could not be created");
+
+            BindToInterface(socket, networkInterface);
+
+            return new IntPtr(socket);
+        }
+
+        public static bool SetCanRawSocketOption<T>(SafeHandle handle, CanSocketOption optName, ReadOnlySpan<T> data)
+            where T : struct
+        {
+            return SetSocketOption(handle, SOL_CAN_RAW, optName, data);
+        }
+
+        private static unsafe bool SetSocketOption<T>(SafeHandle handle, int level, CanSocketOption optName, ReadOnlySpan<T> data)
+            where T : struct
+        {
+            int fd = (int)handle.DangerousGetHandle();
+            ReadOnlySpan<byte> buf = MemoryMarshal.AsBytes(data);
+            fixed (byte* pinned = buf)
+            {
+                return SetSocketOpt(fd, level, (int)optName, pinned, buf.Length) == 0;
+            }
+        }
+
+        private static unsafe void BindToInterface(int fd, string interfaceName)
+        {
+            int idx = GetInterfaceIndex(fd, interfaceName);
+            CanSocketAddress addr = new CanSocketAddress();
+            addr.can_family = PF_CAN;
+            addr.can_ifindex = idx;
+
+            if (-1 == BindSocket(fd, ref addr, (uint)Marshal.SizeOf<CanSocketAddress>()))
+            {
+                throw new IOException($"Cannot bind to socket to `{interfaceName}`");
+            }
+        }
+
+        private static unsafe int GetInterfaceIndex(int fd, string name)
+        {
+            const uint SIOCGIFINDEX = 0x8933;
+            const int MaxLen = ifreq.IFNAMSIZ - 1;
+
+            if (Encoding.ASCII.GetByteCount(name) >= MaxLen)
+            {
+                throw new ArgumentException($"`{name}` exceeds maximum allowed length of {MaxLen} size", nameof(name));
+            }
+
+            ifreq ifr = new ifreq();
+            fixed (char* inIntefaceName = name)
+            {
+                int written = Encoding.ASCII.GetBytes(inIntefaceName, name.Length, ifr.ifr_name, MaxLen);
+                ifr.ifr_name[written] = 0;
+            }
+
+            int ret = Ioctl3(fd, SIOCGIFINDEX, ref ifr);
+            if (ret == -1)
+            {
+                throw new IOException($"Could not get interface index for `{name}`");
+            }
+
+            return ifr.ifr_ifindex;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct ifreq
+        {
+            internal const int IFNAMSIZ = 16;
+            public fixed byte ifr_name[IFNAMSIZ];
+            public int ifr_ifindex;
+            private fixed byte _padding[IFNAMSIZ - sizeof(int)];
+
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct CanSocketAddress
+        {
+            public short can_family;
+            public int can_ifindex;
+            public uint rx_id;
+            public uint tx_id;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct CanFilter
+        {
+            public uint can_id;
+            public uint can_mask;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct CanFdFrame
+        {
+            private const int CANFD_MAX_DLEN = 64;
+            // can_id includes EFF, RTR and ERR flags
+            public uint can_id;
+            public byte len;
+            private CanFdFlags flags;
+            private byte _res0;
+            private byte _res1;
+            public fixed byte data[CANFD_MAX_DLEN];
+        }
+
+        internal enum CanProtocol : int
+        {
+            CAN_RAW = 1,
+            // Broadcast Manager
+            CAN_BCM = 2,
+            // VAG Transport Protocol v1.6
+            CAN_TP16 = 3,
+            // VAG Transport Protocol v2.0
+            CAN_TP20 = 4,
+            // Bosch MCNet
+            CAN_MCNET = 5,
+            // ISO 15765-2 Transport Protocol
+            CAN_ISOTP = 6,
+            CAN_NPROTO = 7,
+        }
+
+        internal enum CanSocketOption : int
+        {
+            // set 0 .. n can_filter(s)
+            CAN_RAW_FILTER = 1,       
+            // set filter for error frames
+            CAN_RAW_ERR_FILTER,
+            // local loopback (default:on)
+            CAN_RAW_LOOPBACK,
+            // receive my own msgs (default:off)
+            CAN_RAW_RECV_OWN_MSGS,
+            // allow CAN FD frames (default:off)
+            CAN_RAW_FD_FRAMES,
+            // all filters must match to trigger
+            CAN_RAW_JOIN_FILTERS,
+        }
+
+        [Flags]
+        internal enum CanFdFlags : byte
+        {
+            CANFD_BRS = 0x01,
+            CANFD_ESI = 0x02,
+        }
+    }
+}

--- a/src/devices/SocketCan/README.md
+++ b/src/devices/SocketCan/README.md
@@ -1,0 +1,56 @@
+﻿# SocketCan
+
+Controller Area Network Protocol Family bindings (SocketCAN).
+
+[samples/README.md](See sample for usage.)
+
+## Setup for Raspberry PI and MCP2515
+
+- Connect SPI device to regular SPI pins (SI/MOSI - `BCM 10`; SO/MISO - `BCM 9`; CLK/SCK - `BCM 11`; CS - `CE0`)
+- Interrupt pin should be connected to any GPIO pin i.e. `BCM 25` (note: interrupt pin can be adjusted below)
+- Add following in `/boot/config.txt`
+
+```
+dtparam=spi=on
+dtoverlay=mcp2515-can0,oscillator=8000000,interrupt=25
+dtoverlay=spi-bcm2835-overlay
+```
+
+For test run `ifconfig -a` and check if `can0` (or similar) device is on the list.
+
+Now we need to set network bitrate and "start" the network.
+Other popular bit rates: 10000, 20000, 50000, 100000, 125000, 250000, 500000, 800000, 1000000
+
+```sh
+sudo ip link set can0 up type can bitrate 125000
+sudo ifconfig can0 up
+```
+
+## Diagnosing the network (tested on Raspberry Pi)
+
+These steps are not required but might be useful for diagnosing potential issues.
+
+- Install can-utils package (i.e. `sudo apt-get install can-utils`)
+
+```sh
+sudo apt-get -y install can-utils
+```
+
+- On first device listen to CAN frames (can be also sent on the same device but ensure seperate terminal)
+
+```sh
+candump can0
+```
+
+- On second device send a packet
+
+```sh
+cansend can0 01a#11223344AABBCCDD
+```
+
+- On the first device you should see the packet being send by the second device
+
+
+## References
+
+- https://www.kernel.org/doc/Documentation/networking/can.txt

--- a/src/devices/SocketCan/SafeCanRawSocketHandle.cs
+++ b/src/devices/SocketCan/SafeCanRawSocketHandle.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+
+namespace Iot.Device.SocketCan
+{
+    internal class SafeCanRawSocketHandle : SafeHandle
+    {
+        public SafeCanRawSocketHandle(string networkInterface) : base(Interop.CreateCanRawSocket(networkInterface), true)
+        {
+        }
+
+        public override bool IsInvalid => (int)handle == -1;
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.CloseSocket(handle);
+            return true;
+        }
+    }
+}

--- a/src/devices/SocketCan/SocketCan.csproj
+++ b/src/devices/SocketCan/SocketCan.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <!--Disabling default items so samples source won't get build by the main library-->
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <LangVersion>Latest</LangVersion>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="*.cs" />
+    <None Include="README.md" />
+    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+  </ItemGroup>
+
+</Project>

--- a/src/devices/SocketCan/SocketCan.csproj
+++ b/src/devices/SocketCan/SocketCan.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <PackageReference Include="System.Device.Gpio" Version="0.1.0-prerelease*" />
+    <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/SocketCan/samples/README.md
+++ b/src/devices/SocketCan/samples/README.md
@@ -1,0 +1,73 @@
+﻿# SocketCan
+
+APIs are under `Iot.Device.SocketCan` namespace.
+
+## Reading a frame
+
+```csharp
+using (CanRaw can = new CanRaw())
+{
+    CanFrame frame = new CanFrame();
+    while (true)
+    {
+        can.ReadFrame(ref frame);
+        if (frame.IsValid)
+        {
+            string type = frame.ExtendedFrameFormat ? "EFF" : "SFF";
+            string dataAsHex = string.Join("", frame.Data.ToArray().Select((x) => x.ToString("X2")));
+            Console.WriteLine($"Id: {frame.Id} [{type}]: {dataAsHex}");
+        }
+        else
+        {
+            Console.WriteLine($"Invalid frame received!");
+        }
+    }
+}
+```
+
+## Writing a frame
+
+
+```csharp
+using (CanRaw can = new CanRaw())
+{
+    byte[] buffer = new byte[8] { 1, 2, 3, 40, 50, 60, 70, 80 };
+    CanFrame frame = new CanFrame();
+    frame.StandardId = Id;
+
+    while (true)
+    {
+        frame.Data = buffer;
+        can.WriteFrame(ref frame);
+        string dataAsHex = string.Join("", frame.Data.ToArray().Select((x) => x.ToString("X2")));
+        Console.WriteLine($"Sending: {dataAsHex}");
+        Thread.Sleep(1000);
+    }
+}
+```
+
+## Filtering
+
+```csharp
+using (CanRaw can = new CanRaw())
+{
+    // first argument is true if id (0x1A) is extended
+    can.Filter(false, 0x1A);
+    CanFrame frame = new CanFrame();
+
+    while (true)
+    {
+        can.ReadFrame(ref frame);
+        if (frame.IsValid)
+        {
+            string type = frame.ExtendedFrameFormat ? "EFF" : "SFF";
+            string dataAsHex = string.Join("", frame.Data.ToArray().Select((x) => x.ToString("X2")));
+            Console.WriteLine($"Id: {frame.Id} [{type}]: {dataAsHex}");
+        }
+        else
+        {
+            Console.WriteLine($"Invalid frame received!");
+        }
+    }
+}
+```

--- a/src/devices/SocketCan/samples/SocketCan.Sample.cs
+++ b/src/devices/SocketCan/samples/SocketCan.Sample.cs
@@ -1,0 +1,129 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Iot.Device.SocketCan.Samples
+{
+    class Program
+    {
+        const uint Id = 0x1A; // arbitrary id
+
+        static Dictionary<string, Action> s_samples = new Dictionary<string, Action>
+        {
+            { "send", SendExample },
+            { "receive", ReceiveAllExample },
+            { "receive-on-specific-address", ReceiveOnAddressExample },
+        };
+
+        static void Main(string[] args)
+        {
+            if (args.Length == 0 || !s_samples.ContainsKey(args[0]))
+            {
+                Console.WriteLine("Usage: SocketCan.Sample <sample-name>");
+                Console.WriteLine("Available samples:");
+
+                foreach (var kv in s_samples)
+                {
+                    Console.WriteLine($"- {kv.Key}");
+                }
+
+                return;
+            }
+
+            s_samples[args[0]]();
+        }
+
+        private static void SendExample()
+        {
+            Console.WriteLine($"Sending to id = {Id}");
+
+            using (CanRaw can = new CanRaw())
+            {
+                byte[][] buffers = new byte[][]
+                {
+                    new byte[8] { 1, 2, 3, 40, 50, 60, 70, 80 },
+                    new byte[7] { 1, 2, 3, 40, 50, 60, 70 },
+                    new byte[0] { },
+                    new byte[1] { 254 },
+                };
+
+                CanFrame frame = new CanFrame();
+                frame.StandardId = Id;
+
+                if (!frame.IsValid)
+                {
+                    // This is more form of the test rather than actual part of the sample
+                    throw new Exception("Frame is invalid");
+                }
+
+                while (true)
+                {
+                    foreach (byte[] buffer in buffers)
+                    {
+                        frame.Data = buffer;
+                        can.WriteFrame(ref frame);
+                        string dataAsHex = string.Join("", frame.Data.ToArray().Select((x) => x.ToString("X2")));
+                        Console.WriteLine($"Sending: {dataAsHex}");
+                        Thread.Sleep(1000);
+                    }
+                }
+            }
+        }
+
+        private static void ReceiveAllExample()
+        {
+            Console.WriteLine("Listening for any id");
+
+            using (CanRaw can = new CanRaw())
+            {
+                CanFrame frame = new CanFrame();
+                while (true)
+                {
+                    can.ReadFrame(ref frame);
+
+                    if (frame.IsValid)
+                    {
+                        string type = frame.ExtendedFrameFormat ? "EFF" : "SFF";
+                        string dataAsHex = string.Join("", frame.Data.ToArray().Select((x) => x.ToString("X2")));
+                        Console.WriteLine($"Id: {frame.Id} [{type}]: {dataAsHex}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Invalid frame received!");
+                    }
+                }
+            }
+        }
+
+        private static void ReceiveOnAddressExample()
+        {
+            Console.WriteLine($"Listening for id = {Id}");
+
+            using (CanRaw can = new CanRaw())
+            {
+                can.Filter(false, Id);
+                CanFrame frame = new CanFrame();
+                while (true)
+                {
+                    can.ReadFrame(ref frame);
+
+                    if (frame.IsValid)
+                    {
+                        string type = frame.ExtendedFrameFormat ? "EFF" : "SFF";
+                        string dataAsHex = string.Join("", frame.Data.ToArray().Select((x) => x.ToString("X2")));
+                        Console.WriteLine($"Id: {frame.Id} [{type}]: {dataAsHex}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Invalid frame received!");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/devices/SocketCan/samples/SocketCan.Samples.csproj
+++ b/src/devices/SocketCan/samples/SocketCan.Samples.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+  	<ProjectReference Include="../SocketCan.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Note: This is implemented in Iot.Device.Bindings since this requires much more testing on different kinds of devices which I currently don't have.

Multiple scenarios of CanBus require using CanRaw protocol which covers:

- listening for multiple devices
- writing to a single id
- hardware/driver filtering

cc: @richlander @shaggygi @joperezr

There exist higher level protocols based on this which are not covered in this PR (some of them might be already implemented directly in the kernel for free but that is also not covered here - I haven't got any devices I could test it on).
