### PR TITLE
Fix DS3231 set RTC date/time bug

### DIFF
--- a/src/devices/Ds3231/Ds3231.cs
+++ b/src/devices/Ds3231/Ds3231.cs
@@ -23,7 +23,7 @@ namespace Iot.Device.Ds3231
         /// <summary>
         /// DS3231 DateTime
         /// </summary>
-        public DateTime DateTime { get => ReadTime(); set => SetTime(DateTime); }
+        public DateTime DateTime { get => ReadTime(); set => SetTime(value); }
 
         /// <summary>
         /// DS3231 Temperature


### PR DESCRIPTION
Device binding is not using user supplied DateTime, instead it reads the RTC time and sets that again.