### PR TITLE
Change the Raspberry Pi detection logic.

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
@@ -31,25 +31,27 @@ namespace System.Device.Gpio
         /// <returns>A driver that works with the board the program is executing on.</returns>
         private static GpioDriver GetBestDriverForBoard()
         {
-            string[] cpuInfoLines = File.ReadAllLines(CpuInfoPath);
-            Regex regex = new Regex(@"Hardware\s*:\s*(.*)");
+            string[] cpuInfoLines;
+            Regex regex;
+
+            // a first chance of finding a raspberry pi..... perhaps not on Raspbian. note
+            // that we want this to fail quietly if something goes wrong with the test and continue
+            // with detecting a PI usiing /dev/cpuinfo
+            try
+            {
+                if (File.ReadAllText(ModelInfoPath).StartsWith("Raspberry Pi"))
+                {
+                    return new RaspberryPi3Driver();
+                }
+            }
+            catch { }
+
+            regex = new Regex(@"Hardware\s*:\s*(.*)");
+            cpuInfoLines = File.ReadAllLines(CpuInfoPath);
+
             foreach (string cpuInfoLine in cpuInfoLines)
             {
-                Match match;
-
-                // a first chance of finding a raspberry pi..... perhaps not on Raspbian. note
-                // that we want this to fail quietly if something goes wrong with the test and continue
-                // with detecing a PI usiing /dev/cpuinfo
-                try
-                {
-                    if (File.ReadAllText(ModelInfoPath).StartsWith("Raspberry Pi"))
-                    {
-                        return new RaspberryPi3Driver();
-                    }
-                }
-                catch { }
-
-                match = regex.Match(cpuInfoLine);
+                Match match = regex.Match(cpuInfoLine);
 
                 if (match.Success)
                 {

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
@@ -11,6 +11,7 @@ namespace System.Device.Gpio
     public sealed partial class GpioController
     {
         private const string CpuInfoPath = "/proc/cpuinfo";
+        private const string ModelInfoPath = "/proc/device-tree/model";
         private const string RaspberryPiHardware = "BCM2835";
         private const string HummingBoardHardware = @"Freescale i.MX6 Quad/DualLite (Device Tree)";
 
@@ -34,7 +35,22 @@ namespace System.Device.Gpio
             Regex regex = new Regex(@"Hardware\s*:\s*(.*)");
             foreach (string cpuInfoLine in cpuInfoLines)
             {
-                Match match = regex.Match(cpuInfoLine);
+                Match match;
+
+                // a first chance of finding a raspberry pi..... perhaps not on Raspbian. note
+                // that we want this to fail quietly if something goes wrong with the test and continue
+                // with detecing a PI usiing /dev/cpuinfo
+                try
+                {
+                    if (File.ReadAllText(ModelInfoPath).StartsWith("Raspberry Pi"))
+                    {
+                        return new RaspberryPi3Driver();
+                    }
+                }
+                catch { }
+
+                match = regex.Match(cpuInfoLine);
+
                 if (match.Success)
                 {
                     if (match.Groups.Count > 1)


### PR DESCRIPTION
Fixes #661

This PR aims to solve an issue with the detection of a raspberry pi within the GpioController.

At the moment the /dev/cpuinfo is read to identify the Pi but it seems that the Pi info is only made available within Raspbian.

To resolve this the detection mechanism is augmented by reading the device tree to find the Raspberry Pi identifier. If there are any issues with reading the device tree or the identifier is not found then it falls back to original detection logic.