### PR TITLE
RgbLedMatrix: Allow drawing text outside of top drawing area

### DIFF
--- a/src/devices/RGBLedMatrix/RgbLedMatrix.cs
+++ b/src/devices/RGBLedMatrix/RgbLedMatrix.cs
@@ -468,7 +468,7 @@ namespace Iot.Device.LEDMatrix
             int charWidth = font.Width;
             int totalTextWith = charWidth * text.Length;
 
-            if (y < 0 || y >= Height || x >= Width || x + totalTextWith <= 0)
+            if (y <= -font.Height || y >= Height || x >= Width || x + totalTextWith <= 0)
             {
                 return;
             }


### PR DESCRIPTION
Currently drawing text is possible outside of drawing area at left, right and bottom edge but not at the top. This is fixing last edge. This allows scrolling text top bottom smoothly and also just trimming top part of the text by a pixel or two since it's most of the time blank anyway