### PR TITLE
Create Documentation for running the tests

### DIFF
--- a/src/System.Device.Gpio.Tests/README.md
+++ b/src/System.Device.Gpio.Tests/README.md
@@ -22,7 +22,7 @@ After that, you can run the tests with the RaspberryPiDriver (which is the defau
 ```
 dotnet test --filter RaspberryPiDriverTests System.Device.Gpio.sln 
 ```
-Depending on the version of the Pi and the installed linux version, it may be required to run the tests as root:
+Depending on the version of the Pi and the installed Linux distribution, it may be required to run the tests as root:
 ```
 sudo dotnet test --filter RaspberryPiDriverTests System.Device.Gpio.sln 
 ```

--- a/src/System.Device.Gpio.Tests/README.md
+++ b/src/System.Device.Gpio.Tests/README.md
@@ -10,15 +10,13 @@ cd src/System.Device.Gpio
 dotnet build System.Device.Gpio.sln
 ```
 This builds the main System.Device.Gpio assembly together with its test assembly. Before running the tests, you need to:
-- Connect an LED in series with a matching resistor to BCM Pin 18 (physical Pin 12) 
-- Connect BCM Pins 12 and 16 (physical Pins 32 and 36) with a cable
+- Connect BCM Pins 12 and 16 (physical Pins 32 and 36) with a 10kΩ resistor between them. 
 
 ## Raspberry Pi driver tests
 After that, you can run the tests with the RaspberryPiDriver (which is the default low-level driver for the Raspberry Pi) like:
 ```
 dotnet test --filter RaspberryPiDriverTests System.Device.Gpio.sln 
 ```
-During the tests, you should see the LED light up for a second. 
 
 If everything went smoothly, the output should end with a success message. 
 

--- a/src/System.Device.Gpio.Tests/README.md
+++ b/src/System.Device.Gpio.Tests/README.md
@@ -1,0 +1,39 @@
+# How to run tests on the Raspberry Pi
+
+Prerequisites: 
+- Installed .NET SDK with the "dotnet" executable in the path
+- Locally cloned repository
+
+Build System.Device.Gpio.dll:
+```
+cd src/System.Device.Gpio
+dotnet build System.Device.Gpio.sln
+```
+This builds the main System.Device.Gpio assembly together with its test assembly. Before running the tests, you need to:
+- Connect an LED in series with a matching resistor to BCM Pin 18 (physical Pin 12) 
+- Connect BCM Pins 12 and 16 (physical Pins 32 and 36) with a cable
+
+## Raspberry Pi driver tests
+After that, you can run the tests with the RaspberryPiDriver (which is the default low-level driver for the Raspberry Pi) like:
+```
+dotnet test --filter RaspberryPiDriverTests System.Device.Gpio.sln 
+```
+During the tests, you should see the LED light up for a second. 
+
+If everything went smoothly, the output should end with a success message. 
+
+## SysFsDriver Tests
+You can also run the SysFsDriver Tests (this uses a more generic approach). This driver requires root permissions to run, so you need to `sudo` the command:
+```
+sudo dotnet test --filter SysFsDriverTests System.Device.Gpio.sln 
+```
+
+## LibgpiodDriver Tests
+To run the Libgpiod Driver test (a Linux Kernel Driver for the GPIO device), you need to first install the libgpiod package:
+```
+sudo apt install -y libgpiod-dev
+```
+These tests do not require root permissions to run:
+```
+dotnet test --filter LibGpiodDriverTests System.Device.Gpio.sln 
+```

--- a/src/System.Device.Gpio.Tests/README.md
+++ b/src/System.Device.Gpio.Tests/README.md
@@ -1,5 +1,10 @@
-# How to run tests on the Raspberry Pi
+# How to run the tests
+This shows how to run the tests on a Raspberry Pi. On other platforms, things should be similar. 
 
+## Building on the desktop PC
+(to be extended)
+
+## Building directly on the Pi
 Prerequisites: 
 - Installed .NET SDK with the "dotnet" executable in the path
 - Locally cloned repository
@@ -10,12 +15,16 @@ cd src/System.Device.Gpio
 dotnet build System.Device.Gpio.sln
 ```
 This builds the main System.Device.Gpio assembly together with its test assembly. Before running the tests, you need to:
-- Connect BCM Pins 12 and 16 (physical Pins 32 and 36) with a 10kΩ resistor between them. 
+- Connect BCM Pins 12 and 16 (physical Pins 32 and 36) with a cable. It is suggested to add a resistor between 1kΩ and 10kΩ between the pins, this protects the PI in the case of a missconfiguration (i.e both pins set to Out, one high, the other low). 
 
 ## Raspberry Pi driver tests
 After that, you can run the tests with the RaspberryPiDriver (which is the default low-level driver for the Raspberry Pi) like:
 ```
 dotnet test --filter RaspberryPiDriverTests System.Device.Gpio.sln 
+```
+Depending on the version of the Pi and the installed linux version, it may be required to run the tests as root:
+```
+sudo dotnet test --filter RaspberryPiDriverTests System.Device.Gpio.sln 
 ```
 
 If everything went smoothly, the output should end with a success message. 

--- a/src/System.Device.Gpio.Tests/README.md
+++ b/src/System.Device.Gpio.Tests/README.md
@@ -15,7 +15,7 @@ cd src/System.Device.Gpio
 dotnet build System.Device.Gpio.sln
 ```
 This builds the main System.Device.Gpio assembly together with its test assembly. Before running the tests, you need to:
-- Connect BCM Pins 12 and 16 (physical Pins 32 and 36) with a cable. It is suggested to add a resistor between 1kΩ and 10kΩ between the pins, this protects the PI in the case of a missconfiguration (i.e both pins set to Out, one high, the other low). 
+- Connect BCM Pins 12 and 16 (physical Pins 32 and 36) with a cable. It is suggested to add a 1kΩ to 10kΩ resistor between the pins; this protects the Pi in the case of a misconfiguration (i.e both pins set to Out, one high, the other low). 
 
 ## Raspberry Pi driver tests
 After that, you can run the tests with the RaspberryPiDriver (which is the default low-level driver for the Raspberry Pi) like:

--- a/src/System.Device.Gpio.Tests/README.md
+++ b/src/System.Device.Gpio.Tests/README.md
@@ -5,9 +5,14 @@ This shows how to run the tests on a Raspberry Pi. On other platforms, things sh
 (to be extended)
 
 ## Building directly on the Pi
-Prerequisites: 
-- Installed .NET SDK with the "dotnet" executable in the path
-- Locally cloned repository
+First, clone the repository on the pi: 
+```
+git clone https://github.com/dotnet/iot
+cd iot
+```
+Now you can 
+- Either download and install the NET Core SDK from https://get.dot.net/ (the Raspberry Pi with the default 32 Bit Raspbian Linux requires the ARM32 version) or 
+- run `./build.sh` in the checkout directory. This will install the correct NET Core SDK in the .dotnet subfolder of the working copy.
 
 Build System.Device.Gpio.dll:
 ```


### PR DESCRIPTION
- There was no documentation on what needs to be done to successfully run the unit tests. 
- The tests should be extended (i.e. to test the pull up resistor settings or the I2C interface)
