### PR TITLE
Ensure RaspberryPi4 fix works on ARM64 OS

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -365,7 +365,7 @@ namespace System.Device.Gpio.Drivers
                 }
 
                 IntPtr mapPointer = Interop.mmap(IntPtr.Zero, Environment.SystemPageSize, (MemoryMappedProtections.PROT_READ | MemoryMappedProtections.PROT_WRITE), MemoryMappedFlags.MAP_SHARED, fileDescriptor, GpioRegisterOffset);
-                if (mapPointer.ToInt32() == -1)
+                if (mapPointer.ToInt64() == -1)
                 {
                     throw new IOException($"Error {Marshal.GetLastWin32Error()} initializing the Gpio driver.");
                 }


### PR DESCRIPTION
@krwq, @joperezr  On ensuring that the RaspberryPi4 fix works on ARM64 OS #557 then I found that if the use of the RaspberryPi3Driver was 'forced' then an overflow exception occurred as a 64 bit IntPtr was trying to be converted to  32 bits. (I should have looked in MSDN).

This PR uses 64 bit comparison of the IntPtr. I have tested that the fix works and also that the software fails correctly in the following environments :

- Raspbian Buster on a Pi 4B (arm32)
- Raspbian Buster on a Pi 3B (arm32)
- Ubuntu Server on a Pi 3B (arm64)

The issue I found is unlikely to be encountered in normal operation but is probably worthwhile doing as it feels more correct and is more futureproof.