### PR TITLE
Random cleaning of SpiConnectionSettings

### DIFF
--- a/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
@@ -42,7 +42,7 @@ namespace System.Device.Spi
         /// <summary>
         /// The length of the data to be transfered.
         /// </summary>
-        public int DataBitLength { get; set; } = 8;
+        public int DataBitLength { get; set; } = 8;  // 1 byte
 
         /// <summary>
         /// The frequency in which the data will be transferred.

--- a/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
@@ -11,10 +11,6 @@ namespace System.Device.Spi
     /// </summary>
     public sealed class SpiConnectionSettings
     {
-        private const SpiMode _defaultSpiMode = SpiMode.Mode0;
-        private const int _defaultDataBitLength = 8; // 1 byte
-        private const int _defaultClockFrequency = 500_000; // 500 KHz
-
         private SpiConnectionSettings() { }
 
         /// <summary>
@@ -26,35 +22,38 @@ namespace System.Device.Spi
         {
             BusId = busId;
             ChipSelectLine = chipSelectLine;
-            Mode = _defaultSpiMode;
-            DataBitLength = _defaultDataBitLength;
-            ClockFrequency = _defaultClockFrequency;
         }
 
-        /// <summary>
-        /// The SPI mode being used.
-        /// </summary>
-        public SpiMode Mode { get; set; }
         /// <summary>
         /// The bus ID the device is connected to.
         /// </summary>
         public int BusId { get; set; }
+
         /// <summary>
         /// The chip select line used on the bus.
         /// </summary>
         public int ChipSelectLine { get; set; }
+
+        /// <summary>
+        /// The SPI mode being used.
+        /// </summary>
+        public SpiMode Mode { get; set; } = SpiMode.Mode0;
+
         /// <summary>
         /// The length of the data to be transfered.
         /// </summary>
-        public int DataBitLength { get; set; }
+        public int DataBitLength { get; set; } = 8;
+
         /// <summary>
-        /// The frequency in which the data will be transfered.
+        /// The frequency in which the data will be transferred.
         /// </summary>
-        public int ClockFrequency { get; set; }
+        public int ClockFrequency { get; set; } = 500_000; // 500 KHz
+
         /// <summary>
         /// Specifies order in which bits are transferred first on the SPI bus.
         /// </summary>
         public DataFlow DataFlow { get; set; } = DataFlow.MsbFirst;
+
         /// <summary>
         /// Specifies which value on chip select pin means "active".
         /// </summary>


### PR DESCRIPTION
Removed private fields & moved to default property values, added spaces, and a misspelling in a pear tree.