### PR TITLE
New Pressure Unit

### DIFF
--- a/src/devices/Bmp180/Bmp180.cs
+++ b/src/devices/Bmp180/Bmp180.cs
@@ -101,9 +101,6 @@ namespace Iot.Device.Bmp180
         /// <summary>
         ///  Calculates the altitude in meters from the mean sea-level pressure.
         /// </summary>
-        /// <param name="seaLevelPressure"> 
-        ///  Sea-level pressure
-        /// </param>
         /// <returns>
         ///  Height in meters from the sensor
         /// </returns>

--- a/src/devices/Bmp180/Bmp180.cs
+++ b/src/devices/Bmp180/Bmp180.cs
@@ -81,7 +81,7 @@ namespace Iot.Device.Bmp180
             int p = (B7 < 0x80000000) ? (int)((B7 * 2) / B4) : (int)((B7 / B4) * 2);
             X1 = (((p * p) / 65536 ) * 3038) / 65536;
             
-            return Pressure.FromPa(p + ( ((((p * p) / 65536 ) * 3038) / 65536) + ((-7357 * p) / 65536) + 3791) / 8);
+            return Pressure.FromPascal(p + ( ((((p * p) / 65536 ) * 3038) / 65536) + ((-7357 * p) / 65536) + 3791) / 8);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Iot.Device.Bmp180
         /// </returns>
         public double ReadAltitude(Pressure seaLevelPressure)
         {
-            return 44330.0 * (1.0 - Math.Pow((ReadPressure().Pa / seaLevelPressure.Pa), (1.0 / 5.255)));
+            return 44330.0 * (1.0 - Math.Pow((ReadPressure().Pascal / seaLevelPressure.Pascal), (1.0 / 5.255)));
         }
         
         /// <summary>
@@ -120,7 +120,7 @@ namespace Iot.Device.Bmp180
         /// </returns>
         public Pressure ReadSeaLevelPressure(double altitude = 0.0)
         {
-            return Pressure.FromPa(ReadPressure().Pa / Math.Pow((1.0 - (altitude / 44333.0)), 5.255));
+            return Pressure.FromPascal(ReadPressure().Pascal / Math.Pow((1.0 - (altitude / 44333.0)), 5.255));
         }
 
         /// <summary>

--- a/src/devices/Bmp180/Bmp180.cs
+++ b/src/devices/Bmp180/Bmp180.cs
@@ -93,9 +93,23 @@ namespace Iot.Device.Bmp180
         /// <returns>
         ///  Height in meters from the sensor
         /// </returns>
-        public double ReadAltitude(Pressure seaLevelPressure = Pressure.MeanSeaLevel)
+        public double ReadAltitude(Pressure seaLevelPressure)
         {
             return 44330.0 * (1.0 - Math.Pow((ReadPressure().Pa / seaLevelPressure.Pa), (1.0 / 5.255)));
+        }
+        
+        /// <summary>
+        ///  Calculates the altitude in meters from the mean sea-level pressure.
+        /// </summary>
+        /// <param name="seaLevelPressure"> 
+        ///  Sea-level pressure
+        /// </param>
+        /// <returns>
+        ///  Height in meters from the sensor
+        /// </returns>
+        public double ReadAltitude()
+        {
+            return ReadAltitude(Pressure.MeanSeaLevel);
         }
 
         /// <summary>

--- a/src/devices/Bmp180/Bmp180.cs
+++ b/src/devices/Bmp180/Bmp180.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -64,9 +64,9 @@ namespace Iot.Device.Bmp180
         ///  Reads the pressure from the sensor
         /// </summary>
         /// <returns>
-        ///  Atmospheric pressure in Pa
+        ///  Atmospheric pressure
         /// </returns>
-        public double ReadPressure()
+        public Pressure ReadPressure()
         {
             // Pressure Calculations
             int B6 = CalculateTrueTemperature() - 4000;
@@ -81,21 +81,21 @@ namespace Iot.Device.Bmp180
             int p = (B7 < 0x80000000) ? (int)((B7 * 2) / B4) : (int)((B7 / B4) * 2);
             X1 = (((p * p) / 65536 ) * 3038) / 65536;
             
-            return p + ( ((((p * p) / 65536 ) * 3038) / 65536) + ((-7357 * p) / 65536) + 3791) / 8;
+            return Pressure.FromPa(p + ( ((((p * p) / 65536 ) * 3038) / 65536) + ((-7357 * p) / 65536) + 3791) / 8);
         }
 
         /// <summary>
-        ///  Calculates the altitude in meters from the specified sea-level pressure(in hPa).
+        ///  Calculates the altitude in meters from the specified sea-level pressure.
         /// </summary>
         /// <param name="seaLevelPressure"> 
-        ///  Sea-level pressure in hPa
+        ///  Sea-level pressure
         /// </param>
         /// <returns>
         ///  Height in meters from the sensor
         /// </returns>
-        public double ReadAltitude(double seaLevelPressure = 101325.0)
+        public double ReadAltitude(Pressure seaLevelPressure = Pressure.MeanSeaLevel)
         {
-            return 44330.0 * (1.0 - Math.Pow(((double)ReadPressure() / seaLevelPressure), (1.0 / 5.255)));
+            return 44330.0 * (1.0 - Math.Pow((ReadPressure().Pa / seaLevelPressure.Pa), (1.0 / 5.255)));
         }
 
         /// <summary>
@@ -105,11 +105,11 @@ namespace Iot.Device.Bmp180
         ///  altitude in meters
         /// </param>
         /// <returns>
-        ///  Pressure in Pascals
+        ///  Pressure
         /// </returns>
-        public double ReadSeaLevelPressure(double altitude = 0.0)
+        public Pressure ReadSeaLevelPressure(double altitude = 0.0)
         {
-            return (double)ReadPressure() / Math.Pow((1.0 - (altitude / 44333.0)), 5.255);
+            return Pressure.FromPa(ReadPressure().Pa / Math.Pow((1.0 - (altitude / 44333.0)), 5.255));
         }
 
         /// <summary>

--- a/src/devices/Bmp180/samples/Bmp180.Sample.cs
+++ b/src/devices/Bmp180/samples/Bmp180.Sample.cs
@@ -31,8 +31,8 @@ namespace Iot.Device.Bmp180.Samples
                 //read values
                 Temperature tempValue = i2cBmp280.ReadTemperature();
                 Console.WriteLine($"Temperature {tempValue.Celsius} °C");
-                double preValue = i2cBmp280.ReadPressure();
-                Console.WriteLine($"Pressure {preValue} Pa");
+                var preValue = i2cBmp280.ReadPressure();
+                Console.WriteLine($"Pressure {preValue.Pa} Pa");
                 double altValue = i2cBmp280.ReadAltitude();
                 Console.WriteLine($"Altitude {altValue:0.##} m");
                 Thread.Sleep(1000);
@@ -44,7 +44,7 @@ namespace Iot.Device.Bmp180.Samples
                 tempValue = i2cBmp280.ReadTemperature();
                 Console.WriteLine($"Temperature {tempValue.Celsius} °C");
                 preValue = i2cBmp280.ReadPressure();
-                Console.WriteLine($"Pressure {preValue} Pa");
+                Console.WriteLine($"Pressure {preValue.Pa} Pa");
                 altValue = i2cBmp280.ReadAltitude();
                 Console.WriteLine($"Altitude {altValue:0.##} m");
             }

--- a/src/devices/Bmp180/samples/Bmp180.Sample.cs
+++ b/src/devices/Bmp180/samples/Bmp180.Sample.cs
@@ -32,7 +32,7 @@ namespace Iot.Device.Bmp180.Samples
                 Temperature tempValue = i2cBmp280.ReadTemperature();
                 Console.WriteLine($"Temperature {tempValue.Celsius} °C");
                 var preValue = i2cBmp280.ReadPressure();
-                Console.WriteLine($"Pressure {preValue.Pascal} Pa");
+                Console.WriteLine($"Pressure {preValue.Hectopascal} hPa");
                 double altValue = i2cBmp280.ReadAltitude();
                 Console.WriteLine($"Altitude {altValue:0.##} m");
                 Thread.Sleep(1000);
@@ -44,7 +44,7 @@ namespace Iot.Device.Bmp180.Samples
                 tempValue = i2cBmp280.ReadTemperature();
                 Console.WriteLine($"Temperature {tempValue.Celsius} °C");
                 preValue = i2cBmp280.ReadPressure();
-                Console.WriteLine($"Pressure {preValue.Pascal} Pa");
+                Console.WriteLine($"Pressure {preValue.Hectopascal} hPa");
                 altValue = i2cBmp280.ReadAltitude();
                 Console.WriteLine($"Altitude {altValue:0.##} m");
             }

