### PR TITLE
Fix Windows SPI driver not returning values

### DIFF
--- a/src/System.Device.Gpio/System/Device/Spi/Drivers/Windows10SpiDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Drivers/Windows10SpiDevice.Windows.cs
@@ -115,6 +115,7 @@ namespace System.Device.Spi.Drivers
             }
             byte[] byteArray = new byte[readBuffer.Length];
             _winDevice.TransferFullDuplex(writeBuffer.ToArray(), byteArray);
+            byteArray.CopyTo(readBuffer);
         }
 
         public override void Dispose(bool disposing)


### PR DESCRIPTION
Fixes that the `readBuffer` that is accesible by the user does not get updated with the read values from the SPI device.
See the [I²C implementation](https://github.com/dotnet/iot/blob/68d54688e86e400c7b5d4d493683898aaaa5e1f0/src/System.Device.Gpio/System/Device/I2c/Drivers/Windows10I2cDevice.Windows.cs#L115) for reference.