### PR TITLE
Rename DutyCyclePercentage -> DutyCycle

### DIFF
--- a/src/System.Device.Gpio/System/Device/Pwm/Channels/Windows10PwmChannel.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Channels/Windows10PwmChannel.Windows.cs
@@ -16,7 +16,7 @@ namespace System.Device.Pwm.Channels
         private WinPwm.PwmController _winController;
         private WinPwm.PwmPin _winPin;
         private int _frequency;
-        private double _dutyCyclePercentage;
+        private double _dutyCycle;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Windows10PwmChannel"/> class.
@@ -24,12 +24,12 @@ namespace System.Device.Pwm.Channels
         /// <param name="chip">The PWM chip number.</param>
         /// <param name="channel">The PWM channel number.</param>
         /// <param name="frequency">The frequency in hertz.</param>
-        /// <param name="dutyCyclePercentage">The duty cycle percentage represented as a value between 0.0 and 1.0.</param>
+        /// <param name="dutyCycle">The duty cycle percentage represented as a value between 0.0 and 1.0.</param>
         public Windows10PwmChannel(
             int chip,
             int channel,
             int frequency = 400,
-            double dutyCyclePercentage = 0.5)
+            double dutyCycle = 0.5)
         {
             // When running on Hummingboard we require to use the default chip.
             var deviceInfo = new EasClientDeviceInformation();
@@ -58,12 +58,10 @@ namespace System.Device.Pwm.Channels
             }
 
             Frequency = frequency;
-            DutyCyclePercentage = dutyCyclePercentage;
+            DutyCycle = dutyCycle;
         }
 
-        /// <summary>
-        /// The frequency in hertz.
-        /// </summary>
+        /// <inheritdoc/>
         public override int Frequency
         {
             get => _frequency;
@@ -78,12 +76,10 @@ namespace System.Device.Pwm.Channels
             }
         }
 
-        /// <summary>
-        /// The duty cycle percentage represented as a value between 0.0 and 1.0.
-        /// </summary>
-        public override double DutyCyclePercentage
+        /// <inheritdoc/>
+        public override double DutyCycle
         {
-            get => _dutyCyclePercentage;
+            get => _dutyCycle;
             set
             {
                 if (value < 0.0 || value > 1.0)
@@ -91,23 +87,19 @@ namespace System.Device.Pwm.Channels
                     throw new ArgumentOutOfRangeException(nameof(value), value, "Value must be between 0.0 and 1.0.");
                 }
                 _winPin.SetActiveDutyCyclePercentage(value);
-                _dutyCyclePercentage = value;
+                _dutyCycle = value;
             }
         }
 
-        /// <summary>
-        /// Starts the PWM channel.
-        /// </summary>
+        /// <inheritdoc/>
         public override void Start()
         {
             _winPin.Start();
             // This extra call is required to generate PWM output - remove when the underlying issue is fixed. See issue #109
-            DutyCyclePercentage = _dutyCyclePercentage;
+            DutyCycle = _dutyCycle;
         }
 
-        /// <summary>
-        /// Stops the PWM channel.
-        /// </summary>
+        /// <inheritdoc/>
         public override void Stop()
         {
             _winPin.Stop();

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.cs
@@ -15,9 +15,9 @@ namespace System.Device.Pwm
         public abstract int Frequency { get; set; }
 
         /// <summary>
-        /// The duty cycle percentage represented as a value between 0.0 and 1.0.
+        /// The duty cycle represented as a value between 0.0 and 1.0.
         /// </summary>
-        public abstract double DutyCyclePercentage { get; set; }
+        public abstract double DutyCycle { get; set; }
 
         /// <summary>
         /// Starts the PWM channel.

--- a/src/devices/DCMotor/DCMotor2PinNoEnable.cs
+++ b/src/devices/DCMotor/DCMotor2PinNoEnable.cs
@@ -60,7 +60,7 @@ namespace Iot.Device.DCMotor
                         Controller.Write(_pin1, PinValue.Low);
                     }
 
-                    _pwm.DutyCyclePercentage = val;
+                    _pwm.DutyCycle = val;
                 }
                 else
                 {
@@ -69,7 +69,7 @@ namespace Iot.Device.DCMotor
                         Controller.Write(_pin1, PinValue.High);
                     }
 