--- a/src/devices/Bmp180/samples/Bmp180.Sample.cs
+++ b/src/devices/Bmp180/samples/Bmp180.Sample.cs
@@ -30,7 +30,7 @@ namespace Iot.Device.Bmp180.Samples
 
                 //read values
                 Temperature tempValue = i2cBmp280.ReadTemperature();
-                Console.WriteLine($"Temperature {tempValue.Celsius} °C");
+                Console.WriteLine($"Temperature {tempValue.Celsius} \u00B0C");
                 var preValue = i2cBmp280.ReadPressure();
                 Console.WriteLine($"Pressure {preValue.Hectopascal} hPa");
                 double altValue = i2cBmp280.ReadAltitude();
@@ -42,7 +42,7 @@ namespace Iot.Device.Bmp180.Samples
 
                 //read values
                 tempValue = i2cBmp280.ReadTemperature();
-                Console.WriteLine($"Temperature {tempValue.Celsius} °C");
+                Console.WriteLine($"Temperature {tempValue.Celsius} \u00B0C");
                 preValue = i2cBmp280.ReadPressure();
                 Console.WriteLine($"Pressure {preValue.Hectopascal} hPa");
                 altValue = i2cBmp280.ReadAltitude();

--- a/src/devices/Bmp180/samples/Bmp180.Sample.cs
+++ b/src/devices/Bmp180/samples/Bmp180.Sample.cs
@@ -32,7 +32,7 @@ namespace Iot.Device.Bmp180.Samples
                 Temperature tempValue = i2cBmp280.ReadTemperature();
                 Console.WriteLine($"Temperature {tempValue.Celsius} °C");
                 var preValue = i2cBmp280.ReadPressure();
-                Console.WriteLine($"Pressure {preValue.Pa} Pa");
+                Console.WriteLine($"Pressure {preValue.Pascal} Pa");
                 double altValue = i2cBmp280.ReadAltitude();
                 Console.WriteLine($"Altitude {altValue:0.##} m");
                 Thread.Sleep(1000);
@@ -44,7 +44,7 @@ namespace Iot.Device.Bmp180.Samples
                 tempValue = i2cBmp280.ReadTemperature();
                 Console.WriteLine($"Temperature {tempValue.Celsius} °C");
                 preValue = i2cBmp280.ReadPressure();
-                Console.WriteLine($"Pressure {preValue.Pa} Pa");
+                Console.WriteLine($"Pressure {preValue.Pascal} Pa");
                 altValue = i2cBmp280.ReadAltitude();
                 Console.WriteLine($"Altitude {altValue:0.##} m");
             }

--- a/src/devices/Bmxx80/Bme680.cs
+++ b/src/devices/Bmxx80/Bme680.cs
@@ -336,7 +336,7 @@ namespace Iot.Device.Bmxx80
         {
             if (PressureSampling == Sampling.Skipped)
             {
-                pressure = Pressure.FromPa(double.NaN);
+                pressure = Pressure.FromPascal(double.NaN);
                 return false;
             }
                 
@@ -478,7 +478,7 @@ namespace Iot.Device.Bmxx80
                 calculatedPressure = 0;
             }
 
-            return Pressure.FromPa(calculatedPressure);
+            return Pressure.FromPascal(calculatedPressure);
         }
 
         private bool ReadGasMeasurementIsValid()

--- a/src/devices/Bmxx80/Bme680.cs
+++ b/src/devices/Bmxx80/Bme680.cs
@@ -347,7 +347,7 @@ namespace Iot.Device.Bmxx80
             // Read the temperature first to load the t_fine value for compensation.
             TryReadTemperature(out _);
 
-            pressure = Pressure.FromPa(CompensatePressure(press >> 4));
+            pressure = CompensatePressure(press >> 4);
             return true;
         }
 
@@ -452,7 +452,7 @@ namespace Iot.Device.Bmxx80
         /// </summary>
         /// <param name="adcPressure">The pressure value read from the device.</param>
         /// <returns>The pressure in Pa.</returns>
-        private double CompensatePressure(long adcPressure)
+        private Pressure CompensatePressure(long adcPressure)
         {
             // Calculate the pressure.
             var var1 = (TemperatureFine / 2.0) - 64000.0;

--- a/src/devices/Bmxx80/Bme680.cs
+++ b/src/devices/Bmxx80/Bme680.cs
@@ -452,7 +452,7 @@ namespace Iot.Device.Bmxx80
         /// </summary>
         /// <param name="adcPressure">The pressure value read from the device.</param>
         /// <returns>The pressure in Pa.</returns>
-        private double CompensatePressure(Pressure adcPressure)
+        private double CompensatePressure(long adcPressure)
         {
             // Calculate the pressure.
             var var1 = (TemperatureFine / 2.0) - 64000.0;
@@ -461,7 +461,7 @@ namespace Iot.Device.Bmxx80
             var2 = (var2 / 4.0) + (_bme680Calibration.DigP4 * 65536.0);
             var1 = ((_bme680Calibration.DigP3 * var1 * var1 / 16384.0) + (_bme680Calibration.DigP2 * var1)) / 524288.0;
             var1 = (1.0 + (var1 / 32768.0)) * _bme680Calibration.DigP1;
-            var calculatedPressure = 1048576.0 - adcPressure.Pa;
+            var calculatedPressure = 1048576.0 - adcPressure;
 
             // Avoid exception caused by division by zero.
             if (var1 != 0)

--- a/src/devices/Bmxx80/Bme680.cs
+++ b/src/devices/Bmxx80/Bme680.cs
@@ -347,7 +347,7 @@ namespace Iot.Device.Bmxx80
             // Read the temperature first to load the t_fine value for compensation.
             TryReadTemperature(out _);
 
-            pressure = CompensatePressure(press >> 4);
+            pressure = Pressure.FromPa(CompensatePressure(press >> 4));
             return true;
         }
 

--- a/src/devices/Bmxx80/Bme680.cs
+++ b/src/devices/Bmxx80/Bme680.cs
@@ -328,15 +328,15 @@ namespace Iot.Device.Bmxx80
         /// Reads the pressure. A return value indicates whether the reading succeeded.
         /// </summary>
         /// <param name="pressure">
-        /// Contains the measured pressure in Pa if the <see cref="Bmxx80Base.PressureSampling"/> was not set to <see cref="Sampling.Skipped"/>.
+        /// Contains the measured pressure if the <see cref="Bmxx80Base.PressureSampling"/> was not set to <see cref="Sampling.Skipped"/>.
         /// Contains <see cref="double.NaN"/> otherwise.
         /// </param>
         /// <returns><code>true</code> if measurement was not skipped, otherwise <code>false</code>.</returns>
-        public override bool TryReadPressure(out double pressure)
+        public override bool TryReadPressure(out Pressure pressure)
         {
             if (PressureSampling == Sampling.Skipped)
             {
-                pressure = double.NaN;
+                pressure = Pressure.FromPa(double.NaN);
                 return false;
             }
                 
@@ -452,7 +452,7 @@ namespace Iot.Device.Bmxx80
         /// </summary>
         /// <param name="adcPressure">The pressure value read from the device.</param>
         /// <returns>The pressure in Pa.</returns>
-        private double CompensatePressure(int adcPressure)
+        private double CompensatePressure(Pressure adcPressure)
         {
             // Calculate the pressure.
             var var1 = (TemperatureFine / 2.0) - 64000.0;
@@ -461,7 +461,7 @@ namespace Iot.Device.Bmxx80
             var2 = (var2 / 4.0) + (_bme680Calibration.DigP4 * 65536.0);
             var1 = ((_bme680Calibration.DigP3 * var1 * var1 / 16384.0) + (_bme680Calibration.DigP2 * var1)) / 524288.0;
             var1 = (1.0 + (var1 / 32768.0)) * _bme680Calibration.DigP1;
-            var calculatedPressure = 1048576.0 - adcPressure;
+            var calculatedPressure = 1048576.0 - adcPressure.Pa;
 
             // Avoid exception caused by division by zero.
             if (var1 != 0)
@@ -478,7 +478,7 @@ namespace Iot.Device.Bmxx80
                 calculatedPressure = 0;
             }
 
-            return calculatedPressure;
+            return Pressure.FromPa(calculatedPressure);
         }
 
         private bool ReadGasMeasurementIsValid()

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -153,7 +153,7 @@ namespace Iot.Device.Bmxx80
             var press = (int)Read24BitsFromRegister((byte)Bmx280Register.PRESSUREDATA, Endianness.BigEndian);
 
             //Convert the raw value to the pressure in Pa.
-            var pressPa = CompensatePressure(Pressure.FromPa(press >> 4));
+            var pressPa = CompensatePressure(press >> 4);
 
             //Return the pressure as a Pressure instance.
             pressure = Pressure.FromHpa(pressPa.Hpa / 256);
@@ -260,7 +260,7 @@ namespace Iot.Device.Bmxx80
         /// <remarks>
         /// Output value of “24674867” represents 24674867/256 = 96386.2 Pa = 963.862 hPa.
         /// </remarks>
-        private Pressure CompensatePressure(Pressure adcPressure)
+        private Pressure CompensatePressure(long adcPressure)
         {
             // Formula from the datasheet http://www.adafruit.com/datasheets/BST-BMP280-DS001-11.pdf
             // The pressure is calculated using the compensation formula in the BMP280 datasheet
@@ -275,7 +275,7 @@ namespace Iot.Device.Bmxx80
                 return 0; //Avoid exception caused by division by zero
             }
             //Perform calibration operations
-            long p = 1048576 - Convert.ToInt64(adcPressure.Pa);
+            long p = 1048576 - adcPressure;
             p = (((p << 31) - var2) * 3125) / var1;
             var1 = ((long)_calibrationData.DigP9 * (p >> 13) * (p >> 13)) >> 25;
             var2 = ((long)_calibrationData.DigP8 * p) >> 19;

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -138,7 +138,7 @@ namespace Iot.Device.Bmxx80
         /// Contains <see cref="double.NaN"/> otherwise.
         /// </param>
         /// <returns><code>true</code> if measurement was not skipped, otherwise <code>false</code>.</returns>
-        public override bool TryReadPressure(out double pressure)
+        public override bool TryReadPressure(out Pressure pressure)
         {
             if (PressureSampling == Sampling.Skipped)
             {
@@ -156,7 +156,7 @@ namespace Iot.Device.Bmxx80
             long pressPa = CompensatePressure(press >> 4);
 
             //Return the temperature as a float value.
-            pressure = (double)pressPa / 256;
+            pressure = Pressure.FromHpa((double)pressPa / 256);
             return true;
         }
 
@@ -197,7 +197,7 @@ namespace Iot.Device.Bmxx80
         /// <returns><code>true</code> if pressure measurement was not skipped, otherwise <code>false</code>.</returns>
         public bool TryReadAltitude(out double altitude)
         {
-            return TryReadAltitude(Iot.Units.Pressure.MeanSeaLevelPressure, out altitude);
+            return TryReadAltitude((new Iot.Units.Pressure()).MeanSeaLevel.Hpa, out altitude);
         }
 
         /// <summary>

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -272,7 +272,7 @@ namespace Iot.Device.Bmxx80
             var1 = (((((long)1 << 47) + var1)) * (long)_calibrationData.DigP1) >> 33;
             if (var1 == 0)
             {
-                return Pressure.FromPa(0); //Avoid exception caused by division by zero
+                return Pressure.FromPascal(0); //Avoid exception caused by division by zero
             }
             //Perform calibration operations
             long p = 1048576 - adcPressure;

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -156,7 +156,7 @@ namespace Iot.Device.Bmxx80
             var pressPa = CompensatePressure(press >> 4);
 
             //Return the pressure as a Pressure instance.
-            pressure = Pressure.FromHpa(pressPa.Pa / 25600);
+            pressure = Pressure.FromHpa(pressPa.Hpa / 256);
             return true;
         }
 
@@ -275,7 +275,7 @@ namespace Iot.Device.Bmxx80
                 return 0; //Avoid exception caused by division by zero
             }
             //Perform calibration operations
