### PR TITLE
Fixed typo in sample program

### DIFF
--- a/src/devices/Nrf24l01/samples/Program.cs
+++ b/src/devices/Nrf24l01/samples/Program.cs
@@ -64,7 +64,7 @@ namespace Iot.Device.Nrf24l01.Samples
             }
             Console.WriteLine();
 
-            Console.WriteLine($"Massage: {res}");
+            Console.WriteLine($"Message: {res}");
             Console.WriteLine();
         }
     }


### PR DESCRIPTION
This fixes a typo in `Program.cs`.

I should have known that https://github.com/dotnet/iot/pull/747 came from this file :see_no_evil: