### PR TITLE
Avoid openning file handle when changing duty cycle or freq in hardware PWM

### DIFF
--- a/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.Linux.cs
@@ -41,7 +41,7 @@ namespace System.Device.Pwm.Channels
             Validate();
             Open();
 
-            // avoid openning the file for operations changing relatively frequently
+            // avoid opening the file for operations changing relatively frequently
             _dutyCycleWriter = new StreamWriter(new FileStream($"{_channelPath}/duty_cycle", FileMode.Open, FileAccess.ReadWrite));
             _frequencyWriter = new StreamWriter(new FileStream($"{_channelPath}/period", FileMode.Open, FileAccess.ReadWrite));
 

--- a/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.Linux.cs
@@ -18,6 +18,8 @@ namespace System.Device.Pwm.Channels
         private double _dutyCyclePercentage;
         private readonly string _chipPath;
         private readonly string _channelPath;
+        private StreamWriter _dutyCycleWriter;
+        private StreamWriter _frequencyWriter;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UnixPwmChannel"/> class.
@@ -38,6 +40,11 @@ namespace System.Device.Pwm.Channels
             _channel = channel;
             Validate();
             Open();
+
+            // avoid openning the file for operations changing relatively frequently
+            _dutyCycleWriter = new StreamWriter(new FileStream($"{_channelPath}/duty_cycle", FileMode.Open, FileAccess.ReadWrite));
+            _frequencyWriter = new StreamWriter(new FileStream($"{_channelPath}/period", FileMode.Open, FileAccess.ReadWrite));
+
             SetFrequency(frequency);
             DutyCyclePercentage = dutyCyclePercentage;
         }
@@ -95,7 +102,9 @@ namespace System.Device.Pwm.Channels
             }
             
             int periodInNanoseconds = GetPeriodInNanoseconds(frequency);
-            File.WriteAllText($"{_channelPath}/period", Convert.ToString(periodInNanoseconds));
+            _frequencyWriter.BaseStream.SetLength(0);
+            _frequencyWriter.Write(periodInNanoseconds);
+            _frequencyWriter.Flush();
             _frequency = frequency;
         }
 
@@ -112,7 +121,9 @@ namespace System.Device.Pwm.Channels
 
             // In Linux, the period needs to be a whole number and can't have decimal point.
             int dutyCycleInNanoseconds = (int)(GetPeriodInNanoseconds(_frequency) * dutyCyclePercentage);
-            File.WriteAllText($"{_channelPath}/duty_cycle", Convert.ToString(dutyCycleInNanoseconds));
+            _dutyCycleWriter.BaseStream.SetLength(0);
+            _dutyCycleWriter.Write(dutyCycleInNanoseconds);
+            _dutyCycleWriter.Flush();
             _dutyCyclePercentage = dutyCyclePercentage;
         }
 
@@ -184,6 +195,10 @@ namespace System.Device.Pwm.Channels
 
         protected override void Dispose(bool disposing)
         {
+            _dutyCycleWriter?.Dispose();
+            _dutyCycleWriter = null;
+            _frequencyWriter?.Dispose();
+            _frequencyWriter = null;
             Close();
             base.Dispose(disposing);
         }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/iot/issues/638

I noticed that depending on the battery level PWM is more or less responsive in general but this allows to be more consistent since we don't have to open the file on every operation.

Most of the cases only duty cycles will be changed frequently but some other like buzzer the frequency is changed relatively quickly as well