-                    _pwm.DutyCyclePercentage = 1.0 + val;
+                    _pwm.DutyCycle = 1.0 + val;
                 }
 
                 _speed = val;

--- a/src/devices/DCMotor/DCMotor3Pin.cs
+++ b/src/devices/DCMotor/DCMotor3Pin.cs
@@ -76,7 +76,7 @@ namespace Iot.Device.DCMotor
                     Controller.Write(_pin1, PinValue.Low);
                 }
 
-                _pwm.DutyCyclePercentage = Math.Abs(val);
+                _pwm.DutyCycle = Math.Abs(val);
 
                 _speed = val;
             }

--- a/src/devices/Pca9685/Pca9685PwmChannel.cs
+++ b/src/devices/Pca9685/Pca9685PwmChannel.cs
@@ -26,7 +26,7 @@ namespace  Iot.Device.Pwm
             set => _parent.SetDutyCycleInternal(_channel, value);
         }
 
-        public override double DutyCyclePercentage
+        public override double DutyCycle
         {
             get => _running ? ActualDutyCycle : _dutyCycle;
             set

--- a/src/devices/Pca9685/samples/README.md
+++ b/src/devices/Pca9685/samples/README.md
@@ -7,8 +7,8 @@ using (var pca9685 = new Pca9685(device, pwmFrequency: 50))
     PwmChannel firstChannel = pca9685.CreatePwmChannel(0); // channel 0
     PwmChannel secondChannel = pca9685.CreatePwmChannel(1); // channel 1
 
-    firstChannel.DutyCyclePercentage = 0.0; // min
-    secondChannel.DutyCyclePercentage = 1.0; // max
+    firstChannel.DutyCycle = 0.0; // min
+    secondChannel.DutyCycle = 1.0; // max
 
     // note: SetDutyCycleAllChannels cannot be used anymore
     //       because it would interfere with firstChannel and secondChannel setting

--- a/src/devices/ServoMotor/ServoMotor.cs
+++ b/src/devices/ServoMotor/ServoMotor.cs
@@ -92,8 +92,8 @@ namespace Iot.Device.ServoMotor
         /// <param name="microseconds">The pulse width, in microseconds, to write to the servo motor.</param>
         public void WritePulseWidth(int microseconds)
         {
-            double dutyCyclePercentage = (double)microseconds / 1_000_000 * _pwmChannel.Frequency; // Convert to seconds 1st.
-            _pwmChannel.DutyCyclePercentage = dutyCyclePercentage;
+            double dutyCycle = (double)microseconds / 1_000_000 * _pwmChannel.Frequency; // Convert to seconds 1st.
+            _pwmChannel.DutyCycle = dutyCycle;
         }
 
         /// <inheritdoc/>

--- a/src/devices/ServoMotor/samples/ServoMotor.Sample.cs
+++ b/src/devices/ServoMotor/samples/ServoMotor.Sample.cs
@@ -45,7 +45,7 @@ namespace Iot.Device.ServoMotor.Samples
                 }
 
                 servoMotor.WritePulseWidth(pulseWidthValue);
-                Console.WriteLine($"Duty Cycle Percentage: {pwmChannel.DutyCyclePercentage}");
+                Console.WriteLine($"Duty Cycle: {pwmChannel.DutyCycle * 100.0}%");
             }
 
             servoMotor.Stop();
@@ -71,7 +71,7 @@ namespace Iot.Device.ServoMotor.Samples
                 }
 
                 servoMotor.WriteAngle(angleValue);
-                Console.WriteLine($"Duty Cycle Percentage: {pwmChannel.DutyCyclePercentage}");
+                Console.WriteLine($"Duty Cycle: {pwmChannel.DutyCycle * 100.0}%");
             }
 
             servoMotor.Stop();

--- a/src/devices/ServoMotor/tests/ServoMotorTests.cs
+++ b/src/devices/ServoMotor/tests/ServoMotorTests.cs
@@ -55,13 +55,13 @@ namespace Iot.Device.ServoMotor.Tests
         [InlineData(50, 180, 1_000, 2_000, 180, 0.1)]
         [InlineData(50, 90, 1_000, 1_500, 0, 0.05)]
         [InlineData(50, 90, 1_000, 1_500, 90, 0.075)]
