### PR TITLE
pcf8574t/at

### DIFF
--- a/src/devices/CharacterLcd/README.md
+++ b/src/devices/CharacterLcd/README.md
@@ -34,14 +34,15 @@ using (var lcd = new LcdRgb1602(i2cLcdDevice, i2cRgbDevice))
 }
 ```
 
-PCF8574T Sample
-The I2C backpack based on the PCF8574T IC uses specific pin mapping, to consume this device binding on this backpack use like so
+PCF8574T/PCF8574AT Sample
+The I2C backpack based on the PCF8574T/AT IC uses specific pin mapping, to consume this device binding on this backpack use like so
 ```c#
 var i2cDevice = new UnixI2cDevice(new I2cConnectionSettings(busId: 1, deviceAddress: 0x27)); 
-var controller = new Mcp23008(i2cDevice); 
+var controller = new Pcf8574(i2cDevice);
 var lcd = new Lcd1602(registerSelectPin: 0, enablePin: 2, dataPins: new int[] { 4, 5, 6, 7}, backlightPin: 3, readWritePin: 1, controller: controller);
 ```
 there is a full working example in the samples directory called Pcf8574tSample.cs
+For PCF8574T i2c addresses can be between 0x27 and 0x20 depending on bridged solder jumpers and for PCF8574AT i2c addresses can be between 0x3f and 0x38 depending on bridged solder jumpers
 
 ## References 
 - Very complete tutorial on how to connect and work with one of these displays: https://learn.adafruit.com/drive-a-16x2-lcd-directly-with-a-raspberry-pi/overview

--- a/src/devices/CharacterLcd/samples/CharacterLcd.Samples.csproj
+++ b/src/devices/CharacterLcd/samples/CharacterLcd.Samples.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../Mcp23xxx/Mcp23xxx.csproj" />
+    <ProjectReference Include="../../Pcx857x/Pcx857x.csproj" />
     <PackageReference Include="System.Device.Gpio" Version="$(SystemDeviceGpioPackageVersion)" />
     <ProjectReference Include="..\CharacterLcd.csproj" />
   </ItemGroup>

--- a/src/devices/CharacterLcd/samples/Pcf8574tSample.cs
+++ b/src/devices/CharacterLcd/samples/Pcf8574tSample.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Text;
 using System.Timers;
-using Iot.Device.Mcp23xxx;
+using Iot.Device.Pcx857x;
 
 namespace Iot.Device.CharacterLcd.Samples
 {
@@ -24,9 +24,10 @@ namespace Iot.Device.CharacterLcd.Samples
         public static void SampleEntryPoint()
         {
             Console.WriteLine("Starting...");
-
+            //for PCF8574T i2c addresses can be between 0x27 and 0x20 depending on bridged solder jumpers
+            //for PCF8574AT i2c addresses can be between 0x3f and 0x38 depending on bridged solder jumpers
             var i2cDevice = new UnixI2cDevice(new I2cConnectionSettings(busId: 1, deviceAddress: 0x27));
-            var controller = new Mcp23008(i2cDevice);
+            var controller = new Pcf8574(i2cDevice);
             var lcd = new Lcd1602(registerSelectPin: 0, enablePin: 2, dataPins: new int[] { 4, 5, 6, 7 }, backlightPin: 3, readWritePin: 1, controller: controller);
 
             using (lcd)


### PR DESCRIPTION
Hi All

my original PR worked fine on a PCF8754T but not on the "AT" chip at all, as it has a very different i2c address scheme.
Went back to the drawing board and this works on both as well as more functions in the extended test sample are working (not sure if autoshit if working but; didnt work for the original PR)
this is a pretty minor change as can be seen from the 2 changed files, I added some comments in the code to reflect the very different i2c schemes.

