### PR TITLE
GPIO-access without root-permissions

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -67,6 +67,7 @@ namespace System.Device.Gpio.Drivers
             InitializeSysFS();
 
             _sysFSDriver.OpenPin(pinNumber);
+            Thread.Sleep(100);
             _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
 
             _sysFSDriver.AddCallbackForPinValueChangedEvent(pinNumber, eventTypes, callback);
@@ -147,6 +148,7 @@ namespace System.Device.Gpio.Drivers
             InitializeSysFS();
 
             _sysFSDriver.OpenPin(pinNumber);
+            Thread.Sleep(100);
             _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
 
             _sysFSDriver.RemoveCallbackForPinValueChangedEvent(pinNumber, callback);
@@ -270,6 +272,7 @@ namespace System.Device.Gpio.Drivers
             InitializeSysFS();
 
             _sysFSDriver.OpenPin(pinNumber);
+            Thread.Sleep(100);
             _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
 
             return _sysFSDriver.WaitForEvent(pinNumber, eventTypes, cancellationToken);
@@ -288,6 +291,7 @@ namespace System.Device.Gpio.Drivers
             InitializeSysFS();
 
             _sysFSDriver.OpenPin(pinNumber);
+            Thread.Sleep(100);
             _sysFSDriver.SetPinMode(pinNumber, GetModeForUnixDriver(_sysFSModes[pinNumber]));
 
             return _sysFSDriver.WaitForEventAsync(pinNumber, eventTypes, cancellationToken);


### PR DESCRIPTION
Gets this when running DeviceApiTester.
pi@raspberrypi:~/tests $ ./DeviceApiTester gpio-button-event --button-pin 12 --led-pin 17
Driver=Default, Scheme=Logical, ButtonPin=12, LedPin=17, PressedValue=Rising, OnValue=1
Listening for button presses on GPIO Logical pin 12 . . .
Error: Setting a mode to a pin requires root permissions.

Added delay between _sysFSDriver.OpenPin and_sysFSDriver.SetPinMode so udev have time to set the permissions on all the virtual files.
According to this article [https://forum.up-community.org/discussion/2141/solved-tutorial-gpio-i2c-spi-access-without-root-permissions](url) 