### PR TITLE
Do not dispose GPIO Controller if it's not our own

### DIFF
--- a/src/devices/SoftPwm/SoftwarePwmChannel.cs
+++ b/src/devices/SoftPwm/SoftwarePwmChannel.cs
@@ -35,8 +35,8 @@ namespace System.Device.Pwm.Drivers
 
         private Thread _runningThread;
         private GpioController _controller;
-        private bool _runThread = true;
-        private bool _shouldDispose;
+        private readonly bool _shouldDispose;
+		private bool _runThread = true;
 
         /// <summary>
         /// The frequency in hertz.

--- a/src/devices/SoftPwm/SoftwarePwmChannel.cs
+++ b/src/devices/SoftPwm/SoftwarePwmChannel.cs
@@ -36,6 +36,7 @@ namespace System.Device.Pwm.Drivers
         private Thread _runningThread;
         private GpioController _controller;
         private bool _runThread = true;
+        private bool _ownController;
 
         /// <summary>
         /// The frequency in hertz.
@@ -82,7 +83,16 @@ namespace System.Device.Pwm.Drivers
         /// <param name="controller">The <see cref="GpioController"/> to which <paramref name="pinNumber"/> belongs to. Null defaults to board GpioController</param>
         public SoftwarePwmChannel(int pinNumber, int frequency = 400, double dutyCycle = 0.5, bool usePrecisionTimer = false, GpioController controller = null)
         {
-            _controller = controller ?? new GpioController();
+            if (controller == null)
+            {
+                _controller = new GpioController();
+                _ownController = true;
+            }
+            else
+            {
+                _controller = controller;
+                _ownController = false;
+            }
             if (_controller == null)
             {
                 Debug.WriteLine("GPIO does not exist on the current system.");
@@ -197,8 +207,11 @@ namespace System.Device.Pwm.Drivers
             _runThread = false;
             _runningThread?.Join();
             _runningThread = null;
-            _controller?.Dispose();
-            _controller = null;
+            if (_ownController)
+            {
+                _controller?.Dispose();
+                _controller = null;
+            }
             base.Dispose(disposing);
         }
     }

--- a/src/devices/SoftPwm/SoftwarePwmChannel.cs
+++ b/src/devices/SoftPwm/SoftwarePwmChannel.cs
@@ -36,7 +36,7 @@ namespace System.Device.Pwm.Drivers
         private Thread _runningThread;
         private GpioController _controller;
         private readonly bool _shouldDispose;
-		private bool _runThread = true;
+        private bool _runThread = true;
 
         /// <summary>
         /// The frequency in hertz.

--- a/src/devices/SoftPwm/SoftwarePwmChannel.cs
+++ b/src/devices/SoftPwm/SoftwarePwmChannel.cs
@@ -36,7 +36,7 @@ namespace System.Device.Pwm.Drivers
         private Thread _runningThread;
         private GpioController _controller;
         private bool _runThread = true;
-        private bool _ownController;
+        private bool _shouldDispose;
 
         /// <summary>
         /// The frequency in hertz.
@@ -81,18 +81,21 @@ namespace System.Device.Pwm.Drivers
         /// <param name="dutyCycle">The duty cycle percentage represented as a value between 0.0 and 1.0</param>
         /// <param name="usePrecisionTimer">Determines if a high precision timer should be used.</param>
         /// <param name="controller">The <see cref="GpioController"/> to which <paramref name="pinNumber"/> belongs to. Null defaults to board GpioController</param>
-        public SoftwarePwmChannel(int pinNumber, int frequency = 400, double dutyCycle = 0.5, bool usePrecisionTimer = false, GpioController controller = null)
+        /// <param name="shouldDispose">True to automatically dispose the controller when this class is disposed, false otherwise.
+        /// This parameter is ignored if <paramref name="controller"/> is null.</param>
+        public SoftwarePwmChannel(int pinNumber, int frequency = 400, double dutyCycle = 0.5, bool usePrecisionTimer = false, GpioController controller = null, bool shouldDispose = true)
         {
             if (controller == null)
             {
                 _controller = new GpioController();
-                _ownController = true;
+                _shouldDispose = true;
             }
             else
             {
                 _controller = controller;
-                _ownController = false;
+                _shouldDispose = shouldDispose;
             }
+
             if (_controller == null)
             {
                 Debug.WriteLine("GPIO does not exist on the current system.");
@@ -207,11 +210,13 @@ namespace System.Device.Pwm.Drivers
             _runThread = false;
             _runningThread?.Join();
             _runningThread = null;
-            if (_ownController)
+
+            if (_shouldDispose)
             {
                 _controller?.Dispose();
                 _controller = null;
             }
+
             base.Dispose(disposing);
         }
     }


### PR DESCRIPTION
If the reference to the GPIO Controller was provided from outside, we must not dispose it in the Dispose method, otherwise this closes any other pins we might have open at the same time. 