-        public void Verify_Duty_Cycle_Percentage_When_Writing_Angle(
+        public void Verify_Duty_Cycle_When_Writing_Angle(
             int frequency,
             int maxiumAngle,
             int minimumPulseWidthMicroseconds,
             int maximumPulseWidthMicroseconds,
             int angle,
-            double expectedDutyCyclePercentage)
+            double expectedDutyCycle)
         {
             Mock<PwmChannel> mockPwmChannel = new Mock<PwmChannel>();
             mockPwmChannel.SetupAllProperties();
@@ -74,7 +74,7 @@ namespace Iot.Device.ServoMotor.Tests
 
             servo.WriteAngle(angle);
 
-            Assert.Equal(expectedDutyCyclePercentage, mockPwmChannel.Object.DutyCyclePercentage, 5);
+            Assert.Equal(expectedDutyCycle, mockPwmChannel.Object.DutyCycle, 5);
         }
 
         [Theory]
@@ -82,10 +82,10 @@ namespace Iot.Device.ServoMotor.Tests
         [InlineData(50, 2_000, 0.1)]
         [InlineData(60, 1_000, 0.06)]
         [InlineData(60, 2_000, 0.12)]
-        public void Verify_Duty_Cycle_Percentage_When_Writing_Pulse_Width(
+        public void Verify_Duty_Cycle_When_Writing_Pulse_Width(
             int frequency,
             int pulseWithInMicroseconds,
-            double expectedDutyCyclePercentage)
+            double expectedDutyCycle)
         {
             Mock<PwmChannel> mockPwmChannel = new Mock<PwmChannel>();
             mockPwmChannel.SetupAllProperties();
@@ -94,7 +94,7 @@ namespace Iot.Device.ServoMotor.Tests
 
             servo.WritePulseWidth(pulseWithInMicroseconds);
 
-            Assert.Equal(expectedDutyCyclePercentage, mockPwmChannel.Object.DutyCyclePercentage, 5);
+            Assert.Equal(expectedDutyCycle, mockPwmChannel.Object.DutyCycle, 5);
         }
 
         [Theory]

--- a/src/devices/SoftPwm/SoftwarePwmChannel.cs
+++ b/src/devices/SoftPwm/SoftwarePwmChannel.cs
@@ -23,7 +23,7 @@ namespace System.Device.Pwm.Drivers
         // Use to determine the length of the pulse
         // 100 % = full output. 0%= nothing as output
         private double _percentage;
-      
+
         // Determines if a high precision timer should be used.
         private bool _usePrecisionTimer = false;
 
@@ -58,7 +58,7 @@ namespace System.Device.Pwm.Drivers
         /// <summary>
         /// The duty cycle percentage represented as a value between 0.0 and 1.0.
         /// </summary>
-        public override double DutyCyclePercentage
+        public override double DutyCycle
         {
             get => _percentage;
             set
@@ -77,10 +77,10 @@ namespace System.Device.Pwm.Drivers
         /// </summary>
         /// <param name="pinNumber">The GPIO pin number to be used</param>
         /// <param name="frequency">The frequency in hertz. Defaults to 400</param>
-        /// <param name="dutyCyclePercentage">The duty cycle percentage represented as a value between 0.0 and 1.0</param>
+        /// <param name="dutyCycle">The duty cycle percentage represented as a value between 0.0 and 1.0</param>
         /// <param name="usePrecisionTimer">Determines if a high precision timer should be used.</param>
         /// <param name="controller">The <see cref="GpioController"/> to which <paramref name="pinNumber"/> belongs to. Null defaults to board GpioController</param>
-        public SoftwarePwmChannel(int pinNumber, int frequency = 400, double dutyCyclePercentage = 0.5, bool usePrecisionTimer = false, GpioController controller = null)
+        public SoftwarePwmChannel(int pinNumber, int frequency = 400, double dutyCycle = 0.5, bool usePrecisionTimer = false, GpioController controller = null)
         {
             _controller = controller ?? new GpioController();
             if (_controller == null)
@@ -98,7 +98,7 @@ namespace System.Device.Pwm.Drivers
             _frequency = frequency;
             _pulseFrequency = (frequency > 0) ? 1.0 / frequency * 1000.0 : 0.0;
 
-            DutyCyclePercentage = dutyCyclePercentage;
+            DutyCycle = dutyCycle;
         }
 
         private void UpdateRange()

--- a/src/devices/SoftPwm/samples/README.md
+++ b/src/devices/SoftPwm/samples/README.md
@@ -12,13 +12,13 @@ To initialize the software with frequency of 200 on pin 17 and duty cycle of 50%
 
 ```csharp
 var channel = new SoftwarePwmChannel(17, 200, 0.5);
-channel.Start();        
+channel.Start();
 ```
 
 Then you can change the duty cycle during the execution (75% used in the example below):
 
 ```csharp
-channel.DutyCyclePercentage = 0.75;
+channel.DutyCycle = 0.75;
 ```
 
 Here is a full example:
@@ -40,7 +40,7 @@ class Program
             pwmChannel.Start();
             for (double fill = 0.0; fill <= 1.0; fill += 0.01)
             {
-                pwmChannel.DutyCyclePercentage = fill;
+                pwmChannel.DutyCycle = fill;
                 Thread.Sleep(500);
             }
         }
