### PR TITLE
Clone I2cConnectionSettings and SpiConnectionSettings in order to make them immutable

### DIFF
--- a/src/System.Device.Gpio/System/Device/I2c/Devices/UnixI2cDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Devices/UnixI2cDevice.Linux.cs
@@ -36,9 +36,10 @@ namespace System.Device.I2c
         public string DevicePath { get; set; }
 
         /// <summary>
-        /// The connection settings of a device on an I2C bus.
+        /// The connection settings of a device on an I2C bus. The connection settings are immutable after the device is created
+        /// so the object returned will be a clone of the settings object.
         /// </summary>
-        public override I2cConnectionSettings ConnectionSettings => _settings;
+        public override I2cConnectionSettings ConnectionSettings => new I2cConnectionSettings(_settings);
 
         private unsafe void Initialize()
         {

--- a/src/System.Device.Gpio/System/Device/I2c/Devices/Windows10I2cDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Devices/Windows10I2cDevice.Windows.cs
@@ -41,9 +41,10 @@ namespace System.Device.I2c
         }
 
         /// <summary>
-        /// The connection settings of a device on an I2C bus.
+        /// The connection settings of a device on an I2C bus. The connection settings are immutable after the device is created
+        /// so the object returned will be a clone of the settings object.
         /// </summary>
-        public override I2cConnectionSettings ConnectionSettings => _settings;
+        public override I2cConnectionSettings ConnectionSettings => new I2cConnectionSettings(_settings);
 
         /// <summary>
         /// Reads a byte from the I2C device.

--- a/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
@@ -22,6 +22,12 @@ namespace System.Device.I2c
             DeviceAddress = deviceAddress;
         }
 
+        internal I2cConnectionSettings(I2cConnectionSettings other)
+        {
+            BusId = other.BusId;
+            DeviceAddress = other.DeviceAddress;
+        }
+
         /// <summary>
         /// The bus ID the I2C device is connected to.
         /// </summary>

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
@@ -10,7 +10,8 @@ namespace System.Device.I2c
     public abstract partial class I2cDevice : IDisposable
     {
         /// <summary>
-        /// The connection settings of a device on an I2C bus.
+        /// The connection settings of a device on an I2C bus. The connection settings are immutable after the device is created
+        /// so the object returned will be a clone of the settings object.
         /// </summary>
         public abstract I2cConnectionSettings ConnectionSettings { get; }
 

--- a/src/System.Device.Gpio/System/Device/Spi/Devices/UnixSpiDevice.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Devices/UnixSpiDevice.Linux.cs
@@ -37,9 +37,10 @@ namespace System.Device.Spi
         public string DevicePath { get; set; }
 
         /// <summary>
-        /// The connection settings of a device on a SPI bus.
+        /// The connection settings of a device on a SPI bus. The connection settings are immutable after the device is created
+        /// so the object returned will be a clone of the settings object.
         /// </summary>
-        public override SpiConnectionSettings ConnectionSettings => _settings;
+        public override SpiConnectionSettings ConnectionSettings => new SpiConnectionSettings(_settings);
 
         private unsafe void Initialize()
         {

--- a/src/System.Device.Gpio/System/Device/Spi/Devices/Windows10SpiDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Devices/Windows10SpiDevice.Windows.cs
@@ -50,9 +50,10 @@ namespace System.Device.Spi
         }
 
         /// <summary>
-        /// The connection settings of a device on a SPI bus.
+        /// The connection settings of a device on a SPI bus. The connection settings are immutable after the device is created
+        /// so the object returned will be a clone of the settings object.
         /// </summary>
-        public override SpiConnectionSettings ConnectionSettings => _settings;
+        public override SpiConnectionSettings ConnectionSettings => new SpiConnectionSettings(_settings);
 
         /// <summary>
         /// Reads a byte from the SPI device.

--- a/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
@@ -24,6 +24,17 @@ namespace System.Device.Spi
             ChipSelectLine = chipSelectLine;
         }
 
+        internal SpiConnectionSettings(SpiConnectionSettings other)
+        {
+            BusId = other.BusId;
+            ChipSelectLine = other.ChipSelectLine;
+            Mode = other.Mode;
+            DataBitLength = other.DataBitLength;
+            ClockFrequency = other.ClockFrequency;
+            DataFlow = other.DataFlow;
+            ChipSelectLineActiveState = other.ChipSelectLineActiveState;
+        }
+
         /// <summary>
         /// The bus ID the device is connected to.
         /// </summary>

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
@@ -10,7 +10,8 @@ namespace System.Device.Spi
     public abstract partial class SpiDevice : IDisposable
     {
         /// <summary>
-        /// The connection settings of a device on a SPI bus.
+        /// The connection settings of a device on a SPI bus. The connection settings are immutable after the device is created
+        /// so the object returned will be a clone of the settings object.
         /// </summary>
         public abstract SpiConnectionSettings ConnectionSettings { get; }
 


### PR DESCRIPTION
fixes #603 

cc: @shaggygi @Frankenslag @krwq 

These changes will fix the current issue where you can modify the connection settings of a device after creation. It would still allow people to change settings object themselves in order to allow dynamic instantiation (see comment https://github.com/dotnet/iot/issues/603#issuecomment-513172714) and when the settings are requested form the device, it will just create a clone and pass it to the caller.