### PR TITLE
Fix compensate_temperature formula

### DIFF
--- a/src/devices/Bmx280/BmxBase.cs
+++ b/src/devices/Bmx280/BmxBase.cs
@@ -282,7 +282,8 @@ namespace Iot.Device.Bmx280
             //Formula from the datasheet
             //The temperature is calculated using the compensation formula in the BMP280 datasheet
             double var1 = ((adcTemperature / 16384.0) - (_calibrationData.DigT1 / 1024.0)) * _calibrationData.DigT2;
-            double var2 = Math.Pow(((adcTemperature / 131072.0) - (_calibrationData.DigT1 / 8192.0)), 2) * _calibrationData.DigT3;
+            double var2 = ((adcTemperature / 131072.0) - (_calibrationData.DigT1 / 8192.0));
+            var2 *= var2 * _calibrationData.DigT3;
 
             TemperatureFine = (int)(var1 + var2);
 

--- a/src/devices/Bmx280/BmxBase.cs
+++ b/src/devices/Bmx280/BmxBase.cs
@@ -282,7 +282,7 @@ namespace Iot.Device.Bmx280
             //Formula from the datasheet
             //The temperature is calculated using the compensation formula in the BMP280 datasheet
             double var1 = ((adcTemperature / 16384.0) - (_calibrationData.DigT1 / 1024.0)) * _calibrationData.DigT2;
-            double var2 = ((adcTemperature / 131072.0) - (_calibrationData.DigT1 / 8192.0)) * _calibrationData.DigT3;
+            double var2 = Math.Pow(((adcTemperature / 131072.0) - (_calibrationData.DigT1 / 8192.0)), 2) * _calibrationData.DigT3;
 
             TemperatureFine = (int)(var1 + var2);
 


### PR DESCRIPTION
I came across what I think is a little mistake in the compensate_temperature method of the BmxBase class. Both datasheets of [Bmp280](https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BMP280-DS001.pdf) (page 22) and [Bme280](https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BME280-DS002.pdf) (page 25) and driver implementations from Bosch for [Bmp280](https://github.com/BoschSensortec/BMP280_driver/blob/master/bmp280.c) and [Bme280](https://github.com/BoschSensortec/BME280_driver/blob/master/bme280.c) have a slightly different implementation.

This change should fix it.