### PR TITLE
Support setting the Pull up/Pull down resistor mode on the Pi4

### DIFF
--- a/src/System.Device.Gpio.Tests/RaspberryPi3DriverTests.Linux.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPi3DriverTests.Linux.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.Device.Gpio.Tests
 {
-    public class RaspberryPiDriverTests : GpioControllerTestBase
+    public class RaspberryPi3DriverTests : GpioControllerTestBase
     {
         protected override GpioDriver GetTestDriver() => new RaspberryPi3Driver();
 

--- a/src/System.Device.Gpio.Tests/RaspberryPi4DriverTests.Linux.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPi4DriverTests.Linux.cs
@@ -1,4 +1,8 @@
-﻿using System.Device.Gpio.Drivers;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Device.Gpio.Drivers;
 using System.Threading;
 using Xunit;
 
@@ -31,7 +35,6 @@ namespace System.Device.Gpio.Tests
             using (GpioController controller = new GpioController(GetTestNumberingScheme(), bestDriver))
             {
                 controller.OpenPin(OpenPin, PinMode.InputPullUp);
-                Thread.Sleep(10);
                 Assert.Equal(PinValue.High, controller.Read(OpenPin));
                 controller.SetPinMode(OpenPin, PinMode.InputPullDown);
                 Assert.Equal(PinValue.Low, controller.Read(OpenPin));

--- a/src/System.Device.Gpio.Tests/RaspberryPi4DriverTests.Linux.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPi4DriverTests.Linux.cs
@@ -1,39 +1,43 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Device.Gpio.Drivers;
-using System.Text;
+﻿using System.Device.Gpio.Drivers;
 using System.Threading;
 using Xunit;
 
 namespace System.Device.Gpio.Tests
 {
-	public class RaspberryPi4DriverTests : GpioControllerTestBase
-	{
+    public class RaspberryPi4DriverTests : GpioControllerTestBase
+    {
         /// <summary>
-		/// Leave this pin open (unconnected) for the tests
-		/// </summary>
-		private const int OpenPin = 23;
+        /// Leave this pin open (unconnected) for the tests
+        /// </summary>
+        private const int OpenPin = 23;
 
-		protected override GpioDriver GetTestDriver()
-		{
-			return new RaspberryPi4Driver();
-		}
+        protected override GpioDriver GetTestDriver()
+        {
+            return new RaspberryPi4Driver();
+        }
 
-		protected override PinNumberingScheme GetTestNumberingScheme() => PinNumberingScheme.Logical;
+        protected override PinNumberingScheme GetTestNumberingScheme() => PinNumberingScheme.Logical;
 
         [Fact]
         public void InputPullResistorsWork()
-		{
-			using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
-			{
-				controller.OpenPin(OpenPin, PinMode.InputPullUp);
-				Thread.Sleep(10);
-				Assert.Equal(PinValue.High, controller.Read(OpenPin));
-				controller.SetPinMode(OpenPin, PinMode.InputPullDown);
-				Assert.Equal(PinValue.Low, controller.Read(OpenPin));
-				controller.SetPinMode(OpenPin, PinMode.InputPullUp);
-				Assert.Equal(PinValue.High, controller.Read(OpenPin));
-			}
-		}
-	}
+        {
+            // This is a hack to test whether we're running on a Pi4 without duplicating that detection logic. 
+            var bestDriver = GpioController.GetBestDriverForBoard();
+            if (!(bestDriver is RaspberryPi4Driver))
+            {
+                bestDriver.Dispose();
+                return;
+            }
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), bestDriver))
+            {
+                controller.OpenPin(OpenPin, PinMode.InputPullUp);
+                Thread.Sleep(10);
+                Assert.Equal(PinValue.High, controller.Read(OpenPin));
+                controller.SetPinMode(OpenPin, PinMode.InputPullDown);
+                Assert.Equal(PinValue.Low, controller.Read(OpenPin));
+                controller.SetPinMode(OpenPin, PinMode.InputPullUp);
+                Assert.Equal(PinValue.High, controller.Read(OpenPin));
+            }
+        }
+    }
 }