-            long p = 1048576 - adcPressure.Pa;
+            long p = 1048576 - Convert.ToInt64(adcPressure.Pa);
             p = (((p << 31) - var2) * 3125) / var1;
             var1 = ((long)_calibrationData.DigP9 * (p >> 13) * (p >> 13)) >> 25;
             var2 = ((long)_calibrationData.DigP8 * p) >> 19;

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -156,7 +156,7 @@ namespace Iot.Device.Bmxx80
             var pressPa = CompensatePressure(press >> 4);
 
             //Return the pressure as a Pressure instance.
-            pressure = Pressure.FromHectoPascal(pressPa.HectoPascal / 256);
+            pressure = Pressure.FromHectopascal(pressPa.Hectopascal / 256);
             return true;
         }
 
@@ -180,7 +180,7 @@ namespace Iot.Device.Bmxx80
             }
 
             // Calculate and return the altitude using the international barometric formula.
-            altitude = 44330.0 * (1.0 - Math.Pow(pressure.HectoPascal / seaLevelPressure.HectoPascal, 0.1903));
+            altitude = 44330.0 * (1.0 - Math.Pow(pressure.Hectopascal / seaLevelPressure.Hectopascal, 0.1903));
             return true;
         }        
         

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -163,7 +163,7 @@ namespace Iot.Device.Bmxx80
         /// <summary>
         /// Calculates the altitude in meters from the specified sea-level pressure(in hPa).
         /// </summary>
-        /// <param name="seaLevelPressure">Sea-level pressure in hPa.</param>
+        /// <param name="seaLevelPressure">Sea-level pressure</param>
         /// <param name="altitude">
         /// Contains the calculated metres above sea-level if the <see cref="Bmxx80Base.PressureSampling"/> was not set to <see cref="Sampling.Skipped"/>.
         /// Contains <see cref="double.NaN"/> otherwise.
@@ -194,7 +194,7 @@ namespace Iot.Device.Bmxx80
         /// <returns><code>true</code> if pressure measurement was not skipped, otherwise <code>false</code>.</returns>
         public bool TryReadAltitude(out double altitude)
         {
-            return TryReadAltitude(Pressure.MeanSeaLevel.Hpa, out altitude);
+            return TryReadAltitude(Pressure.MeanSeaLevel, out altitude);
         }
 
         /// <summary>
@@ -260,7 +260,7 @@ namespace Iot.Device.Bmxx80
         /// <remarks>
         /// Output value of “24674867” represents 24674867/256 = 96386.2 Pa = 963.862 hPa.
         /// </remarks>
-        private Pressure CompensatePressure(int adcPressure)
+        private Pressure CompensatePressure(Pressure adcPressure)
         {
             // Formula from the datasheet http://www.adafruit.com/datasheets/BST-BMP280-DS001-11.pdf
             // The pressure is calculated using the compensation formula in the BMP280 datasheet
@@ -275,7 +275,7 @@ namespace Iot.Device.Bmxx80
                 return 0; //Avoid exception caused by division by zero
             }
             //Perform calibration operations
-            long p = 1048576 - adcPressure;
+            long p = 1048576 - adcPressure.Pa;
             p = (((p << 31) - var2) * 3125) / var1;
             var1 = ((long)_calibrationData.DigP9 * (p >> 13) * (p >> 13)) >> 25;
             var2 = ((long)_calibrationData.DigP8 * p) >> 19;

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -156,7 +156,7 @@ namespace Iot.Device.Bmxx80
             var pressPa = CompensatePressure(press >> 4);
 
             //Return the pressure as a Pressure instance.
-            pressure = Pressure.FromPa(pressPa.Pa / 256);
+            pressure = Pressure.FromHpa(pressPa.Pa / 25600);
             return true;
         }
 

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -142,7 +142,7 @@ namespace Iot.Device.Bmxx80
         {
             if (PressureSampling == Sampling.Skipped)
             {
-                pressure = double.NaN;
+                pressure = Pressure.FromPa(double.NaN);
                 return false;
             }
 

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -153,7 +153,7 @@ namespace Iot.Device.Bmxx80
             var press = (int)Read24BitsFromRegister((byte)Bmx280Register.PRESSUREDATA, Endianness.BigEndian);
 
             //Convert the raw value to the pressure in Pa.
-            var pressPa = CompensatePressure(press >> 4);
+            var pressPa = CompensatePressure(Pressure.FromPa(press >> 4));
 
             //Return the pressure as a Pressure instance.
             pressure = Pressure.FromHpa(pressPa.Hpa / 256);

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -272,7 +272,7 @@ namespace Iot.Device.Bmxx80
             var1 = (((((long)1 << 47) + var1)) * (long)_calibrationData.DigP1) >> 33;
             if (var1 == 0)
             {
-                return 0; //Avoid exception caused by division by zero
+                return Pressure.FromPa(0); //Avoid exception caused by division by zero
             }
             //Perform calibration operations
             long p = 1048576 - adcPressure;

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -142,7 +142,7 @@ namespace Iot.Device.Bmxx80
         {
             if (PressureSampling == Sampling.Skipped)
             {
-                pressure = Pressure.FromPa(double.NaN);
+                pressure = Pressure.FromPascal(double.NaN);
                 return false;
             }
 
@@ -156,7 +156,7 @@ namespace Iot.Device.Bmxx80
             var pressPa = CompensatePressure(press >> 4);
 
             //Return the pressure as a Pressure instance.
-            pressure = Pressure.FromHpa(pressPa.Hpa / 256);
+            pressure = Pressure.FromHectoPascal(pressPa.HectoPascal / 256);
             return true;
         }
 
@@ -180,7 +180,7 @@ namespace Iot.Device.Bmxx80
             }
 
             // Calculate and return the altitude using the international barometric formula.
