### PR TITLE
Update namespace from recent SPI/I2C changes

### DIFF
--- a/src/devices/Ads1115/Ads1115.cs
+++ b/src/devices/Ads1115/Ads1115.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Ads1115

--- a/src/devices/Ads1115/samples/Program.cs
+++ b/src/devices/Ads1115/samples/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 using Iot.Device.Ads1115;
 

--- a/src/devices/Adxl345/samples/Program.cs
+++ b/src/devices/Adxl345/samples/Program.cs
@@ -6,7 +6,6 @@ using System;
 using System.Numerics;
 using System.Threading;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 using Iot.Device.Adxl345;
 
 namespace Adxl345.Samples

--- a/src/devices/Ags01db/Ags01db.cs
+++ b/src/devices/Ags01db/Ags01db.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Ags01db

--- a/src/devices/Ags01db/samples/Program.cs
+++ b/src/devices/Ags01db/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Ags01db.Samples

--- a/src/devices/Bh1750fvi/Bh1750fvi.cs
+++ b/src/devices/Bh1750fvi/Bh1750fvi.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.Bh1750fvi
 {

--- a/src/devices/Bh1750fvi/samples/Program.cs
+++ b/src/devices/Bh1750fvi/samples/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Bh1750fvi.Samples

--- a/src/devices/Bmp180/Bmp180.cs
+++ b/src/devices/Bmp180/Bmp180.cs
@@ -7,7 +7,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Threading;
 using Iot.Units;
 

--- a/src/devices/Bmp180/samples/Bmp180.Sample.cs
+++ b/src/devices/Bmp180/samples/Bmp180.Sample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 using Iot.Device.Bmp180;
 using Iot.Units;

--- a/src/devices/Bmx280/Bme280.cs
+++ b/src/devices/Bmx280/Bme280.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Threading.Tasks;
 
 namespace Iot.Device.Bmx280

--- a/src/devices/Bmx280/Bmp280.cs
+++ b/src/devices/Bmx280/Bmp280.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Bmx280
 {

--- a/src/devices/Bmx280/BmxBase.cs
+++ b/src/devices/Bmx280/BmxBase.cs
@@ -7,7 +7,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Threading.Tasks;
 using Iot.Units;
 

--- a/src/devices/Bmx280/samples/Bme280.sample.cs
+++ b/src/devices/Bmx280/samples/Bme280.sample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 using System.Threading.Tasks;
 using Iot.Device.Bmx280;

--- a/src/devices/Bmx280/samples/Bmp280.sample.cs
+++ b/src/devices/Bmx280/samples/Bmp280.sample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 using System.Threading.Tasks;
 using Iot.Device.Bmx280;

--- a/src/devices/Bno055/Bno055Sensor.cs
+++ b/src/devices/Bno055/Bno055Sensor.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Numerics;
 using System.Threading;
 using Iot.Units;

--- a/src/devices/Bno055/samples/Bno055.sample.cs
+++ b/src/devices/Bno055/samples/Bno055.sample.cs
@@ -5,7 +5,6 @@
 using Iot.Device.Bno055;
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Numerics;
 using System.Threading;
 

--- a/src/devices/BrickPi3/BrickPi3.cs
+++ b/src/devices/BrickPi3/BrickPi3.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 using System.Linq;
 using System.IO;
 

--- a/src/devices/CharacterLcd/Lcd1602.cs
+++ b/src/devices/CharacterLcd/Lcd1602.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Drawing;
 
 namespace Iot.Device.CharacterLcd

--- a/src/devices/CharacterLcd/LcdInterface.I2c.cs
+++ b/src/devices/CharacterLcd/LcdInterface.I2c.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.CharacterLcd
 {

--- a/src/devices/CharacterLcd/LcdInterface.cs
+++ b/src/devices/CharacterLcd/LcdInterface.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Device;
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.CharacterLcd
 {

--- a/src/devices/CharacterLcd/LcdRgb1602.cs
+++ b/src/devices/CharacterLcd/LcdRgb1602.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Drawing;
 
 namespace Iot.Device.CharacterLcd

--- a/src/devices/CharacterLcd/samples/CharacterLcd.Sample.cs
+++ b/src/devices/CharacterLcd/samples/CharacterLcd.Sample.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using Iot.Device.Mcp23xxx;
 
 namespace Iot.Device.CharacterLcd.Samples

--- a/src/devices/CharacterLcd/samples/Hd44780.ExtendedSample.cs
+++ b/src/devices/CharacterLcd/samples/Hd44780.ExtendedSample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Diagnostics;
 using System.Drawing;
 using System.Text;

--- a/src/devices/CharacterLcd/samples/Pcf8574tSample.cs
+++ b/src/devices/CharacterLcd/samples/Pcf8574tSample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Diagnostics;
 using System.Drawing;
 using System.Text;

--- a/src/devices/Dhtxx/DhtSensor.cs
+++ b/src/devices/Dhtxx/DhtSensor.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Device;
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Diagnostics;
 using System.Threading;
 using Dhtxx.Devices;

--- a/src/devices/Ds1307/Ds1307.cs
+++ b/src/devices/Ds1307/Ds1307.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Ds1307
 {

--- a/src/devices/Ds1307/samples/Program.cs
+++ b/src/devices/Ds1307/samples/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Ds1307.Samples

--- a/src/devices/Ds3231/Ds3231.cs
+++ b/src/devices/Ds3231/Ds3231.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using Iot.Units;
 
 namespace Iot.Device.Ds3231

--- a/src/devices/Ds3231/samples/Program.cs
+++ b/src/devices/Ds3231/samples/Program.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.Ds3231.Samples
 {

--- a/src/devices/GoPiGo3/GoPiGo3.cs
+++ b/src/devices/GoPiGo3/GoPiGo3.cs
@@ -6,7 +6,6 @@ using Iot.Device.GoPiGo3.Models;
 using System;
 using System.Buffers.Binary;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;

--- a/src/devices/GoPiGo3/samples/Program.cs
+++ b/src/devices/GoPiGo3/samples/Program.cs
@@ -8,7 +8,6 @@ using System;
 using System.Threading;
 using System.Drawing;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 
 namespace GoPiGo3.sample
 {

--- a/src/devices/GrovePi/GrovePi.cs
+++ b/src/devices/GrovePi/GrovePi.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.IO;
 using System.Threading;
 using Iot.Device.GrovePiDevice.Models;

--- a/src/devices/GrovePi/samples/Program.cs
+++ b/src/devices/GrovePi/samples/Program.cs
@@ -8,7 +8,6 @@ using Iot.Device.GrovePiDevice.Models;
 using Iot.Device.GrovePiDevice;
 using Iot.Device.GrovePiDevice.Sensors;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Device.Gpio;
 
 namespace GrovePisample

--- a/src/devices/Hcsr04/samples/Hcsr04.Sample.cs
+++ b/src/devices/Hcsr04/samples/Hcsr04.Sample.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Device.Gpio;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 using System.Threading;
 using Iot.Device.Hcsr04;
 

--- a/src/devices/Hmc5883l/Hmc5883l.cs
+++ b/src/devices/Hmc5883l/Hmc5883l.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Numerics;
 
 namespace Iot.Device.Hmc5883l

--- a/src/devices/Hmc5883l/samples/Program.cs
+++ b/src/devices/Hmc5883l/samples/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Hmc5883l.Samples

--- a/src/devices/Hts221/Hts221.cs
+++ b/src/devices/Hts221/Hts221.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using Iot.Units;
 
 namespace Iot.Device.Hts221

--- a/src/devices/Hts221/samples/Hts221.Sample.cs
+++ b/src/devices/Hts221/samples/Hts221.Sample.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.Hts221.Samples
 {

--- a/src/devices/Lm75/Lm75.cs
+++ b/src/devices/Lm75/Lm75.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using Iot.Units;
 
 namespace Iot.Device.Lm75

--- a/src/devices/Lm75/samples/Program.cs
+++ b/src/devices/Lm75/samples/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Lm75.Samples

--- a/src/devices/Lps25h/Lps25h.cs
+++ b/src/devices/Lps25h/Lps25h.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Diagnostics;
 using Iot.Units;
 

--- a/src/devices/Lps25h/samples/Lps25h.Sample.cs
+++ b/src/devices/Lps25h/samples/Lps25h.Sample.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.Lps25h.Samples
 {

--- a/src/devices/Lsm9Ds1/Lsm9Ds1.AccelerometerAndGyroscope.cs
+++ b/src/devices/Lsm9Ds1/Lsm9Ds1.AccelerometerAndGyroscope.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Numerics;
 
 namespace Iot.Device.Lsm9Ds1

--- a/src/devices/Lsm9Ds1/Lsm9Ds1.Magnetometer.cs
+++ b/src/devices/Lsm9Ds1/Lsm9Ds1.Magnetometer.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Numerics;
 
 namespace Iot.Device.Lsm9Ds1

--- a/src/devices/Lsm9Ds1/samples/Lsm9Ds1.AccelerometerAndGyroscope.Sample.cs
+++ b/src/devices/Lsm9Ds1/samples/Lsm9Ds1.AccelerometerAndGyroscope.Sample.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.Lsm9Ds1.Samples
 {

--- a/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Magnetometer.Sample.cs
+++ b/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Magnetometer.Sample.cs
@@ -6,7 +6,6 @@ using System;
 using System.Numerics;
 using System.Threading;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Diagnostics;
 using System.Collections.Generic;
 

--- a/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Sample.cs
+++ b/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Sample.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.Lsm9Ds1.Samples
 {

--- a/src/devices/Max44009/Max44009.cs
+++ b/src/devices/Max44009/Max44009.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Max44009
 {

--- a/src/devices/Max44009/samples/Program.cs
+++ b/src/devices/Max44009/samples/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Max44009.Samples

--- a/src/devices/Max7219/samples/Max7219.sample.cs
+++ b/src/devices/Max7219/samples/Max7219.sample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 using System.Threading;
 
 namespace Iot.Device.Samples

--- a/src/devices/Mcp23xxx/I2cAdapter.cs
+++ b/src/devices/Mcp23xxx/I2cAdapter.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Mcp23xxx
 {

--- a/src/devices/Mcp23xxx/Mcp23008.cs
+++ b/src/devices/Mcp23xxx/Mcp23008.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Mcp23xxx
 {

--- a/src/devices/Mcp23xxx/Mcp23009.cs
+++ b/src/devices/Mcp23xxx/Mcp23009.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Mcp23xxx
 {

--- a/src/devices/Mcp23xxx/Mcp23017.cs
+++ b/src/devices/Mcp23xxx/Mcp23017.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Mcp23xxx
 {

--- a/src/devices/Mcp23xxx/Mcp23018.cs
+++ b/src/devices/Mcp23xxx/Mcp23018.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Mcp23xxx
 {

--- a/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
+++ b/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Device.Gpio;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 using System.Threading;
 
 namespace Iot.Device.Mcp23xxx.Samples

--- a/src/devices/Mcp23xxx/tests/Mcp23xxxTest.cs
+++ b/src/devices/Mcp23xxx/tests/Mcp23xxxTest.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Device.Gpio;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Device.Spi;
 using Xunit;
 

--- a/src/devices/Mcp25xxx/samples/Mcp25xxx.Sample.cs
+++ b/src/devices/Mcp25xxx/samples/Mcp25xxx.Sample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.AcceptanceFilter;
 using Iot.Device.Mcp25xxx.Register.BitTimeConfiguration;

--- a/src/devices/Mcp3008/samples/Mcp3008.Sample.cs
+++ b/src/devices/Mcp3008/samples/Mcp3008.Sample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 using System.Threading;
 
 namespace Iot.Device.Samples

--- a/src/devices/Mpr121/Mpr121.cs
+++ b/src/devices/Mpr121/Mpr121.cs
@@ -6,7 +6,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Threading;
 
 namespace Iot.Device.Mpr121

--- a/src/devices/Mpr121/samples/Mpr121.Sample.cs
+++ b/src/devices/Mpr121/samples/Mpr121.Sample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.Mpr121.Samples
 {

--- a/src/devices/Nrf24l01/samples/Program.cs
+++ b/src/devices/Nrf24l01/samples/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 using System.Text;
 using System.Threading;
 

--- a/src/devices/Pca95x4/Pca95x4.cs
+++ b/src/devices/Pca95x4/Pca95x4.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Pca95x4
 {

--- a/src/devices/Pca95x4/samples/Pca95x4.Sample.cs
+++ b/src/devices/Pca95x4/samples/Pca95x4.Sample.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Device.Gpio;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Pca95x4.Samples

--- a/src/devices/Pca9685/Pca9685.cs
+++ b/src/devices/Pca9685/Pca9685.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Threading;
 using static Iot.Device.Pca9685.Mode1;
 using static Iot.Device.Pca9685.Mode2;

--- a/src/devices/Pca9685/samples/Pca9685.Sample.cs
+++ b/src/devices/Pca9685/samples/Pca9685.Sample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.Pca9685.Samples
 {

--- a/src/devices/Pcx857x/Pca8574.cs
+++ b/src/devices/Pcx857x/Pca8574.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Pcx857x
 {

--- a/src/devices/Pcx857x/Pca8575.cs
+++ b/src/devices/Pcx857x/Pca8575.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Pcx857x
 {

--- a/src/devices/Pcx857x/Pcf8574.cs
+++ b/src/devices/Pcx857x/Pcf8574.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Pcx857x
 {

--- a/src/devices/Pcx857x/Pcf8575.cs
+++ b/src/devices/Pcx857x/Pcf8575.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Pcx857x
 {

--- a/src/devices/Pcx857x/Pcx8574.cs
+++ b/src/devices/Pcx857x/Pcx8574.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Pcx857x
 {

--- a/src/devices/Pcx857x/Pcx8575.cs
+++ b/src/devices/Pcx857x/Pcx8575.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 
 namespace Iot.Device.Pcx857x
 {

--- a/src/devices/Pcx857x/Pcx857x.cs
+++ b/src/devices/Pcx857x/Pcx857x.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Device.Gpio;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Runtime.CompilerServices;
 
 namespace Iot.Device.Pcx857x

--- a/src/devices/Pcx857x/tests/Pcx857xTest.cs
+++ b/src/devices/Pcx857x/tests/Pcx857xTest.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Device.Gpio;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using Xunit;
 
 namespace Iot.Device.Pcx857x.Tests

--- a/src/devices/SenseHat/SenseHatAccelerometerAndGyroscope.cs
+++ b/src/devices/SenseHat/SenseHatAccelerometerAndGyroscope.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using Iot.Device.Lsm9Ds1;
 
 namespace Iot.Device.SenseHat

--- a/src/devices/SenseHat/SenseHatJoystick.cs
+++ b/src/devices/SenseHat/SenseHatJoystick.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.SenseHat
 {

--- a/src/devices/SenseHat/SenseHatLedMatrixI2c.cs
+++ b/src/devices/SenseHat/SenseHatLedMatrixI2c.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Drawing;
 using System.Runtime.CompilerServices;
 

--- a/src/devices/SenseHat/SenseHatMagnetometer.cs
+++ b/src/devices/SenseHat/SenseHatMagnetometer.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using Iot.Device.Lsm9Ds1;
 
 namespace Iot.Device.SenseHat

--- a/src/devices/SenseHat/SenseHatPressureAndTemperature.cs
+++ b/src/devices/SenseHat/SenseHatPressureAndTemperature.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.SenseHat
 {

--- a/src/devices/SenseHat/SenseHatTemperatureAndHumidity.cs
+++ b/src/devices/SenseHat/SenseHatTemperatureAndHumidity.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 
 namespace Iot.Device.SenseHat
 {

--- a/src/devices/SenseHat/samples/Magnetometer.Sample.cs
+++ b/src/devices/SenseHat/samples/Magnetometer.Sample.cs
@@ -6,7 +6,6 @@ using System;
 using System.Numerics;
 using System.Threading;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Drawing;

--- a/src/devices/Sht3x/Sht3x.cs
+++ b/src/devices/Sht3x/Sht3x.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Threading;
 using Iot.Units;
 

--- a/src/devices/Sht3x/samples/Program.cs
+++ b/src/devices/Sht3x/samples/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Sht3x.Samples

--- a/src/devices/Si7021/Si7021.cs
+++ b/src/devices/Si7021/Si7021.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Threading;
 using Iot.Units;
 

--- a/src/devices/Si7021/samples/Program.cs
+++ b/src/devices/Si7021/samples/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 
 namespace Iot.Device.Si7021.Samples

--- a/src/devices/Ssd13xx/Ssd1306.cs
+++ b/src/devices/Ssd13xx/Ssd1306.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using Iot.Device.Ssd13xx.Commands;
 
 namespace Iot.Device.Ssd13xx

--- a/src/devices/Ssd13xx/Ssd1327.cs
+++ b/src/devices/Ssd13xx/Ssd1327.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using Iot.Device.Ssd13xx.Commands;
 using Ssd1327Cmnds = Iot.Device.Ssd13xx.Commands.Ssd1327Commands;
 

--- a/src/devices/Ssd13xx/Ssd13xx.cs
+++ b/src/devices/Ssd13xx/Ssd13xx.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using Iot.Device.Ssd13xx.Commands;
 
 namespace Iot.Device.Ssd13xx

--- a/src/devices/Ssd13xx/samples/Ssd13xx.Sample.cs
+++ b/src/devices/Ssd13xx/samples/Ssd13xx.Sample.cs
@@ -8,7 +8,6 @@ using Ssd1327Cmnds = Iot.Device.Ssd13xx.Commands.Ssd1327Commands;
 using System;
 using System.Collections.Generic;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;

--- a/src/devices/Tcs3472x/Tcs3472x.cs
+++ b/src/devices/Tcs3472x/Tcs3472x.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Drawing;
 using System.Threading;
 

--- a/src/devices/Tcs3472x/samples/Tcs3472x.sample.cs
+++ b/src/devices/Tcs3472x/samples/Tcs3472x.sample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 using Iot.Device.Tcs3472x;
 

--- a/src/devices/Vl53L0X/Vl53L0X.cs
+++ b/src/devices/Vl53L0X/Vl53L0X.cs
@@ -9,7 +9,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Device.I2c.Devices;
+using System.Device.I2c;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;

--- a/src/devices/Vl53L0X/samples/Vl53L0X.sample.cs
+++ b/src/devices/Vl53L0X/samples/Vl53L0X.sample.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Device.I2c;
-using System.Device.I2c.Devices;
 using System.Threading;
 using Iot.Device.Vl53L0X;
 

--- a/src/devices/Ws28xx/samples/Ws28xx.Sample.cs
+++ b/src/devices/Ws28xx/samples/Ws28xx.Sample.cs
@@ -5,7 +5,6 @@
 using Iot.Device.Graphics;
 using System;
 using System.Device.Spi;
-using System.Device.Spi.Drivers;
 using System.Drawing;
 
 namespace Iot.Device.Ws28xx.Samples


### PR DESCRIPTION
Updated bindings to not reference the older Drivers namespace.