--- a/src/System.Device.Gpio.Tests/RaspberryPi4DriverTests.Linux.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPi4DriverTests.Linux.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Device.Gpio.Drivers;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+namespace System.Device.Gpio.Tests
+{
+	public class RaspberryPi4DriverTests : GpioControllerTestBase
+	{
+        /// <summary>
+		/// Leave this pin open (unconnected) for the tests
+		/// </summary>
+		private const int OpenPin = 23;
+
+		protected override GpioDriver GetTestDriver()
+		{
+			return new RaspberryPi4Driver();
+		}
+
+		protected override PinNumberingScheme GetTestNumberingScheme() => PinNumberingScheme.Logical;
+
+        [Fact]
+        public void InputPullResistorsWork()
+		{
+			using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+			{
+				controller.OpenPin(OpenPin, PinMode.InputPullUp);
+				Thread.Sleep(10);
+				Assert.Equal(PinValue.High, controller.Read(OpenPin));
+				controller.SetPinMode(OpenPin, PinMode.InputPullDown);
+				Assert.Equal(PinValue.Low, controller.Read(OpenPin));
+				controller.SetPinMode(OpenPin, PinMode.InputPullUp);
+				Assert.Equal(PinValue.High, controller.Read(OpenPin));
+			}
+		}
+	}
+}

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.mmap.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.mmap.cs
@@ -88,4 +88,10 @@ internal unsafe struct RegisterView
     ///<summary>GPIO Pin Pull-up/down Enable Clock, 2x32 bits, R/W.</summary>
     [FieldOffset(0x98)]
     public fixed uint GPPUDCLK[2];
+
+    /// <summary>
+    /// Pull-up/down Enable on the BCM2711, 4x32 bits, R/W (2 bits per Pin)
+    /// </summary>
+    [FieldOffset(0xE4)]
+    public fixed uint GPPUPPDN[4];
 }

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.mmap.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.mmap.cs
@@ -89,9 +89,7 @@ internal unsafe struct RegisterView
     [FieldOffset(0x98)]
     public fixed uint GPPUDCLK[2];
 