-            altitude = 44330.0 * (1.0 - Math.Pow(pressure.Hpa / seaLevelPressure.Hpa, 0.1903));
+            altitude = 44330.0 * (1.0 - Math.Pow(pressure.HectoPascal / seaLevelPressure.HectoPascal, 0.1903));
             return true;
         }        
         
@@ -281,7 +281,7 @@ namespace Iot.Device.Bmxx80
             var2 = ((long)_calibrationData.DigP8 * p) >> 19;
             p = ((p + var1 + var2) >> 8) + ((long)_calibrationData.DigP7 << 4);
 
-            return Pressure.FromPa(p);
+            return Pressure.FromPascal(p);
         }
     }
 }

--- a/src/devices/Bmxx80/Bmxx80Base.cs
+++ b/src/devices/Bmxx80/Bmxx80Base.cs
@@ -148,11 +148,11 @@ namespace Iot.Device.Bmxx80
         /// Reads the pressure. A return value indicates whether the reading succeeded.
         /// </summary>
         /// <param name="pressure">
-        /// Contains the measured pressure in Pa if the <see cref="PressureSampling"/> was not set to <see cref="Sampling.Skipped"/>.
+        /// Contains the measured pressure if the <see cref="PressureSampling"/> was not set to <see cref="Sampling.Skipped"/>.
         /// Contains <see cref="double.NaN"/> otherwise.
         /// </param>
         /// <returns><code>true</code> if measurement was not skipped, otherwise <code>false</code>.</returns>
-        public abstract bool TryReadPressure(out double pressure);
+        public abstract bool TryReadPressure(out Pressure pressure);
 
         /// <summary>
         /// Compensates the temperature.

--- a/src/devices/Bmxx80/samples/Bme280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme280.sample.cs
@@ -47,7 +47,7 @@ namespace Iot.Device.Samples
                     i2CBmpe80.TryReadTemperature(out var tempValue);
                     Console.WriteLine($"Temperature: {tempValue.Celsius} C");
                     i2CBmpe80.TryReadPressure(out var preValue);
-                    Console.WriteLine($"Pressure: {preValue.Pa} Pa");
+                    Console.WriteLine($"Pressure: {preValue.Pascal} Pa");
                     i2CBmpe80.TryReadAltitude(defaultSeaLevelPressure, out var altValue);
                     Console.WriteLine($"Altitude: {altValue} meters");
                     i2CBmpe80.TryReadHumidity(out var humValue);
@@ -71,7 +71,7 @@ namespace Iot.Device.Samples
                     i2CBmpe80.TryReadTemperature(out tempValue);
                     Console.WriteLine($"Temperature: {tempValue.Celsius} C");
                     i2CBmpe80.TryReadPressure(out preValue);
-                    Console.WriteLine($"Pressure: {preValue.Pa} Pa");
+                    Console.WriteLine($"Pressure: {preValue.Pascal} Pa");
                     i2CBmpe80.TryReadAltitude(defaultSeaLevelPressure, out altValue);
                     Console.WriteLine($"Altitude: {altValue} meters");
                     i2CBmpe80.TryReadHumidity(out humValue);

--- a/src/devices/Bmxx80/samples/Bme280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme280.sample.cs
@@ -45,7 +45,7 @@ namespace Iot.Device.Samples
 
                     //read values
                     i2CBmpe80.TryReadTemperature(out var tempValue);
-                    Console.WriteLine($"Temperature: {tempValue.Celsius} °C");
+                    Console.WriteLine($"Temperature: {tempValue.Celsius} \u00B0C");
                     i2CBmpe80.TryReadPressure(out var preValue);
                     Console.WriteLine($"Pressure: {preValue.Hectopascal} hPa");
                     i2CBmpe80.TryReadAltitude(defaultSeaLevelPressure, out var altValue);
@@ -69,7 +69,7 @@ namespace Iot.Device.Samples
 
                     //read values
                     i2CBmpe80.TryReadTemperature(out tempValue);
-                    Console.WriteLine($"Temperature: {tempValue.Celsius} °C");
+                    Console.WriteLine($"Temperature: {tempValue.Celsius} \u00B0C");
                     i2CBmpe80.TryReadPressure(out preValue);
                     Console.WriteLine($"Pressure: {preValue.Hectopascal} hPa");
                     i2CBmpe80.TryReadAltitude(defaultSeaLevelPressure, out altValue);

--- a/src/devices/Bmxx80/samples/Bme280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme280.sample.cs
@@ -45,9 +45,9 @@ namespace Iot.Device.Samples
 
                     //read values
                     i2CBmpe80.TryReadTemperature(out var tempValue);
-                    Console.WriteLine($"Temperature: {tempValue.Celsius} C");
+                    Console.WriteLine($"Temperature: {tempValue.Celsius} °C");
                     i2CBmpe80.TryReadPressure(out var preValue);
-                    Console.WriteLine($"Pressure: {preValue.Pascal} Pa");
+                    Console.WriteLine($"Pressure: {preValue.Hectopascal} hPa");
                     i2CBmpe80.TryReadAltitude(defaultSeaLevelPressure, out var altValue);
                     Console.WriteLine($"Altitude: {altValue} meters");
                     i2CBmpe80.TryReadHumidity(out var humValue);
@@ -69,9 +69,9 @@ namespace Iot.Device.Samples
 
                     //read values
                     i2CBmpe80.TryReadTemperature(out tempValue);
-                    Console.WriteLine($"Temperature: {tempValue.Celsius} C");
+                    Console.WriteLine($"Temperature: {tempValue.Celsius} °C");
                     i2CBmpe80.TryReadPressure(out preValue);
-                    Console.WriteLine($"Pressure: {preValue.Pascal} Pa");
+                    Console.WriteLine($"Pressure: {preValue.Hectopascal} hPa");
                     i2CBmpe80.TryReadAltitude(defaultSeaLevelPressure, out altValue);
                     Console.WriteLine($"Altitude: {altValue} meters");
                     i2CBmpe80.TryReadHumidity(out humValue);

--- a/src/devices/Bmxx80/samples/Bme280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme280.sample.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Iot.Device.Bmxx80;
 using Iot.Device.Bmxx80.FilteringMode;
 using Iot.Device.Bmxx80.PowerMode;
