### PR TITLE
Fix build break by removing wildcards from package dependencies

### DIFF
--- a/src/devices/Ssd13xx/samples/Ssd13xx.Samples.csproj
+++ b/src/devices/Ssd13xx/samples/Ssd13xx.Samples.csproj
@@ -9,10 +9,10 @@
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj">
       <AdditionalProperties>$(AdditionalProperties);RuntimeIdentifier=linux</AdditionalProperties>
     </ProjectReference>
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-*" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-*" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-*" />
-    <PackageReference Include="SixLabors.Shapes.Text" Version="1.0.0-*" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0008" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0006" />
+    <PackageReference Include="SixLabors.Shapes.Text" Version="1.0.0-beta0008" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
cc: @krwq @Ellerbach 

Fixing iot build caused by referencing wildcard package versions that caused package downgrades.
