### PR TITLE
Fixed typo in Nrf24l01 README

### DIFF
--- a/src/devices/Nrf24l01/README.md
+++ b/src/devices/Nrf24l01/README.md
@@ -47,7 +47,7 @@ private static void Receiver_ReceivedData(object sender, DataReceivedEventArgs e
     }
     Console.WriteLine();
 
-    Console.WriteLine($"Massage: {msg}");
+    Console.WriteLine($"Message: {msg}");
     Console.WriteLine();
 }
 ```


### PR DESCRIPTION
`Massage` -> `Message`