+using IoT.Units;
 
 namespace Iot.Device.Samples
 {
@@ -20,7 +21,7 @@ namespace Iot.Device.Samples
             //bus id on the raspberry pi 3
             const int busId = 1;
             //set this to the current sea level pressure in the area for correct altitude readings
-            const double defaultSeaLevelPressure = Iot.Units.Pressure.MeanSeaLevelPressure;
+            var defaultSeaLevelPressure = Pressure.MeanSeaLevel;
 
             var i2cSettings = new I2cConnectionSettings(busId, Bme280.DefaultI2cAddress);
             var i2cDevice = I2cDevice.Create(i2cSettings);
@@ -46,7 +47,7 @@ namespace Iot.Device.Samples
                     i2CBmpe80.TryReadTemperature(out var tempValue);
                     Console.WriteLine($"Temperature: {tempValue.Celsius} C");
                     i2CBmpe80.TryReadPressure(out var preValue);
-                    Console.WriteLine($"Pressure: {preValue} Pa");
+                    Console.WriteLine($"Pressure: {preValue.Pa} Pa");
                     i2CBmpe80.TryReadAltitude(defaultSeaLevelPressure, out var altValue);
                     Console.WriteLine($"Altitude: {altValue} meters");
                     i2CBmpe80.TryReadHumidity(out var humValue);
@@ -70,7 +71,7 @@ namespace Iot.Device.Samples
                     i2CBmpe80.TryReadTemperature(out tempValue);
                     Console.WriteLine($"Temperature: {tempValue.Celsius} C");
                     i2CBmpe80.TryReadPressure(out preValue);
-                    Console.WriteLine($"Pressure: {preValue} Pa");
+                    Console.WriteLine($"Pressure: {preValue.Pa} Pa");
                     i2CBmpe80.TryReadAltitude(defaultSeaLevelPressure, out altValue);
                     Console.WriteLine($"Altitude: {altValue} meters");
                     i2CBmpe80.TryReadHumidity(out humValue);

--- a/src/devices/Bmxx80/samples/Bme280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme280.sample.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using Iot.Device.Bmxx80;
 using Iot.Device.Bmxx80.FilteringMode;
 using Iot.Device.Bmxx80.PowerMode;
-using IoT.Units;
+using Iot.Units;
 
 namespace Iot.Device.Samples
 {

--- a/src/devices/Bmxx80/samples/Bme680.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme680.sample.cs
@@ -26,9 +26,9 @@ namespace Iot.Device.Samples
             const int busId = 1;
 
             var i2cSettings = new I2cConnectionSettings(busId, Bme680.DefaultI2cAddress);
-            var unixI2cDevice = I2cDevice.Create(i2cSettings);
+            var i2cDevice = I2cDevice.Create(i2cSettings);
 
-            using (var bme680 = new Bme680(unixI2cDevice))
+            using (var bme680 = new Bme680(i2cDevice))
             {
                 while (true)
                 {

--- a/src/devices/Bmxx80/samples/Bme680.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme680.sample.cs
@@ -50,7 +50,7 @@ namespace Iot.Device.Samples
                         bme680.TryReadHumidity(out var humidity);
                         bme680.TryReadGasResistance(out var gasResistance);
 
-                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.Hectopascal:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
+                        Console.WriteLine($"{temperature.Celsius:N2} \u00B0C | {pressure.Hectopascal:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
 
                         // when measuring the gas resistance on each cycle it is important to wait a certain interval
                         // because a heating plate is activated which will heat up the sensor without sleep, this can
@@ -81,7 +81,7 @@ namespace Iot.Device.Samples
                         bme680.TryReadHumidity(out var humidity);
                         bme680.TryReadGasResistance(out var gasResistance);
 
-                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.Hectopascal:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
+                        Console.WriteLine($"{temperature.Celsius:N2} \u00B0C | {pressure.Hectopascal:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
                         Thread.Sleep(1000);
                     }
 

--- a/src/devices/Bmxx80/samples/Bme680.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme680.sample.cs
@@ -50,7 +50,7 @@ namespace Iot.Device.Samples
                         bme680.TryReadHumidity(out var humidity);
                         bme680.TryReadGasResistance(out var gasResistance);
 
-                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure / 100:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
+                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.Hpa:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
 
                         // when measuring the gas resistance on each cycle it is important to wait a certain interval
                         // because a heating plate is activated which will heat up the sensor without sleep, this can
@@ -81,7 +81,7 @@ namespace Iot.Device.Samples
                         bme680.TryReadHumidity(out var humidity);
                         bme680.TryReadGasResistance(out var gasResistance);
 
-                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure / 100:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
+                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.Hpa:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
                         Thread.Sleep(1000);
                     }
 

--- a/src/devices/Bmxx80/samples/Bme680.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme680.sample.cs
@@ -50,7 +50,7 @@ namespace Iot.Device.Samples
                         bme680.TryReadHumidity(out var humidity);
                         bme680.TryReadGasResistance(out var gasResistance);
 
-                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.HectoPascal:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
+                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.Hectopascal:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
 
                         // when measuring the gas resistance on each cycle it is important to wait a certain interval
                         // because a heating plate is activated which will heat up the sensor without sleep, this can
@@ -81,7 +81,7 @@ namespace Iot.Device.Samples
                         bme680.TryReadHumidity(out var humidity);
                         bme680.TryReadGasResistance(out var gasResistance);
 
-                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.HectoPascal:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
+                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.Hectopascal:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
                         Thread.Sleep(1000);
                     }
 

--- a/src/devices/Bmxx80/samples/Bme680.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme680.sample.cs
@@ -50,7 +50,7 @@ namespace Iot.Device.Samples
                         bme680.TryReadHumidity(out var humidity);
                         bme680.TryReadGasResistance(out var gasResistance);
 
-                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.Hpa:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
+                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.HectoPascal:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
 
                         // when measuring the gas resistance on each cycle it is important to wait a certain interval
                         // because a heating plate is activated which will heat up the sensor without sleep, this can
@@ -81,7 +81,7 @@ namespace Iot.Device.Samples
                         bme680.TryReadHumidity(out var humidity);
                         bme680.TryReadGasResistance(out var gasResistance);
 
-                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.Hpa:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
+                        Console.WriteLine($"{temperature.Celsius:N2} °c | {pressure.HectoPascal:N2} hPa | {humidity:N2} %rH | {gasResistance:N2} Ohm");
                         Thread.Sleep(1000);
                     }
 

--- a/src/devices/Bmxx80/samples/Bmp280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bmp280.sample.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Iot.Device.Bmxx80;
 using Iot.Device.Bmxx80.FilteringMode;
 using Iot.Device.Bmxx80.PowerMode;
+using Iot.Units;
 
 namespace Iot.Device.Samples
 {
@@ -20,7 +21,7 @@ namespace Iot.Device.Samples
             //bus id on the raspberry pi 3
             const int busId = 1;
             //set this to the current sea level pressure in the area for correct altitude readings
-            const double defaultSeaLevelPressure = 1033.00;
+            var defaultSeaLevelPressure = Pressure.MeanSeaLevel;
 
             var i2cSettings = new I2cConnectionSettings(busId, Bmp280.DefaultI2cAddress);
             var i2cDevice = I2cDevice.Create(i2cSettings);

--- a/src/devices/Bmxx80/samples/Bmp280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bmp280.sample.cs
@@ -44,11 +44,11 @@ namespace Iot.Device.Samples
 
                     //read values
                     i2CBmp280.TryReadTemperature(out var tempValue);
-                    Console.WriteLine($"Temperature {tempValue.Celsius}");
+                    Console.WriteLine($"Temperature: {tempValue.Celsius} °C");
                     i2CBmp280.TryReadPressure(out var preValue);
-                    Console.WriteLine($"Pressure {preValue.Pascal}");
+                    Console.WriteLine($"Pressure: {preValue.Hectopascal} hPa");
                     i2CBmp280.TryReadAltitude(defaultSeaLevelPressure, out var altValue);
-                    Console.WriteLine($"Altitude: {altValue}");
+                    Console.WriteLine($"Altitude: {altValue} m");
                     Thread.Sleep(1000);
 
                     //change sampling rate
@@ -65,11 +65,11 @@ namespace Iot.Device.Samples
 
                     //read values
                     i2CBmp280.TryReadTemperature(out tempValue);
-                    Console.WriteLine($"Temperature {tempValue.Celsius}");
+                    Console.WriteLine($"Temperature {tempValue.Celsius} °C");
                     i2CBmp280.TryReadPressure(out preValue);
-                    Console.WriteLine($"Pressure {preValue.Pascal}");
+                    Console.WriteLine($"Pressure {preValue.Hectopascal} hPa");
                     i2CBmp280.TryReadAltitude(defaultSeaLevelPressure, out altValue);
-                    Console.WriteLine($"Altitude: {altValue}");
+                    Console.WriteLine($"Altitude: {altValue} m");
                     Thread.Sleep(5000);
                 }
             }

--- a/src/devices/Bmxx80/samples/Bmp280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bmp280.sample.cs
@@ -46,7 +46,7 @@ namespace Iot.Device.Samples
                     i2CBmp280.TryReadTemperature(out var tempValue);
                     Console.WriteLine($"Temperature {tempValue.Celsius}");
                     i2CBmp280.TryReadPressure(out var preValue);
-                    Console.WriteLine($"Pressure {preValue}");
+                    Console.WriteLine($"Pressure {preValue.Pa}");
                     i2CBmp280.TryReadAltitude(defaultSeaLevelPressure, out var altValue);
                     Console.WriteLine($"Altitude: {altValue}");
                     Thread.Sleep(1000);
@@ -67,7 +67,7 @@ namespace Iot.Device.Samples
                     i2CBmp280.TryReadTemperature(out tempValue);
                     Console.WriteLine($"Temperature {tempValue.Celsius}");
                     i2CBmp280.TryReadPressure(out preValue);
-                    Console.WriteLine($"Pressure {preValue}");
+                    Console.WriteLine($"Pressure {preValue.Pa}");
                     i2CBmp280.TryReadAltitude(defaultSeaLevelPressure, out altValue);
                     Console.WriteLine($"Altitude: {altValue}");
                     Thread.Sleep(5000);

--- a/src/devices/Bmxx80/samples/Bmp280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bmp280.sample.cs
@@ -44,7 +44,7 @@ namespace Iot.Device.Samples
 
                     //read values
                     i2CBmp280.TryReadTemperature(out var tempValue);
-                    Console.WriteLine($"Temperature: {tempValue.Celsius} °C");
+                    Console.WriteLine($"Temperature: {tempValue.Celsius} \u00B0C");
                     i2CBmp280.TryReadPressure(out var preValue);
                     Console.WriteLine($"Pressure: {preValue.Hectopascal} hPa");
                     i2CBmp280.TryReadAltitude(defaultSeaLevelPressure, out var altValue);
@@ -65,7 +65,7 @@ namespace Iot.Device.Samples
 
                     //read values
                     i2CBmp280.TryReadTemperature(out tempValue);
-                    Console.WriteLine($"Temperature {tempValue.Celsius} °C");
+                    Console.WriteLine($"Temperature {tempValue.Celsius} \u00B0C");
                     i2CBmp280.TryReadPressure(out preValue);
                     Console.WriteLine($"Pressure {preValue.Hectopascal} hPa");
                     i2CBmp280.TryReadAltitude(defaultSeaLevelPressure, out altValue);

--- a/src/devices/Bmxx80/samples/Bmp280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bmp280.sample.cs
@@ -46,7 +46,7 @@ namespace Iot.Device.Samples
                     i2CBmp280.TryReadTemperature(out var tempValue);
                     Console.WriteLine($"Temperature {tempValue.Celsius}");
                     i2CBmp280.TryReadPressure(out var preValue);
-                    Console.WriteLine($"Pressure {preValue.Pa}");
+                    Console.WriteLine($"Pressure {preValue.Pascal}");
                     i2CBmp280.TryReadAltitude(defaultSeaLevelPressure, out var altValue);
                     Console.WriteLine($"Altitude: {altValue}");
                     Thread.Sleep(1000);
@@ -67,7 +67,7 @@ namespace Iot.Device.Samples
                     i2CBmp280.TryReadTemperature(out tempValue);
                     Console.WriteLine($"Temperature {tempValue.Celsius}");
                     i2CBmp280.TryReadPressure(out preValue);
-                    Console.WriteLine($"Pressure {preValue.Pa}");
+                    Console.WriteLine($"Pressure {preValue.Pascal}");
                     i2CBmp280.TryReadAltitude(defaultSeaLevelPressure, out altValue);
                     Console.WriteLine($"Altitude: {altValue}");
                     Thread.Sleep(5000);

--- a/src/devices/Lps25h/Lps25h.cs
+++ b/src/devices/Lps25h/Lps25h.cs
@@ -52,7 +52,7 @@ namespace Iot.Device.Lps25h
         /// <summary>
         /// Pressure
         /// </summary>
-        public Pressure Pressure => Pressure.FromHpa(ReadInt24(Register.Pressure) / 4096.0);
+        public Pressure Pressure => Pressure.FromHectoPascal(ReadInt24(Register.Pressure) / 4096.0);
 
         private void WriteByte(Register register, byte data)
         {

--- a/src/devices/Lps25h/Lps25h.cs
+++ b/src/devices/Lps25h/Lps25h.cs
@@ -52,7 +52,7 @@ namespace Iot.Device.Lps25h
         /// <summary>
         /// Pressure
         /// </summary>
-        public Pressure Pressure => Pressure.FromHectoPascal(ReadInt24(Register.Pressure) / 4096.0);
+        public Pressure Pressure => Pressure.FromHectopascal(ReadInt24(Register.Pressure) / 4096.0);
 
         private void WriteByte(Register register, byte data)
         {

--- a/src/devices/Lps25h/Lps25h.cs
+++ b/src/devices/Lps25h/Lps25h.cs
@@ -50,9 +50,9 @@ namespace Iot.Device.Lps25h
         public Temperature Temperature => Temperature.FromCelsius(42.5f + ReadInt16(Register.Temperature) / 480f);
 
         /// <summary>
-        /// Pressure in hPa
+        /// Pressure
         /// </summary>
-        public float Pressure => ReadInt24(Register.Pressure) / 4096f;
+        public Pressure Pressure => Pressure.FromHpa(ReadInt24(Register.Pressure) / 4096.0);
 
         private void WriteByte(Register register, byte data)
         {

--- a/src/devices/Lps25h/samples/Lps25h.Sample.cs
+++ b/src/devices/Lps25h/samples/Lps25h.Sample.cs
@@ -19,7 +19,7 @@ namespace Iot.Device.Lps25h.Samples
             {
                 while (true)
                 {
-                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Pressure: {th.Pressure}hPa");
+                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Pressure: {th.Pressure.Hpa}hPa");
                     Thread.Sleep(1000);
                 }
             }

--- a/src/devices/Lps25h/samples/Lps25h.Sample.cs
+++ b/src/devices/Lps25h/samples/Lps25h.Sample.cs
@@ -19,7 +19,7 @@ namespace Iot.Device.Lps25h.Samples
             {
                 while (true)
                 {
-                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Pressure: {th.Pressure.Hpa}hPa");
+                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Pressure: {th.Pressure.HectoPascal}hPa");
                     Thread.Sleep(1000);
                 }
             }

--- a/src/devices/Lps25h/samples/Lps25h.Sample.cs
+++ b/src/devices/Lps25h/samples/Lps25h.Sample.cs
@@ -19,7 +19,7 @@ namespace Iot.Device.Lps25h.Samples
             {
                 while (true)
                 {
-                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Pressure: {th.Pressure.HectoPascal}hPa");
+                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Pressure: {th.Pressure.Hectopascal}hPa");
                     Thread.Sleep(1000);
                 }
             }

--- a/src/devices/Lps25h/samples/Lps25h.Sample.cs
+++ b/src/devices/Lps25h/samples/Lps25h.Sample.cs
@@ -19,7 +19,7 @@ namespace Iot.Device.Lps25h.Samples
             {
                 while (true)
                 {
-                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Pressure: {th.Pressure.Hectopascal}hPa");
+                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}\u00B0C   Pressure: {th.Pressure.Hectopascal}hPa");
                     Thread.Sleep(1000);
                 }
             }

--- a/src/devices/SenseHat/SenseHat.cs
+++ b/src/devices/SenseHat/SenseHat.cs
@@ -125,7 +125,7 @@ namespace Iot.Device.SenseHat
         /// <summary>
         /// Gets pressure from pressure and temperature sensor
         /// </summary>
-        public float Pressure => _press.Pressure;
+        public Pressure Pressure => _press.Pressure;
 
         /// <summary>
         /// Gets temperature from pressure and temperature sensor

--- a/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
+++ b/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
@@ -19,7 +19,7 @@ namespace Iot.Device.SenseHat.Samples
             {
                 while (true)
                 {
-                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Humidity: {th.Pressure}hPa");
+                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Humidity: {th.Pressure.HectoPascal}hPa");
                     Thread.Sleep(1000);
                 }
             }

--- a/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
+++ b/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
@@ -19,7 +19,7 @@ namespace Iot.Device.SenseHat.Samples
             {
                 while (true)
                 {
-                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Humidity: {th.Pressure.HectoPascal}hPa");
+                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Humidity: {th.Pressure.Hectopascal}hPa");
                     Thread.Sleep(1000);
                 }
             }

--- a/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
+++ b/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
@@ -19,7 +19,7 @@ namespace Iot.Device.SenseHat.Samples
             {
                 while (true)
                 {
-                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Humidity: {th.Pressure.Hectopascal}hPa");
+                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}\u00B0C   Humidity: {th.Pressure.Hectopascal}hPa");
                     Thread.Sleep(1000);
                 }
             }

--- a/src/devices/SenseHat/samples/TemperatureAndHumidity.Sample.cs
+++ b/src/devices/SenseHat/samples/TemperatureAndHumidity.Sample.cs
@@ -19,7 +19,7 @@ namespace Iot.Device.SenseHat.Samples
             {
                 while (true)
                 {
-                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}°C   Humidity: {th.Humidity}%rH");
+                    Console.WriteLine($"Temperature: {th.Temperature.Celsius}\u00B0C   Humidity: {th.Humidity}%rH");
                     Thread.Sleep(1000);
                 }
             }

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -97,16 +97,6 @@ namespace Iot.Units
         }
         
         /// <summary>
