### PR TITLE
Fix GPIO access issue with sysfs caused by udev setting permissions.

### DIFF
--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.access.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.access.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    [DllImport(LibcLibrary, SetLastError = true)]
+    internal static extern int access([MarshalAs(UnmanagedType.LPStr)] string pathname, AccessModeFlags flags);
+}
+
+internal enum AccessModeFlags
+{
+    F_OK = 0,
+    X_OK = 1,
+    W_OK = 2,
+    R_OK = 4
+}

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.Linux.cs
@@ -78,8 +78,8 @@ namespace System.Device.Gpio.Drivers
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         protected internal override void OpenPin(int pinNumber)
         {
-            const int numOpenRetries = 100; // wait 1 second max for udev to set the permissions
-            int openRetries;
+            const int retryDelayMaximumMillis = 1000; // wait 1 second max for udev to set the permissions
+            Diagnostics.Stopwatch retryStopwatch;
             int pinOffset = pinNumber + s_pinOffset;
             string pinPath = $"{GpioBasePath}/gpio{pinOffset}";
             // If the directory exists, this becomes a no-op since the pin might have been opened already by the some controller or somebody else.
@@ -90,20 +90,22 @@ namespace System.Device.Gpio.Drivers
                     File.WriteAllText(Path.Combine(GpioBasePath, "export"), pinOffset.ToString(CultureInfo.InvariantCulture));
 
                     // test to see if we have rw access to the GPIO pin.
-                    if ( Interop.access(pinPath, AccessModeFlags.R_OK | AccessModeFlags.W_OK) != 0 )
+                    if (Interop.access(pinPath, AccessModeFlags.R_OK | AccessModeFlags.W_OK) != 0)
                     {
-                        openRetries = 0;
+                        retryStopwatch = new Diagnostics.Stopwatch();
+                        retryStopwatch.Start();
 
-                        // repeatedly check for access to the GPIO pin until access is granted or the number of tries is exceeded
+                        // repeatedly check for access to the GPIO pin until access is granted or the timeout is exceeded
                         do
                         {
                             // delay a little to give udev potentially time to respond
                             Thread.Sleep(TimeSpan.FromMilliseconds(10));
-                            openRetries++;
-                        } while ( Interop.access(pinPath, AccessModeFlags.R_OK | AccessModeFlags.W_OK) != 0 & openRetries < numOpenRetries );
+                        } while (Interop.access(pinPath, AccessModeFlags.R_OK | AccessModeFlags.W_OK) != 0 & retryStopwatch.ElapsedMilliseconds < retryDelayMaximumMillis);
 
-                        // if we have run out of retries then throw an exception. 
-                        if( openRetries >= numOpenRetries )
+                        retryStopwatch.Stop();
+
+                        // if we have run out of time for the permissions to be set then throw an exception. 
+                        if (retryStopwatch.ElapsedMilliseconds >= retryDelayMaximumMillis)
                         {
                             throw new UnauthorizedAccessException("Opening pins requires root permissions.");
                         }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.Linux.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -78,8 +79,7 @@ namespace System.Device.Gpio.Drivers
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         protected internal override void OpenPin(int pinNumber)
         {
-            const int retryDelayMaximumMillis = 1000; // wait 1 second max for udev to set the permissions
-            Diagnostics.Stopwatch retryStopwatch;
+            const int RetryDelayMaximumMillis = 1000; // wait 1 second max for udev to set the permissions
             int pinOffset = pinNumber + s_pinOffset;
             string pinPath = $"{GpioBasePath}/gpio{pinOffset}";
             // If the directory exists, this becomes a no-op since the pin might have been opened already by the some controller or somebody else.
@@ -92,22 +92,21 @@ namespace System.Device.Gpio.Drivers
                     // test to see if we have rw access to the GPIO pin.
                     if (Interop.access(pinPath, AccessModeFlags.R_OK | AccessModeFlags.W_OK) != 0)
                     {
-                        retryStopwatch = new Diagnostics.Stopwatch();
-                        retryStopwatch.Start();
+                        Stopwatch retryStopwatch = Stopwatch.StartNew();
 
                         // repeatedly check for access to the GPIO pin until access is granted or the timeout is exceeded
                         do
                         {
                             // delay a little to give udev potentially time to respond
                             Thread.Sleep(TimeSpan.FromMilliseconds(10));
-                        } while (Interop.access(pinPath, AccessModeFlags.R_OK | AccessModeFlags.W_OK) != 0 & retryStopwatch.ElapsedMilliseconds < retryDelayMaximumMillis);
+                        } while (Interop.access(pinPath, AccessModeFlags.R_OK | AccessModeFlags.W_OK) != 0 & retryStopwatch.ElapsedMilliseconds < RetryDelayMaximumMillis);
 
                         retryStopwatch.Stop();
 
                         // if we have run out of time for the permissions to be set then throw an exception. 
-                        if (retryStopwatch.ElapsedMilliseconds >= retryDelayMaximumMillis)
+                        if (retryStopwatch.ElapsedMilliseconds >= RetryDelayMaximumMillis)
                         {
-                            throw new UnauthorizedAccessException("Opening pins requires root permissions.");
+                            throw new UnauthorizedAccessException("Timeout exceeded waiting for access to the pin.");
                         }
                     }
 


### PR DESCRIPTION
Fixes #811 

This PR aims to resolve issues when OpenPin is called as a non-root user on a Raspberry Pi running Raspian whilst using the SYSFS driver. The user is correctly in the gpio group.

The first time OpenPin is called it creates a node in the sysfs file system for the pin but the permissions are not set for the gpio group. 

Udev is used to set the permissions but those doesn't happen instantly.

 The implication of this is that often the first operation on the pin will fail and if retried for a second time will succeed

This PR tests if the access is correct to the node representing the pin has the correct permissions and if it hasn't retries a limited number of times until all is well.

Users with root privileges should pass the access test right away and not have to wait for the permissions to be applied.