### PR TITLE
UnixPwmChannel.Linux: Fix pwm chip and channel assignment and concatenation order

### DIFF
--- a/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.Linux.cs
@@ -38,7 +38,7 @@ namespace System.Device.Pwm.Channels
             _channel = channel;
             _chipPath = $"/sys/class/pwm/pwmchip{_chip}";
             _channelPath = $"{_chipPath}/pwm{_channel}";
-			Validate();
+            Validate();
             Open();
 
             // avoid opening the file for operations changing relatively frequently

--- a/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.Linux.cs
@@ -34,11 +34,11 @@ namespace System.Device.Pwm.Channels
             int frequency = 400,
             double dutyCyclePercentage = 0.5)
         {
-            _chipPath = $"/sys/class/pwm/pwmchip{_chip}";
-            _channelPath = $"{_chipPath}/pwm{_channel}";
             _chip = chip;
             _channel = channel;
-            Validate();
+            _chipPath = $"/sys/class/pwm/pwmchip{_chip}";
+            _channelPath = $"{_chipPath}/pwm{_channel}";
+			Validate();
             Open();
 
             // avoid opening the file for operations changing relatively frequently


### PR DESCRIPTION


without this fix only channel 0 and pwm0 are used
Tested on my Toradex Colibri iMX6 that have 4 hardware pwm controllers

Signed-off-by: Matheus Castello <matheus@castello.eng.br>