-        /// Creates Pressure instance from pressure in Pa
-        /// </summary>
-        /// <param name="value">Pressure value in Pa</param>
-        /// <returns>Pressure instance</returns>
-        public static Pressure FromPa(double value)
-        {
-            return new Pressure(value / PaRatio);
-        }
-        
-        /// <summary>
         /// Creates Pressure instance from pressure in inHg
         /// </summary>
         /// <param name="value">Pressure value in inHg</param>

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -12,7 +12,7 @@ namespace Iot.Units
         /// <summary>
         /// The mean sea-level pressure (MSLP), in hPa, is the average atmospheric pressure at mean sea level.
         /// </summary>
-        public const double MeanSeaLevel = 1013.25;
+        public Pressure MeanSeaLevel => Pressure.FromHpa(1013.25);
         
         private const double MbarRatio = 1.0;
         private const double KpaRatio = 0.1;

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -18,7 +18,7 @@ namespace Iot.Units
         
         private Pressure(double pascal)
         {
-            _pasccal = pascal;
+            _pascal = pascal;
         }
         
         /// <summary>

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -9,59 +9,59 @@ namespace Iot.Units
     /// </summary>
     public struct Pressure
     {
-        private const double MbarRatio = 0.01;
-        private const double KpaRatio = 0.001;
-        private const double HpaRatio = 0.01;
-        private const double InhgRatio = 0.000295301;
-        private const double MmhgRatio = 0.00750062;
-        private double _pa;
+        private const double MilliBarRatio = 0.01;
+        private const double KiloPascalRatio = 0.001;
+        private const double HectoPascalRatio = 0.01;
+        private const double InchOfMercuryRatio = 0.000295301;
+        private const double MilliMeterOfMercuryRatio = 0.00750062;
+        private double _pascal;
         
-        private Pressure(double pa)
+        private Pressure(double pascal)
         {
-            _pa = pa;
+            _pasccal = pascal;
         }
         
         /// <summary>
         /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level.
         /// </summary>
-        public static Pressure MeanSeaLevel => Pressure.FromPa(101325);
+        public static Pressure MeanSeaLevel => Pressure.FromPascal(101325);
         
         /// <summary>
         /// Pressure in Pa
         /// </summary>
-        public double Pa => _pa;
+        public double Pascal => _pascal;
         
         /// <summary>
         /// Pressure in mbar
         /// </summary>
-        public double Mbar => MbarRatio * _pa;
+        public double MilliBar => MilliBarRatio * _pascal;
         
         /// <summary>
         /// Pressure in kPa
         /// </summary>
-        public double Kpa => KpaRatio * _pa;
+        public double KiloPascal => KiloPascalRatio * _pascal;
         
         /// <summary>
         /// Pressure in hPa
         /// </summary>
-        public double Hpa => HpaRatio * _pa;
+        public double HectoPascal => HectoPascalRatio * _pascal;
         
         /// <summary>
         /// Pressure in inHg
         /// </summary>
-        public double Inhg => InhgRatio * _pa;
+        public double InchOfMercury => InchOfMercuryRatio * _pascal;
         
         /// <summary>
         /// Pressure in mmHg
         /// </summary>
-        public double Mmhg => MmhgRatio * _pa;
+        public double MilliMeterOfMercury => MilliMeterOfMercuryRatio * _pascal;
         
         /// <summary>
         /// Creates Pressure instance from pressure in Pa
         /// </summary>
         /// <param name="value">Pressure value in Pa</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromPa(double value)
+        public static Pressure FromPascal(double value)
         {
             return new Pressure(value);
         }
@@ -71,9 +71,9 @@ namespace Iot.Units
         /// </summary>
         /// <param name="value">Pressure value in mbar</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromMbar(double value)
+        public static Pressure FromMilliBar(double value)
         {
-            return new Pressure(value / MbarRatio);
+            return new Pressure(value / MilliBarRatio);
         }
         
         /// <summary>
@@ -81,9 +81,9 @@ namespace Iot.Units
         /// </summary>
         /// <param name="value">Pressure value in kPa</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromKpa(double value)
+        public static Pressure FromKiloPascal(double value)
         {
-            return new Pressure(value / KpaRatio);
+            return new Pressure(value / KiloPascalRatio);
         }
         
         /// <summary>
@@ -91,9 +91,9 @@ namespace Iot.Units
         /// </summary>
         /// <param name="value">Pressure value in hPa</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromHpa(double value)
+        public static Pressure FromHectoPascal(double value)
         {
-            return new Pressure(value / HpaRatio);
+            return new Pressure(value / HectoPascalRatio);
         }
         
         /// <summary>
@@ -101,9 +101,9 @@ namespace Iot.Units
         /// </summary>
         /// <param name="value">Pressure value in inHg</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromInhg(double value)
+        public static Pressure FromInchOfMercury(double value)
         {
-            return new Pressure(value / InhgRatio);
+            return new Pressure(value / InchOfMercuryRatio);
         }
         
         /// <summary>
@@ -111,9 +111,9 @@ namespace Iot.Units
         /// </summary>
         /// <param name="value">Pressure value in mmHg</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromMmhg(double value)
+        public static Pressure FromMilliMeterOfMercury(double value)
         {
-            return new Pressure(value / MmhgRatio);
+            return new Pressure(value / MilliMeterOfMercuryRatio);
         }
     }
 }

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -10,9 +10,9 @@ namespace Iot.Units
     public struct Pressure
     {
         /// <summary>
-        /// The mean sea-level pressure (MSLP), in hPa, is the average atmospheric pressure at mean sea level.
+        /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level.
         /// </summary>
-        public Pressure MeanSeaLevel => Pressure.FromHpa(1013.25);
+        public static Pressure MeanSeaLevel => Pressure.FromHpa(1013.25);
         
         private const double MbarRatio = 1.0;
         private const double KpaRatio = 0.1;

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -22,7 +22,7 @@ namespace Iot.Units
         }
         
         /// <summary>