-    /// <summary>
-    /// Pull-up/down Enable on the BCM2711, 4x32 bits, R/W (2 bits per Pin)
-    /// </summary>
+    /// <summary>Pull-up/down Enable on the BCM2711, 4x32 bits, R/W (2 bits per Pin)</summary>
     [FieldOffset(0xE4)]
     public fixed uint GPPUPPDN[4];
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/GenericRaspberryPiDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/GenericRaspberryPiDriver.Linux.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace System.Device.Gpio.Drivers
 {
-    public unsafe partial class RaspberryPi3Driver : GpioDriver
+    public unsafe partial class GenericRaspberryPiDriver : GpioDriver
     {
         private const int ENOENT = 2; // error indicates that an entity doesn't exist
         private RegisterView* _registerViewPointer = null;

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/GenericRaspberryPiDriver.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/GenericRaspberryPiDriver.Windows.cs
@@ -4,7 +4,7 @@
 
 namespace System.Device.Gpio.Drivers
 {
-    public partial class RaspberryPi3Driver : Windows10Driver
+    public partial class GenericRaspberryPiDriver : Windows10Driver
     {
         protected ulong ClearRegister
         {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/GenericRaspberryPiDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/GenericRaspberryPiDriver.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Device.Gpio.Drivers
+{
+    /// <summary>
+    /// A GPIO driver for the Raspberry Pi 3.
+    /// </summary>
+    public partial class GenericRaspberryPiDriver  // Different base classes declared in GenericRaspberryPiDriver.Linux.cs and GenericRaspberryPiDriver.Windows.cs
+    {
+        /// <summary>
+        /// Raspberry Pi 3 has 28 GPIO pins.
+        /// </summary>
+        protected internal override int PinCount => 28;
+
+        protected void ValidatePinNumber(int pinNumber)
+        {
+            if (pinNumber < 0 || pinNumber > 27)
+            {
+                throw new ArgumentException("The specified pin number is invalid.", nameof(pinNumber));
+            }
+        }
+
+        /// <summary>
+        /// Converts a board pin number to the driver's logical numbering scheme.
+        /// </summary>
+        /// <param name="pinNumber">The board pin number to convert.</param>
+        /// <returns>The pin number in the driver's logical numbering scheme.</returns>
+        protected internal override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            return pinNumber switch
+            {
+                3 => 2,
+                5 => 3,
+                7 => 4,
+                8 => 14,
+                10 => 15,
+                11 => 17,
+                12 => 18,
+                13 => 27,
+                15 => 22,
+                16 => 23,
+                18 => 24,
+                19 => 10,
+                21 => 9,
+                22 => 25,
+                23 => 11,
+                24 => 8,
+                26 => 7,
+                27 => 0,
+                28 => 1,
+                29 => 5,
+                31 => 6,
+                32 => 12,
+                33 => 13,
+                35 => 19,
+                36 => 16,
+                37 => 26,
+                38 => 20,
+                40 => 21,
+                _ => throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber))
+            };
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -44,6 +44,14 @@ namespace System.Device.Gpio.Drivers
             }
         }
 
+        internal RegisterView* RegisterViewPointer
+        {
+            get
+            {
+                return _registerViewPointer;
+            }
+        }
+
         /// <summary>
         /// Gets the mode of a pin for Unix.
         /// </summary>
@@ -212,7 +220,7 @@ namespace System.Device.Gpio.Drivers
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         /// <param name="mode">The mode of a pin to set the resistor pull up/down mode.</param>
-        private void SetInputPullMode(int pinNumber, PinMode mode)
+        protected virtual void SetInputPullMode(int pinNumber, PinMode mode)
         {
             byte modeToPullMode = mode switch
             {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -7,60 +7,8 @@ namespace System.Device.Gpio.Drivers
     /// <summary>
     /// A GPIO driver for the Raspberry Pi 3.
     /// </summary>
-    public partial class RaspberryPi3Driver  // Different base classes declared in RaspberryPi3Driver.Linux.cs and RaspberryPi3Driver.Windows.cs
+    public partial class RaspberryPi3Driver : GenericRaspberryPiDriver
     {
-        /// <summary>
-        /// Raspberry Pi 3 has 28 GPIO pins.
-        /// </summary>
-        protected internal override int PinCount => 28;
-
-        protected void ValidatePinNumber(int pinNumber)
-        {
-            if (pinNumber < 0 || pinNumber > 27)
-            {
-                throw new ArgumentException("The specified pin number is invalid.", nameof(pinNumber));
-            }
-        }
-
-        /// <summary>
-        /// Converts a board pin number to the driver's logical numbering scheme.
-        /// </summary>
-        /// <param name="pinNumber">The board pin number to convert.</param>
-        /// <returns>The pin number in the driver's logical numbering scheme.</returns>
-        protected internal override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
-        {
-            return pinNumber switch
-            {
-                3 => 2,
-                5 => 3,
-                7 => 4,
-                8 => 14,
-                10 => 15,
-                11 => 17,
-                12 => 18,
-                13 => 27,
-                15 => 22,
-                16 => 23,
-                18 => 24,
-                19 => 10,
-                21 => 9,
-                22 => 25,
-                23 => 11,
-                24 => 8,
-                26 => 7,
-                27 => 0,
-                28 => 1,
-                29 => 5,
-                31 => 6,
-                32 => 12,
-                33 => 13,
-                35 => 19,
-                36 => 16,
-                37 => 26,
-                38 => 20,
-                40 => 21,
-                _ => throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber))
-            };
-        }
+        // No extra code required for Pi3 only for now
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -14,7 +14,7 @@ namespace System.Device.Gpio.Drivers
         /// </summary>
         protected internal override int PinCount => 28;
 
-        private void ValidatePinNumber(int pinNumber)
+        protected void ValidatePinNumber(int pinNumber)
         {
             if (pinNumber < 0 || pinNumber > 27)
             {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi4Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi4Driver.Linux.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi4Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi4Driver.Linux.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Device.Gpio.Drivers
+{
+    public unsafe partial class RaspberryPi4Driver
+    {
+        /// <summary>
+        /// Sets the resistor pull up/down mode for an input pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="mode">The mode of a pin to set the resistor pull up/down mode.</param>
+        protected override void SetInputPullMode(int pinNumber, PinMode mode)
+        {
+            // Doesn't hurt to use the old (Pi3) code as well
+            base.SetInputPullMode(pinNumber, mode);
+
+            int shift = (pinNumber & 0xf) << 1;
+            UInt32 pull = 0;
+            UInt32 bits = 0;
+            switch (mode)
+            {
+                case PinMode.Input: pull = 0; break;
+                case PinMode.InputPullUp: pull = 1; break;
+                case PinMode.InputPullDown: pull = 2; break;
+            }
+
+            var gpioReg = RegisterViewPointer;
+            bits = (gpioReg->GPPUPPDN[(pinNumber >> 4)]);
+            bits &= ~(3u << shift);
+            bits |= (pull << shift);
+            gpioReg->GPPUPPDN[(pinNumber >> 4)] = bits;
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi4Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi4Driver.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi4Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi4Driver.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Device.Gpio.Drivers
+{
+    public unsafe partial class RaspberryPi4Driver : RaspberryPi3Driver
+    {
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi4Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi4Driver.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace System.Device.Gpio.Drivers
 {
-    public unsafe partial class RaspberryPi4Driver : RaspberryPi3Driver
+    public unsafe partial class RaspberryPi4Driver : GenericRaspberryPiDriver
     {
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
@@ -53,11 +53,12 @@ namespace System.Device.Gpio
                                     if (rev.EndsWith("03111"))
                                     {
                                         // The Pi4 reports the same CPU (although that's technically wrong) but different board revisions.
-                                        // The currently known revisions are 0xa03111, 0xb0311, 0xc03111 for the models with 1GB, 2GB and 4GB of ram, respectively. 
+                                        // The currently known revisions are 0xa03111, 0xb03111, 0xc03111 for the models with 1GB, 2GB and 4GB of ram, respectively. 
                                         return new RaspberryPi4Driver();
                                     }
                                 }
                             }
+
                             // Assume Pi3 otherwise
                             return new RaspberryPi3Driver();
                         }

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.Linux.cs
@@ -28,7 +28,7 @@ namespace System.Device.Gpio
         /// Attempt to get the best applicable driver for the board the program is executing on.
         /// </summary>
         /// <returns>A driver that works with the board the program is executing on.</returns>
-        private static GpioDriver GetBestDriverForBoard()
+        public static GpioDriver GetBestDriverForBoard()
         {
             string[] cpuInfoLines = File.ReadAllLines(CpuInfoPath);
             Regex regexHw = new Regex(@"Hardware\s*:\s*(.*)");

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.Windows.cs
@@ -34,7 +34,7 @@ namespace System.Device.Gpio
         ///     The GpioController could use reflection to find all GpioDriver-derived classes and call this
         ///     static method to determine if the driver considers itself to be the best match for the environment.
         /// </remarks>
-        private static GpioDriver GetBestDriverForBoard()
+        public static GpioDriver GetBestDriverForBoard()
         {
             string baseBoardProduct = Registry.LocalMachine.GetValue(BaseBoardProductRegistryValue, string.Empty).ToString();
 


### PR DESCRIPTION
The Pi4's CPU uses alternate registers to set the pull up/pull down mode than the Pi3 did. This adds a separate driver class for the Pi4 with (for now) one extra method to configure the registers for setting the pull mode of input registers. The required code was adapted from https://github.com/joan2937/pigpio/blob/master/pigpio.c#L8785. 

Unit test provided as well. 

The detection of the Pi4 is quite a hack, this should be improved later (see also PR #766). It would probably be better to either create a separate class for detecting the best driver or to have the drivers detect themselves whether they can run on the given hardware. 