### PR TITLE
Updated CharacterLcd README.md

### DIFF
--- a/src/devices/CharacterLcd/README.md
+++ b/src/devices/CharacterLcd/README.md
@@ -23,6 +23,7 @@ Grove LCD RGB Backlight uses two i2c devices:
 - the device to control LCD (address 0x3E)
 - the device to control RGB backlight (address 0x62)
 
+(Make sure the Grove-LCD RGB Backlight is connected to a I2C port. Not the Digital port!)
 Here is a Hello World example of how to consume Grove LCD RGB Backlight binding:
 ```c#
 var i2cLcdDevice = I2cDevice.Create(new I2cConnectionSettings(busId: 1, deviceAddress: 0x3E));
@@ -30,7 +31,7 @@ var i2cRgbDevice = I2cDevice.Create(new I2cConnectionSettings(busId: 1, deviceAd
 using (var lcd = new LcdRgb1602(i2cLcdDevice, i2cRgbDevice))
 {
     lcd.Write("Hello World!");
-    lcd.SetColor(Color.Azure);
+    lcd.SetBacklightcolor(Color.Azure);
 }
 ```
 

--- a/src/devices/CharacterLcd/README.md
+++ b/src/devices/CharacterLcd/README.md
@@ -23,7 +23,7 @@ Grove LCD RGB Backlight uses two i2c devices:
 - the device to control LCD (address 0x3E)
 - the device to control RGB backlight (address 0x62)
 
-(Make sure the Grove-LCD RGB Backlight is connected to a I2C port. Not the Digital port!)
+Make sure the Grove-LCD RGB Backlight is connected to a I2C port. Not the Digital port!
 Here is a Hello World example of how to consume Grove LCD RGB Backlight binding:
 ```c#
 var i2cLcdDevice = I2cDevice.Create(new I2cConnectionSettings(busId: 1, deviceAddress: 0x3E));

--- a/src/devices/CharacterLcd/README.md
+++ b/src/devices/CharacterLcd/README.md
@@ -31,7 +31,7 @@ var i2cRgbDevice = I2cDevice.Create(new I2cConnectionSettings(busId: 1, deviceAd
 using (var lcd = new LcdRgb1602(i2cLcdDevice, i2cRgbDevice))
 {
     lcd.Write("Hello World!");
-    lcd.SetBacklightcolor(Color.Azure);
+    lcd.SetBacklightColor(Color.Azure);
 }
 ```
 


### PR DESCRIPTION
Hi,

The `.SetColor` method does not exist. 
Should be changed to `SetBacklightColor`:

Old example:
```c#
using (var lcd = new LcdRgb1602(i2cLcdDevice, i2cRgbDevice))
{
    lcd.Write("Hello World!");
    lcd.SetColor(Color.Azure); // <--- old
}
```
New example:
```c#
using (var lcd = new LcdRgb1602(i2cLcdDevice, i2cRgbDevice))
{
    lcd.Write("Hello World!");
    lcd.SetBacklightColor(Color.Azure); // <--- new
}
```

I also added a little note where you should connect the Grove-LCD RGB backlight to a I2C port. 