-        /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level.
+        /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level
         /// </summary>
         public static Pressure MeanSeaLevel => Pressure.FromPascal(101325);
         

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -9,59 +9,59 @@ namespace Iot.Units
     /// </summary>
     public struct Pressure
     {
-        private const double MbarRatio = 1.0;
-        private const double KpaRatio = 0.1;
-        private const double PaRatio = 0.01;
-        private const double InhgRatio = 0.0295301;
-        private const double MmhgRatio = 0.750062;
-        private double _hpa;
+        private const double MbarRatio = 0.01;
+        private const double KpaRatio = 0.001;
+        private const double HpaRatio = 0.01;
+        private const double InhgRatio = 0.000295301;
+        private const double MmhgRatio = 0.00750062;
+        private long _pa;
         
-        private Pressure(double hpa)
+        private Pressure(long pa)
         {
-            _hpa = hpa;
+            _pa = pa;
         }
         
         /// <summary>
         /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level.
         /// </summary>
-        public static Pressure MeanSeaLevel => Pressure.FromHpa(1013.25);
-        
-        /// <summary>
-        /// Pressure in hPa
-        /// </summary>
-        public double Hpa => _hpa;
-        
-        /// <summary>
-        /// Pressure in mbar
-        /// </summary>
-        public double Mbar => MbarRatio * _hpa;
-        
-        /// <summary>
-        /// Pressure in kPa
-        /// </summary>
-        public double Kpa => KpaRatio * _hpa;
+        public static Pressure MeanSeaLevel => Pressure.FromPa(101325);
         
         /// <summary>
         /// Pressure in Pa
         /// </summary>
-        public double Pa => PaRatio * _hpa;
+        public long Pa => _pa;
+        
+        /// <summary>
+        /// Pressure in mbar
+        /// </summary>
+        public double Mbar => MbarRatio * _pa;
+        
+        /// <summary>
+        /// Pressure in kPa
+        /// </summary>
+        public double Kpa => KpaRatio * _pa;
+        
+        /// <summary>
+        /// Pressure in hPa
+        /// </summary>
+        public double Hpa => HpaRatio * _pa;
         
         /// <summary>
         /// Pressure in inHg
         /// </summary>
-        public double Inhg => InhgRatio * _hpa;
+        public double Inhg => InhgRatio * _pa;
         
         /// <summary>
         /// Pressure in mmHg
         /// </summary>
-        public double Mmhg => MmhgRatio * _hpa;
+        public double Mmhg => MmhgRatio * _pa;
         
         /// <summary>
-        /// Creates Pressure instance from pressure in hPa
+        /// Creates Pressure instance from pressure in Pa
         /// </summary>
-        /// <param name="value">Pressure value in hPa</param>
+        /// <param name="value">Pressure value in Pa</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromHpa(double value)
+        public static Pressure FromPa(long value)
         {
             return new Pressure(value);
         }
@@ -84,6 +84,16 @@ namespace Iot.Units
         public static Pressure FromKpa(double value)
         {
             return new Pressure(value / KpaRatio);
+        }
+        
+        /// <summary>
+        /// Creates Pressure instance from pressure in hPa
+        /// </summary>
+        /// <param name="value">Pressure value in hPa</param>
+        /// <returns>Pressure instance</returns>
+        public static Pressure FromHpa(double value)
+        {
+            return new Pressure(value / HpaRatio);
         }
         
         /// <summary>

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -14,9 +14,9 @@ namespace Iot.Units
         private const double HpaRatio = 0.01;
         private const double InhgRatio = 0.000295301;
         private const double MmhgRatio = 0.00750062;
-        private long _pa;
+        private double _pa;
         
-        private Pressure(long pa)
+        private Pressure(double pa)
         {
             _pa = pa;
         }
@@ -29,7 +29,7 @@ namespace Iot.Units
         /// <summary>
         /// Pressure in Pa
         /// </summary>
-        public long Pa => _pa;
+        public double Pa => _pa;
         
         /// <summary>
         /// Pressure in mbar
@@ -61,7 +61,7 @@ namespace Iot.Units
         /// </summary>
         /// <param name="value">Pressure value in Pa</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromPa(long value)
+        public static Pressure FromPa(double value)
         {
             return new Pressure(value);
         }

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -9,11 +9,11 @@ namespace Iot.Units
     /// </summary>
     public struct Pressure
     {
-        private const double MilliBarRatio = 0.01;
-        private const double KiloPascalRatio = 0.001;
-        private const double HectoPascalRatio = 0.01;
+        private const double MillibarRatio = 0.01;
+        private const double KilopascalRatio = 0.001;
+        private const double HectopascalRatio = 0.01;
         private const double InchOfMercuryRatio = 0.000295301;
-        private const double MilliMeterOfMercuryRatio = 0.00750062;
+        private const double MillimeterOfMercuryRatio = 0.00750062;
         private double _pascal;
         
         private Pressure(double pascal)
@@ -34,17 +34,17 @@ namespace Iot.Units
         /// <summary>
         /// Pressure in mbar
         /// </summary>
-        public double MilliBar => MilliBarRatio * _pascal;
+        public double Millibar => MillibarRatio * _pascal;
         
         /// <summary>
         /// Pressure in kPa
         /// </summary>
-        public double KiloPascal => KiloPascalRatio * _pascal;
+        public double Kilopascal => KilopascalRatio * _pascal;
         
         /// <summary>
         /// Pressure in hPa
         /// </summary>
-        public double HectoPascal => HectoPascalRatio * _pascal;
+        public double Hectopascal => HectopascalRatio * _pascal;
         
         /// <summary>
         /// Pressure in inHg
@@ -54,7 +54,7 @@ namespace Iot.Units
         /// <summary>
         /// Pressure in mmHg
         /// </summary>
-        public double MilliMeterOfMercury => MilliMeterOfMercuryRatio * _pascal;
+        public double MillimeterOfMercury => MillimeterOfMercuryRatio * _pascal;
         
         /// <summary>
         /// Creates Pressure instance from pressure in Pa
@@ -71,9 +71,9 @@ namespace Iot.Units
         /// </summary>
         /// <param name="value">Pressure value in mbar</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromMilliBar(double value)
+        public static Pressure FromMillibar(double value)
         {
-            return new Pressure(value / MilliBarRatio);
+            return new Pressure(value / MillibarRatio);
         }
         
         /// <summary>
@@ -81,9 +81,9 @@ namespace Iot.Units
         /// </summary>
         /// <param name="value">Pressure value in kPa</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromKiloPascal(double value)
+        public static Pressure FromKilopascal(double value)
         {
-            return new Pressure(value / KiloPascalRatio);
+            return new Pressure(value / KilopascalRatio);
         }
         
         /// <summary>
@@ -91,9 +91,9 @@ namespace Iot.Units
         /// </summary>
         /// <param name="value">Pressure value in hPa</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromHectoPascal(double value)
+        public static Pressure FromHectopascal(double value)
         {
-            return new Pressure(value / HectoPascalRatio);
+            return new Pressure(value / HectopascalRatio);
         }
         
         /// <summary>
@@ -111,9 +111,9 @@ namespace Iot.Units
         /// </summary>
         /// <param name="value">Pressure value in mmHg</param>
         /// <returns>Pressure instance</returns>
-        public static Pressure FromMilliMeterOfMercury(double value)
+        public static Pressure FromMillimeterOfMercury(double value)
         {
-            return new Pressure(value / MilliMeterOfMercuryRatio);
+            return new Pressure(value / MillimeterOfMercuryRatio);
         }
     }
 }

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -16,6 +16,7 @@ namespace Iot.Units
         
         private const double MbarRatio = 1.0;
         private const double KpaRatio = 0.1;
