### PR TITLE
Fix LibGpioD driver for linux to recognise both rising and falling edges.

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.Linux.cs
@@ -46,7 +46,8 @@ namespace System.Device.Gpio.Drivers
                 {
                     eventHandler.ValueRising += callback;
                 }
-                else if ((eventTypes & PinEventTypes.Falling) != 0)
+
+                if ((eventTypes & PinEventTypes.Falling) != 0)
                 {
                     eventHandler.ValueFalling += callback;
                 }
@@ -181,7 +182,8 @@ namespace System.Device.Gpio.Drivers
                 {
                     eventHandler.ValueRising += callback;
                 }
-                else if ((eventTypes & PinEventTypes.Falling) != 0)
+
+                if ((eventTypes & PinEventTypes.Falling) != 0)
                 {
                     eventHandler.ValueFalling += callback;
                 }


### PR DESCRIPTION
This is to address issue #654.