### PR TITLE
Switching symbols to be generated as snupkg to be uploaded to NuGet

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,6 +17,10 @@
 
   <!-- Packaging Targets -->
   <PropertyGroup>
+    <!-- Generate snupkg package -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- Collect package assets from builds -->
     <IncludeRIDSpecificBuildOutput Condition="'$(IncludeRIDSpecificBuildOutput)' == '' And '$(RuntimeIdentifiers)' != ''">true</IncludeRIDSpecificBuildOutput>
     <TargetsForTfmSpecificContentInPackage Condition="'$(IncludeRIDSpecificBuildOutput)' == 'true'">
       $(TargetsForTfmSpecificContentInPackage);


### PR DESCRIPTION
Adding the generation of .snupkg to the library so that they get pushed to NuGet's symbol server.

cc: @ericstj @richlander 