+        private const double PaRatio = 0.01;
         private const double InhgRatio = 0.0295301;
         private const double MmhgRatio = 0.750062;
         private double _hpa;
@@ -39,6 +40,11 @@ namespace Iot.Units
         /// Pressure in kPa
         /// </summary>
         public double Kpa => KpaRatio * _hpa;
+        
+        /// <summary>
+        /// Pressure in Pa
+        /// </summary>
+        public double Pa => PaRatio * _hpa;
         
         /// <summary>
         /// Pressure in inHg
@@ -78,6 +84,16 @@ namespace Iot.Units
         public static Pressure FromKpa(double value)
         {
             return new Pressure(value / KpaRatio);
+        }
+        
+        /// <summary>
+        /// Creates Pressure instance from pressure in Pa
+        /// </summary>
+        /// <param name="value">Pressure value in Pa</param>
+        /// <returns>Pressure instance</returns>
+        public static Pressure FromPa(double value)
+        {
+            return new Pressure(value / PaRatio);
         }
         
         /// <summary>

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -9,11 +9,6 @@ namespace Iot.Units
     /// </summary>
     public struct Pressure
     {
-        /// <summary>
-        /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level.
-        /// </summary>
-        public static Pressure MeanSeaLevel => Pressure.FromHpa(1013.25);
-        
         private const double MbarRatio = 1.0;
         private const double KpaRatio = 0.1;
         private const double PaRatio = 0.01;
@@ -25,6 +20,11 @@ namespace Iot.Units
         {
             _hpa = hpa;
         }
+        
+        /// <summary>
+        /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level.
+        /// </summary>
+        public static Pressure MeanSeaLevel => Pressure.FromHpa(1013.25);
         
         /// <summary>
         /// Pressure in hPa

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -5,13 +5,99 @@
 namespace Iot.Units
 {
     /// <summary>
-    /// Class representing pressure
+    /// Structure representing pressure
     /// </summary>
-    public static class Pressure
+    public struct Pressure
     {
         /// <summary>
-        /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level.
+        /// The mean sea-level pressure (MSLP), in hPa, is the average atmospheric pressure at mean sea level.
         /// </summary>
-        public const double MeanSeaLevelPressure = 1013.25;
+        public const double MeanSeaLevel = 1013.25;
+        
+        private const double MbarRatio = 1.0;
+        private const double KpaRatio = 0.1;
+        private const double InhgRatio = 0.0295301;
+        private const double MmhgRatio = 0.750062;
+        private double _hpa;
+        
+        private Pressure(double hpa)
+        {
+            _hpa = hpa;
+        }
+        
+        /// <summary>
+        /// Pressure in hPa
+        /// </summary>
+        public double Hpa => _hpa;
+        
+        /// <summary>
+        /// Pressure in mbar
+        /// </summary>
+        public double Mbar => MbarRatio * _hpa;
+        
+        /// <summary>
+        /// Pressure in kPa
+        /// </summary>
+        public double Kpa => KpaRatio * _hpa;
+        
+        /// <summary>
+        /// Pressure in inHg
+        /// </summary>
+        public double Inhg => InhgRatio * _hpa;
+        
+        /// <summary>
+        /// Pressure in mmHg
+        /// </summary>
+        public double Mmhg => MmhgRatio * _hpa;
+        
+        /// <summary>
+        /// Creates Pressure instance from pressure in hPa
+        /// </summary>
+        /// <param name="value">Pressure value in hPa</param>
+        /// <returns>Pressure instance</returns>
+        public static Pressure FromHpa(double value)
+        {
+            return new Pressure(value);
+        }
+        
+        /// <summary>
+        /// Creates Pressure instance from pressure in mbar
+        /// </summary>
+        /// <param name="value">Pressure value in mbar</param>
+        /// <returns>Pressure instance</returns>
+        public static Pressure FromMbar(double value)
+        {
+            return new Pressure(value / MbarRatio);
+        }
+        
+        /// <summary>
+        /// Creates Pressure instance from pressure in kPa
+        /// </summary>
+        /// <param name="value">Pressure value in kPa</param>
+        /// <returns>Pressure instance</returns>
+        public static Pressure FromKpa(double value)
+        {
+            return new Pressure(value / KpaRatio);
+        }
+        
+        /// <summary>
+        /// Creates Pressure instance from pressure in inHg
+        /// </summary>
+        /// <param name="value">Pressure value in inHg</param>
+        /// <returns>Pressure instance</returns>
+        public static Pressure FromInhg(double value)
+        {
+            return new Pressure(value / InhgRatio);
+        }
+        
+        /// <summary>
+        /// Creates Pressure instance from pressure in mmHg
+        /// </summary>
+        /// <param name="value">Pressure value in mmHg</param>
+        /// <returns>Pressure instance</returns>
+        public static Pressure FromMmhg(double value)
+        {
+            return new Pressure(value / MmhgRatio);
+        }
     }
 }


### PR DESCRIPTION
- Created new structure Pressure
- Includes static value for Mean Sea-Level Pressure (MSLP) (1013.25 hPa)
- Updated Bmxx80 (including BMP180), LPS25H and SenseHat to use this new unit, which breaks existing code since the return type is now Pressure.