### PR TITLE
Avoid the unreliable SYS_TRIGGER-based chip reset.

### DIFF
--- a/src/devices/Bno055/Bno055Sensor.cs
+++ b/src/devices/Bno055/Bno055Sensor.cs
@@ -124,7 +124,7 @@ namespace Iot.Device.Bno055
             Info.BootloaderVersion = new Version(ReadByte(Registers.BL_REV_ID), 0);
 
             _operationMode = operationMode;
-            initializeRegisters();
+            InitializeRegisters();
         }
 
         private static readonly byte[][] s_registerDefaults =
@@ -150,7 +150,7 @@ namespace Iot.Device.Bno055
             }
         };
 
-        private void initializeRegisters()
+        private void InitializeRegisters()
         {
             // WriteReg(Registers.SYS_TRIGGER, 0x20);
             // Using the chip's internal reset might not work:

--- a/src/devices/Bno055/Bno055Sensor.cs
+++ b/src/devices/Bno055/Bno055Sensor.cs
@@ -127,16 +127,22 @@ namespace Iot.Device.Bno055
             initializeRegisters();
         }
 
-        private static readonly byte[][] registerDefaults =
+        private static readonly byte[][] s_registerDefaults =
         {
-            new byte[]{ (byte)Registers.UNIT_SEL, (byte)(Units.AccelerationMeterPerSecond | Units.AngularRateDegreePerSecond | Units.DataOutputFormatWindows | Units.EulerAnglesDegrees | Units.TemperatureCelsius) },
-            new byte[]{ (byte)Registers.TEMP_SOURCE, (byte)TemperatureSource.Gyroscope },
-            new byte[]{ (byte)Registers.PWR_MODE, (byte)PowerMode.Normal },
-            new byte[]{ (byte)Registers.AXIS_MAP_CONFIG,
+            new byte[] { (byte)Registers.UNIT_SEL, (byte)(
+                Units.AccelerationMeterPerSecond |
+                Units.AngularRateDegreePerSecond |
+                Units.DataOutputFormatWindows |
+                Units.EulerAnglesDegrees |
+                Units.TemperatureCelsius
+            ) },
+            new byte[] { (byte)Registers.TEMP_SOURCE, (byte)TemperatureSource.Gyroscope },
+            new byte[] { (byte)Registers.PWR_MODE, (byte)PowerMode.Normal },
+            new byte[] { (byte)Registers.AXIS_MAP_CONFIG,
                 0x24, // AXIS_MAP_CONFIG
                 0, // AXIS_MAP_SIGN
             },
-            new byte[]{ (byte)Registers.ACCEL_OFFSET_X_LSB,
+            new byte[] { (byte)Registers.ACCEL_OFFSET_X_LSB,
                 0, 0, 0, 0, 0, 0, // ACC_OFFSET_*_*SB
                 0, 0, 0, 0, 0, 0, // MAC_OFFSET_*_*SB
                 0, 0, 0, 0, 0, 0, // GYR_OFFSET_*_*SB
@@ -151,8 +157,12 @@ namespace Iot.Device.Bno055
             // https://community.bosch-sensortec.com/t5/MEMS-sensors-forum/BNO055-power-on-reset-issues/m-p/8457/highlight/true#M948
 
             SetConfigMode(true);
-            foreach (var registerDefault in registerDefaults)
+
+            foreach (var registerDefault in s_registerDefaults)
+            {
                 _i2cDevice.Write(registerDefault);
+            }
+
             SetConfigMode(false);
         }
 

--- a/src/devices/Bno055/Bno055Sensor.cs
+++ b/src/devices/Bno055/Bno055Sensor.cs
@@ -123,24 +123,37 @@ namespace Iot.Device.Bno055
             Info.FirmwareVersion = new Version(ReadByte(Registers.SW_REV_ID_MSB), ReadByte(Registers.SW_REV_ID_LSB));
             Info.BootloaderVersion = new Version(ReadByte(Registers.BL_REV_ID), 0);
 
-            // Check if a reset is needed
-            if (TemperatureSource != TemperatureSource.Gyroscope)
-            {
-                WriteReg(Registers.SYS_TRIGGER, 0x20);
-                // Need 650 milliseconds after reset
-                Thread.Sleep(650);
-                PowerMode = PowerMode.Normal;
-                WriteReg(Registers.SYS_TRIGGER, 0x00);
-                TemperatureSource = TemperatureSource.Gyroscope;
+            _operationMode = operationMode;
+            initializeRegisters();
+        }
+
+        private static readonly byte[][] registerDefaults =
+        {
+            new byte[]{ (byte)Registers.UNIT_SEL, (byte)(Units.AccelerationMeterPerSecond | Units.AngularRateDegreePerSecond | Units.DataOutputFormatWindows | Units.EulerAnglesDegrees | Units.TemperatureCelsius) },
+            new byte[]{ (byte)Registers.TEMP_SOURCE, (byte)TemperatureSource.Gyroscope },
+            new byte[]{ (byte)Registers.PWR_MODE, (byte)PowerMode.Normal },
+            new byte[]{ (byte)Registers.AXIS_MAP_CONFIG,
+                0x24, // AXIS_MAP_CONFIG
+                0, // AXIS_MAP_SIGN
+            },
+            new byte[]{ (byte)Registers.ACCEL_OFFSET_X_LSB,
+                0, 0, 0, 0, 0, 0, // ACC_OFFSET_*_*SB
+                0, 0, 0, 0, 0, 0, // MAC_OFFSET_*_*SB
+                0, 0, 0, 0, 0, 0, // GYR_OFFSET_*_*SB
+                0, 0, 0, 0, // *_RADIUS_*SB
             }
-            // Select default units
-            Units = Units.AccelerationMeterPerSecond | Units.AngularRateDegreePerSecond | Units.DataOutputFormatWindows | Units.EulerAnglesDegrees | Units.TemperatureCelsius;
-            // Using the gyroscope as temeprature source
-            TemperatureSource = TemperatureSource.Gyroscope;
-            // Set the operation mode
-            OperationMode = operationMode;
-            // Get the current unit (should be all at default)
-            _units = Units;
+        };
+
+        private void initializeRegisters()
+        {
+            // WriteReg(Registers.SYS_TRIGGER, 0x20);
+            // Using the chip's internal reset might not work:
+            // https://community.bosch-sensortec.com/t5/MEMS-sensors-forum/BNO055-power-on-reset-issues/m-p/8457/highlight/true#M948
+
+            SetConfigMode(true);
+            foreach (var registerDefault in registerDefaults)
+                _i2cDevice.Write(registerDefault);
+            SetConfigMode(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #777

I've decided to overwrite all the writable registers in page 0 with their default values according to the data sheet. This means, there's a change in behavior: Prior to this change, the calibration data would remain active between consecutive runs as long as you didn't change the temperature source (which was the trigger for the chip reset). With this change, that data is reset to default values every time you construct a new BNO055 driver.

I tested this on our custom board by reading the Gravity vector.