### PR TITLE
Simplify MCP3008

### DIFF
--- a/src/devices/Mcp3008/Mcp3008.cs
+++ b/src/devices/Mcp3008/Mcp3008.cs
@@ -12,7 +12,7 @@ namespace Iot.Device.Mcp3008
     {
         private SpiDevice _spiDevice;
 
-        public enum InputConfiguration
+        internal enum InputConfiguration
         {
             Differential = 0,
             SingleEnded = 1
@@ -29,14 +29,14 @@ namespace Iot.Device.Mcp3008
             _spiDevice = null;
         }
 
-        public int Read(int channel, InputConfiguration inputConfiguration = InputConfiguration.SingleEnded)
+        public int Read(int channel)
         {
             if (channel < 0 || channel > 7)
             {
                 throw new ArgumentException("ADC channel must be within 0-7 range.");
             }
 
-            return ReadSpi(channel, inputConfiguration);
+            return ReadSpi(channel, InputConfiguration.SingleEnded);
         }
 
         private static byte GetConfigurationBits(int channel, InputConfiguration inputConfiguration)

--- a/src/devices/Mcp3008/Mcp3008.cs
+++ b/src/devices/Mcp3008/Mcp3008.cs
@@ -12,12 +12,6 @@ namespace Iot.Device.Mcp3008
     {
         private SpiDevice _spiDevice;
 
-        internal enum InputConfiguration
-        {
-            Differential = 0,
-            SingleEnded = 1
-        }
-
         public Mcp3008(SpiDevice spiDevice)
         {
             _spiDevice = spiDevice;
@@ -36,34 +30,29 @@ namespace Iot.Device.Mcp3008
                 throw new ArgumentException("ADC channel must be within 0-7 range.");
             }
 
-            return ReadSpi(channel, InputConfiguration.SingleEnded);
-        }
+            Span<byte> writeBuffer = stackalloc byte[3];
+            Span<byte> readBuffer = stackalloc byte[3];
 
-        private static byte GetConfigurationBits(int channel, InputConfiguration inputConfiguration)
-        {
-            int configurationBits = (0b0001_1000 | channel) << 3;
-
-            if (inputConfiguration == InputConfiguration.Differential)
-            {
-                configurationBits &= 0b1011_1111; // Clear mode bit.
-            }
-
-            return (byte)configurationBits;
-        }
-
-        // Ported: https://github.com/adafruit/Adafruit_Python_MCP3008/blob/master/Adafruit_MCP3008/MCP3008.py
-        private int ReadSpi(int channel, InputConfiguration inputConfiguration)
-        {
-            byte configurationBits = GetConfigurationBits(channel, inputConfiguration);
-            byte[] writeBuffer = new byte[] { configurationBits, 0, 0 };
-            byte[] readBuffer = new byte[3];
-
+            // first we send 5 bits, rest is ignored
+            // start bit = 1
+            // conversion bit = 1 (single ended)
+            // next 3 bits are channel
+            writeBuffer[0] = (byte)((0b1_1000 | channel) << 3);
             _spiDevice.TransferFullDuplex(writeBuffer, readBuffer);
 
-            int result = (readBuffer[0] & 0b0000_0001) << 9;
-            result |= (readBuffer[1] & 0b1111_1111) << 1;
-            result |= (readBuffer[2] & 0b1000_0000) >> 7;
-            result = result & 0b0011_1111_1111;
+            // we ignore first 7 bits then read following 10
+            // 7 bits:
+            // - 5 are used for writing start bit, conversion bit and channel
+            // - next bit is ignored so device has time to sample
+            // - following bit should be 0
+            if ((readBuffer[0] & 0b10) != 0)
+            {
+                throw new InvalidOperationException("Invalid data was read from the sensor");
+            }
+
+            int result = (readBuffer[0] & 1) << 9;
+            result |= readBuffer[1] << 1;
+            result |= readBuffer[2] >> 7;
             return result;
         }
     }

--- a/src/devices/Mcp3008/Mcp3008.cs
+++ b/src/devices/Mcp3008/Mcp3008.cs
@@ -8,21 +8,36 @@ using System.Device.Spi;
 
 namespace Iot.Device.Mcp3008
 {
+    /// <summary>
+    /// MCP3008 Analog to Digital Converter (ADC)
+    /// </summary>
     public class Mcp3008 : IDisposable
     {
         private SpiDevice _spiDevice;
 
+        /// <summary>
+        /// Constructs Mcp3008 instance
+        /// </summary>
+        /// <param name="spiDevice">Device used for SPI communication</param>
         public Mcp3008(SpiDevice spiDevice)
         {
             _spiDevice = spiDevice;
         }
 
+        /// <summary>
+        /// Disposes Mcp3008 instances
+        /// </summary>
         public void Dispose()
         {
             _spiDevice?.Dispose();
             _spiDevice = null;
         }
 
+        /// <summary>
+        /// Reads 10-bit (0..1023) value from the device
+        /// </summary>
+        /// <param name="channel">Channel which value should be read from (valid values: 0-7)</param>
+        /// <returns>10-bit value corresponding to relative voltage level on specified device channel</returns>
         public int Read(int channel)
         {
             if (channel < 0 || channel > 7)

--- a/src/devices/Mcp3008/samples/Mcp3008.Sample.cs
+++ b/src/devices/Mcp3008/samples/Mcp3008.Sample.cs
@@ -25,7 +25,7 @@ namespace Iot.Device.Samples
             {
                 while (true)
                 {
-                    double value = mcp.Read(0, Mcp3008.Mcp3008.InputConfiguration.SingleEnded);
+                    double value = mcp.Read(0);
                     value = value / 10.24;
                     value = Math.Round(value);
                     Console.WriteLine($"{value}%");

--- a/src/devices/Mcp3008/samples/README.md
+++ b/src/devices/Mcp3008/samples/README.md
@@ -21,7 +21,7 @@ using (Mcp3008.Mcp3008 mcp = new Mcp3008.Mcp3008(spi))
 {
     while (true)
     {
-        double value = mcp.Read(0, Mcp3008.Mcp3008.InputConfiguration.SingleEnded);
+        double value = mcp.Read(0);
         value = value / 10.24;
         value = Math.Round(value);
         Console.WriteLine($"{value}%");
@@ -56,7 +56,7 @@ using (Mcp3008.Mcp3008 mcp = new Mcp3008.Mcp3008(spi))
 {
     while (true)
     {
-        double value = mcp.Read(0, Mcp3008.Mcp3008.InputConfiguration.SingleEnded);
+        double value = mcp.Read(0);
         value = value / 10.24;
         value = Math.Round(value);
         Console.WriteLine($"{value}%");


### PR DESCRIPTION
Mainly remove InputConfiguration but also:
- remove unnecessary operations
- no allocations
- error detection in reading code
- add comments to explain bit shifting

Fixes TODO on one of our 3.0 items: https://github.com/dotnet/iot/projects/4#card-24042553