@@ -49,6 +49,6 @@ class Program
 
 ```
 
-## Other Example 
+## Other Example
 
 You will find another example of SoftPwm in the [Servo Motor class](/src/devices/Servo/samples/README.md). This Servomotor sample uses a precision timer.

--- a/src/devices/SoftPwm/samples/SoftPwm.sample.cs
+++ b/src/devices/SoftPwm/samples/SoftPwm.sample.cs
@@ -18,7 +18,7 @@ class Program
             pwmChannel.Start();
             for (double fill = 0.0; fill <= 1.0; fill += 0.01)
             {
-                pwmChannel.DutyCyclePercentage = fill;
+                pwmChannel.DutyCycle = fill;
                 Thread.Sleep(500);
             }
         }

--- a/tools/DevicesApiTester/Commands/Pwm/PwmCommand.cs
+++ b/tools/DevicesApiTester/Commands/Pwm/PwmCommand.cs
@@ -19,7 +19,7 @@ namespace DeviceApiTester.Commands.Pwm
         [Option('f', "frequency", HelpText = "The frequency in hertz.", Required = false, Default = 400)]
         public int Frequency { get; set; }
 
-        [Option('d', "dutycycle", HelpText = "The duty cycle percentage for PWM output from 0.0 - 1.0.", Required = false, Default = 0.5)]
-        public double DutyCyclePercentage { get; set; }
+        [Option('d', "dutycycle", HelpText = "The duty cycle for PWM output from 0.0 - 1.0.", Required = false, Default = 0.5)]
+        public double DutyCycle { get; set; }
     }
 }

--- a/tools/DevicesApiTester/Commands/Pwm/PwmPinOutput.cs
+++ b/tools/DevicesApiTester/Commands/Pwm/PwmPinOutput.cs
@@ -16,9 +16,9 @@ namespace DeviceApiTester.Commands.Pwm
         /// <returns>The command's exit code.</returns>
         public async Task<int> ExecuteAsync()
         {
-            using (var pwmChannel = System.Device.Pwm.PwmChannel.Create(Chip, Channel, Frequency, DutyCyclePercentage))
+            using (var pwmChannel = System.Device.Pwm.PwmChannel.Create(Chip, Channel, Frequency, DutyCycle))
             {
-                Console.WriteLine($"Chip={Chip}, Channel={Channel}, Frequency={Frequency}Hz, DC={DutyCyclePercentage}, Duration={Seconds}s");
+                Console.WriteLine($"Chip={Chip}, Channel={Channel}, Frequency={Frequency}Hz, DC={DutyCycle}, Duration={Seconds}s");
 
                 pwmChannel.Start();
                 await Task.Delay(TimeSpan.FromSeconds(Seconds));


### PR DESCRIPTION
Fixes: https://github.com/dotnet/iot/projects/4#card-25528890

`Percentage` suffix means that value will be multiplied by 0.01 (since `%=0.01`) which suggest that value is in range 0-100 which is not correct. Removing the suffix for correctness.