### PR TITLE
Updated summaries using cref with constructors

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.Linux.cs
@@ -52,6 +52,9 @@ namespace System.Device.Gpio.Drivers
             return 0;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SysFsDriver"/> class.
+        /// </summary>
         public SysFsDriver()
         {
             s_eventThreadCancellationTokenSource = new CancellationTokenSource();

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.Windows.cs
@@ -19,7 +19,7 @@ namespace System.Device.Gpio.Drivers
         private readonly Dictionary<int, Windows10DriverPin> _openPins = new Dictionary<int, Windows10DriverPin>();
 
         /// <summary>
-        /// Initializes new instance of Windows10Driver.
+        /// Initializes a new instance of the <see cref="Windows10Driver"/> class.
         /// </summary>
         public Windows10Driver()
         {

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
@@ -15,7 +15,7 @@ namespace System.Device.Gpio
         private const string HummingBoardHardware = @"Freescale i.MX6 Quad/DualLite (Device Tree)";
 
         /// <summary>
-        /// Initializes new instance of GpioController that will use the specified numbering scheme.
+        /// Initializes a new instance of the <see cref="GpioController"/> class that will use the specified numbering scheme.
         /// The controller will default to use the driver that best applies given the platform the program is executing on.
         /// </summary>
         /// <param name="numberingScheme">The numbering scheme used to represent pins provided by the controller.</param>

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.Windows.cs
@@ -15,7 +15,7 @@ namespace System.Device.Gpio
         private const string HummingBoardProduct = "HummingBoard-Edge";
 
         /// <summary>
-        /// Initializes new instance of GpioController that will use the specified numbering scheme.
+        /// Initializes a new instance of the <see cref="GpioController"/> class that will use the specified numbering scheme.
         /// The controller will default to use the driver that best applies given the platform the program is executing on.
         /// </summary>
         /// <param name="numberingScheme">The numbering scheme used to represent pins provided by the controller.</param>

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -17,7 +17,7 @@ namespace System.Device.Gpio
         private readonly HashSet<int> _openPins;
 
         /// <summary>
-        /// Initializes new instance of GpioController that will use the logical pin numbering scheme as default.
+        /// Initializes a new instance of the <see cref="GpioController"/> class that will use the logical pin numbering scheme as default.
         /// </summary>
         public GpioController()
             : this(PinNumberingScheme.Logical)
@@ -25,7 +25,7 @@ namespace System.Device.Gpio
         }
 
         /// <summary>
-        /// Initializes new instance of GpioController that will use the specified numbering scheme and driver.
+        /// Initializes a new instance of the <see cref="GpioController"/> class that will use the specified numbering scheme and driver.
         /// </summary>
         /// <param name="numberingScheme">The numbering scheme used to represent pins provided by the controller.</param>
         /// <param name="driver">The driver that manages all of the pin operations for the controller.</param>

--- a/src/System.Device.Gpio/System/Device/Gpio/PinValueChangedEventArgs.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinValueChangedEventArgs.cs
@@ -10,7 +10,7 @@ namespace System.Device.Gpio
     public class PinValueChangedEventArgs : EventArgs
     {
         /// <summary>
-        /// Initializes new instance of PinValueChangedEventArgs.
+        /// Initializes a new instance of the <see cref="PinValueChangedEventArgs"/> class.
         /// </summary>
         /// <param name="changeType">The change type that triggered the event.</param>
         /// <param name="pinNumber">The pin number that triggered the event.</param>

--- a/src/System.Device.Gpio/System/Device/Gpio/PinValuePair.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinValuePair.cs
@@ -20,7 +20,7 @@ namespace System.Device.Gpio
         public PinValue PinValue { get; }
 
         /// <summary>
-        /// Initializes new instance of PinValuePair.
+        /// Initializes a new instance of the <see cref="PinValuePair"/> struct.
         /// </summary>
         /// <param name="pinNumber">The pin number.</param>
         /// <param name="pinValue">The pin value.</param>

--- a/src/System.Device.Gpio/System/Device/I2c/Devices/UnixI2cDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Devices/UnixI2cDevice.Linux.cs
@@ -19,7 +19,7 @@ namespace System.Device.I2c
         private static readonly object s_initializationLock = new object();
 
         /// <summary>
-        /// Initializes new instance of UnixI2cDevice that will use the specified settings to communicate with the I2C device.
+        /// Initializes a new instance of the <see cref="UnixI2cDevice"/> class that will use the specified settings to communicate with the I2C device.
         /// </summary>
         /// <param name="settings">
         /// The connection settings of a device on an I2C bus.

--- a/src/System.Device.Gpio/System/Device/I2c/Devices/Windows10I2cDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Devices/Windows10I2cDevice.Windows.cs
@@ -16,7 +16,7 @@ namespace System.Device.I2c
         private WinI2c.I2cDevice _winI2cDevice;
 
         /// <summary>
-        /// Initializes new instance of Windows10I2cDevice that will use the specified settings to communicate with the I2C device.
+        /// Initializes a new instance of the <see cref="Windows10I2cDevice"/> class that will use the specified settings to communicate with the I2C device.
         /// </summary>
         /// <param name="settings">The connection settings of a device on an I2C bus.</param>
         public Windows10I2cDevice(I2cConnectionSettings settings)

--- a/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
@@ -12,7 +12,7 @@ namespace System.Device.I2c
         private I2cConnectionSettings() { }
 
         /// <summary>
-        /// Initializes new instance of I2cConnectionSettings.
+        /// Initializes a new instance of the <see cref="I2cConnectionSettings"/> class.
         /// </summary>
         /// <param name="busId">The bus ID the I2C device is connected to.</param>
         /// <param name="deviceAddress">The bus address of the I2C device.</param>

--- a/src/System.Device.Gpio/System/Device/Pwm/Drivers/Windows10PwmDriverChip.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Drivers/Windows10PwmDriverChip.Windows.cs
@@ -14,7 +14,7 @@ namespace System.Device.Pwm.Drivers
         private readonly Dictionary<int, Windows10PwmDriverChannel> _channelMap = new Dictionary<int, Windows10PwmDriverChannel>();
 
         /// <summary>
-        /// Initializes new instance of Windows10PwmDriverChip
+        /// Initializes a new instance of the <see cref="Windows10PwmDriverChip"/> class.
         /// </summary>
         /// <param name="pwmChip">The PWM chip.</param>
         /// <param name="useDefaultChip">Use the default chip.</param>

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmController.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmController.cs
@@ -15,7 +15,7 @@ namespace System.Device.Pwm
         private readonly HashSet<(int, int)> _openChannels;
 
         /// <summary>
-        /// Initializes new instance of PwmController that will use the specified driver.
+        /// Initializes a new instance of the <see cref="PwmController"/> class that will use the specified driver.
         /// </summary>
         /// <param name="driver">The driver that manages all of the channel operations for the controller.</param>
         public PwmController(PwmDriver driver)

--- a/src/System.Device.Gpio/System/Device/Spi/Devices/UnixSpiDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Devices/UnixSpiDevice.Linux.cs
@@ -20,7 +20,7 @@ namespace System.Device.Spi
         private static readonly object s_initializationLock = new object();
 
         /// <summary>
-        /// Initializes new instance of UnixSpiDevice that will use the specified settings to communicate with the SPI device.
+        /// Initializes a new instance of the <see cref="UnixSpiDevice"/> class that will use the specified settings to communicate with the SPI device.
         /// </summary>
         /// <param name="settings">
         /// The connection settings of a device on a SPI bus.

--- a/src/System.Device.Gpio/System/Device/Spi/Devices/Windows10SpiDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Devices/Windows10SpiDevice.Windows.cs
@@ -17,7 +17,7 @@ namespace System.Device.Spi
         private WinSpi.SpiDevice _winDevice;
 
         /// <summary>
-        /// Initializes new instance of Windows10SpiDevice that will use the specified settings to communicate with the SPI device.
+        /// Initializes a new instance of the <see cref="Windows10SpiDevice"/> class that will use the specified settings to communicate with the SPI device.
         /// </summary>
         /// <param name="settings">
         /// The connection settings of a device on a SPI bus.

--- a/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
@@ -14,7 +14,7 @@ namespace System.Device.Spi
         private SpiConnectionSettings() { }
 
         /// <summary>
-        /// Initializes new instance of SpiConnectionSettings.
+        /// Initializes a new instance of the <see cref="SpiConnectionSettings"/> class.
         /// </summary>
         /// <param name="busId">The bus ID the device is connected to.</param>
         /// <param name="chipSelectLine">The chip select line used on the bus.</param>


### PR DESCRIPTION
Fixes #565

This focused on updating files that already included similar wording.  Did not update non-OS files (Linux > Windows, vice versa), internal classes or PWM (since they are about to change).