### PR TITLE
4 Bit LCD Display support

### DIFF
--- a/src/devices/CharacterLcd/CharacterLcd.csproj
+++ b/src/devices/CharacterLcd/CharacterLcd.csproj
@@ -15,7 +15,7 @@
     <Compile Include="LcdInterface.Gpio.cs" />
     <Compile Include="LcdInterface.I2c.cs" />
     <Compile Include="LcdInterface.I2c4Bit.cs" />
-    <Compile Include="LcdRgb1602.cs" />
+    <Compile Include="LcdRgb.cs" />
     <Compile Include="Registers.cs" />
   </ItemGroup>
 

--- a/src/devices/CharacterLcd/CharacterLcd.csproj
+++ b/src/devices/CharacterLcd/CharacterLcd.csproj
@@ -14,6 +14,7 @@
     <Compile Include="LcdInterface.cs" />
     <Compile Include="LcdInterface.Gpio.cs" />
     <Compile Include="LcdInterface.I2c.cs" />
+    <Compile Include="LcdInterface.I2c4Bit.cs" />
     <Compile Include="LcdRgb1602.cs" />
     <Compile Include="Registers.cs" />
   </ItemGroup>

--- a/src/devices/CharacterLcd/CharacterLcd.sln
+++ b/src/devices/CharacterLcd/CharacterLcd.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29409.12
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CharacterLcd", "CharacterLcd.csproj", "{A455537F-ECF1-4280-98CD-FFC6F027EA16}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CharacterLcd.Samples", "samples\CharacterLcd.Samples.csproj", "{A642926F-A33B-4BC7-9976-8A7754DF3375}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A455537F-ECF1-4280-98CD-FFC6F027EA16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A455537F-ECF1-4280-98CD-FFC6F027EA16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A455537F-ECF1-4280-98CD-FFC6F027EA16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A455537F-ECF1-4280-98CD-FFC6F027EA16}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A642926F-A33B-4BC7-9976-8A7754DF3375}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A642926F-A33B-4BC7-9976-8A7754DF3375}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A642926F-A33B-4BC7-9976-8A7754DF3375}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A642926F-A33B-4BC7-9976-8A7754DF3375}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BF8A0758-8ADC-47DC-A172-AC986F303A94}
+	EndGlobalSection
+EndGlobal

--- a/src/devices/CharacterLcd/Hd44780.cs
+++ b/src/devices/CharacterLcd/Hd44780.cs
@@ -59,7 +59,7 @@ namespace Iot.Device.CharacterLcd
         /// <summary>
         /// LCD interface used by the device
         /// </summary>
-        protected readonly LcdInterface _interface;
+        protected readonly LcdInterface _lcdInterface;
 
         /// <summary>
         /// Logical size, in characters, of the LCD.
@@ -70,13 +70,13 @@ namespace Iot.Device.CharacterLcd
         /// Initializes a new HD44780 LCD controller.
         /// </summary>
         /// <param name="size">The logical size of the LCD.</param>
-        /// <param name="interface">The interface to use with the LCD.</param>
-        public Hd44780(Size size, LcdInterface @interface)
+        /// <param name="lcdInterface">The interface to use with the LCD.</param>
+        public Hd44780(Size size, LcdInterface lcdInterface)
         {
             Size = size;
-            _interface = @interface;
+            _lcdInterface = lcdInterface;
 
-            if (_interface.EightBitMode)
+            if (_lcdInterface.EightBitMode)
                 _displayFunction |= DisplayFunction.EightBit;
 
             Initialize(size.Height);
@@ -117,33 +117,33 @@ namespace Iot.Device.CharacterLcd
         /// </summary>
         public virtual bool BacklightOn
         {
-            get => _interface.BacklightOn;
-            set => _interface.BacklightOn = value;
+            get => _lcdInterface.BacklightOn;
+            set => _lcdInterface.BacklightOn = value;
         }
 
         /// <summary>
         /// Sends byte to the device
         /// </summary>
         /// <param name="value">Byte to be sent to the device</param>
-        protected void SendData(byte value) => _interface.SendData(value);
+        protected void SendData(byte value) => _lcdInterface.SendData(value);
 
         /// <summary>
         /// Sends command to the device
         /// </summary>
         /// <param name="command">Byte representing the command to be sent</param>
-        protected void SendCommand(byte command) => _interface.SendCommand(command);
+        protected void SendCommand(byte command) => _lcdInterface.SendCommand(command);
 
         /// <summary>
         /// Sends data to the device
         /// </summary>
         /// <param name="values">Data to be send to the device</param>
-        protected void SendData(ReadOnlySpan<byte> values) => _interface.SendData(values);
+        protected void SendData(ReadOnlySpan<byte> values) => _lcdInterface.SendData(values);
 
         /// <summary>
         /// Send commands to the device
         /// </summary>
         /// <param name="commands">Each byte represents command being sent to the device</param>
-        protected void SendCommands(ReadOnlySpan<byte> commands) => _interface.SendCommands(commands);
+        protected void SendCommands(ReadOnlySpan<byte> commands) => _lcdInterface.SendCommands(commands);
 
         /// <summary>
         /// Determines if the device should use two line mode
@@ -205,7 +205,7 @@ namespace Iot.Device.CharacterLcd
         /// <param name="microseconds">Time to wait if checking busy state isn't possible/practical.</param>
         protected void WaitForNotBusy(int microseconds)
         {
-            _interface.WaitForNotBusy(microseconds);
+            _lcdInterface.WaitForNotBusy(microseconds);
         }
 
         /// <summary>
@@ -425,7 +425,7 @@ namespace Iot.Device.CharacterLcd
         {
             if (disposing)
             {
-                _interface?.Dispose();
+                _lcdInterface?.Dispose();
             }
         }
 

--- a/src/devices/CharacterLcd/Lcd1602.cs
+++ b/src/devices/CharacterLcd/Lcd1602.cs
@@ -35,8 +35,18 @@ namespace Iot.Device.CharacterLcd
         /// This is for on-chip I2c support. For connecting via I2c GPIO expanders, use the GPIO constructor <see cref="Lcd1602(int, int, int[], int, float, int, GpioController)"/>.
         /// </remarks>
         /// <param name="device">The I2c device for the LCD.</param>
-        public Lcd1602(I2cDevice device)
-            : base(new Size(16, 2), LcdInterface.CreateI2c(device))
+        /// <param name="uses8Bit">True if the device uses 8 Bit commands, false if it handles only 4 bit commands.</param>
+        public Lcd1602(I2cDevice device, bool uses8Bit)
+            : base(new Size(16, 2), LcdInterface.CreateI2c(device, uses8Bit))
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new 16x2 LCD controller with the given interface
+        /// </summary>
+        /// <param name="interface">The LCD Interface</param>
+        public Lcd1602(LcdInterface @interface)
+            : base(new Size(16, 2), @interface)
         {
         }
     }

--- a/src/devices/CharacterLcd/Lcd1602.cs
+++ b/src/devices/CharacterLcd/Lcd1602.cs
@@ -44,9 +44,9 @@ namespace Iot.Device.CharacterLcd
         /// <summary>
         /// Constructs a new 16x2 LCD controller with the given interface
         /// </summary>
-        /// <param name="interface">The LCD Interface</param>
-        public Lcd1602(LcdInterface @interface)
-            : base(new Size(16, 2), @interface)
+        /// <param name="lcdInterface">The LCD Interface</param>
+        public Lcd1602(LcdInterface lcdInterface)
+            : base(new Size(16, 2), lcdInterface)
         {
         }
     }

--- a/src/devices/CharacterLcd/Lcd1602.cs
+++ b/src/devices/CharacterLcd/Lcd1602.cs
@@ -36,7 +36,7 @@ namespace Iot.Device.CharacterLcd
         /// </remarks>
         /// <param name="device">The I2c device for the LCD.</param>
         /// <param name="uses8Bit">True if the device uses 8 Bit commands, false if it handles only 4 bit commands.</param>
-        public Lcd1602(I2cDevice device, bool uses8Bit)
+        public Lcd1602(I2cDevice device, bool uses8Bit = true)
             : base(new Size(16, 2), LcdInterface.CreateI2c(device, uses8Bit))
         {
         }

--- a/src/devices/CharacterLcd/Lcd2004.cs
+++ b/src/devices/CharacterLcd/Lcd2004.cs
@@ -44,9 +44,9 @@ namespace Iot.Device.CharacterLcd
         /// <summary>
         /// Constructs a new LCD 20x4 controller with the given interface
         /// </summary>
-        /// <param name="interface">The LCD Interface</param>
-        public Lcd2004(LcdInterface @interface)
-            : base(new Size(20, 4), @interface)
+        /// <param name="lcdInterface">The LCD Interface</param>
+        public Lcd2004(LcdInterface lcdInterface)
+            : base(new Size(20, 4), lcdInterface)
         {
         }
     }

--- a/src/devices/CharacterLcd/Lcd2004.cs
+++ b/src/devices/CharacterLcd/Lcd2004.cs
@@ -36,7 +36,7 @@ namespace Iot.Device.CharacterLcd
         /// </remarks>
         /// <param name="device">The I2c device for the LCD.</param>
         /// <param name="uses8Bit">True if the device uses 8 Bit commands, false if it handles only 4 bit commands.</param>
-        public Lcd2004(I2cDevice device, bool uses8Bit)
+        public Lcd2004(I2cDevice device, bool uses8Bit = true)
             : base(new Size(20, 4), LcdInterface.CreateI2c(device, uses8Bit))
         {
         }

--- a/src/devices/CharacterLcd/Lcd2004.cs
+++ b/src/devices/CharacterLcd/Lcd2004.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
+using System.Device.I2c;
 using System.Drawing;
 
 namespace Iot.Device.CharacterLcd
@@ -24,6 +25,28 @@ namespace Iot.Device.CharacterLcd
         /// <param name="controller">The controller to use with the LCD. If not specified, uses the platform default.</param>
         public Lcd2004(int registerSelectPin, int enablePin, int[] dataPins, int backlightPin = -1, float backlightBrightness = 1.0f, int readWritePin = -1, GpioController controller = null)
             : base(new Size(20, 4), LcdInterface.CreateGpio(registerSelectPin, enablePin, dataPins, backlightPin, backlightBrightness, readWritePin, controller))
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new HD44780 based 16x2 LCD controller with integrated I2c support.
+        /// </summary>
+        /// <remarks>
+        /// This is for on-chip I2c support. For connecting via I2c GPIO expanders, use the GPIO constructor <see cref="Lcd1602(int, int, int[], int, float, int, GpioController)"/>.
+        /// </remarks>
+        /// <param name="device">The I2c device for the LCD.</param>
+        /// <param name="uses8Bit">True if the device uses 8 Bit commands, false if it handles only 4 bit commands.</param>
+        public Lcd2004(I2cDevice device, bool uses8Bit)
+            : base(new Size(20, 4), LcdInterface.CreateI2c(device, uses8Bit))
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new LCD 20x4 controller with the given interface
+        /// </summary>
+        /// <param name="interface">The LCD Interface</param>
+        public Lcd2004(LcdInterface @interface)
+            : base(new Size(20, 4), @interface)
         {
         }
     }

--- a/src/devices/CharacterLcd/LcdInterface.I2c.cs
+++ b/src/devices/CharacterLcd/LcdInterface.I2c.cs
@@ -63,11 +63,13 @@ namespace Iot.Device.CharacterLcd
             {
                 get
                 {
-                    // Not implemented / Not supported, but don't throw exceptions here
+                    // Setting the backlight on or off is not supported with 8 bit commands, according to the docs. 
                     return true;
                 }
                 set
                 {
+                    // Ignore setting the backlight. Exceptions are not expected by user code here, as it is normal to 
+                    // enable this during initialization, so that it is enabled whether switching it is supported or not.
                 }
             }
 

--- a/src/devices/CharacterLcd/LcdInterface.I2c.cs
+++ b/src/devices/CharacterLcd/LcdInterface.I2c.cs
@@ -59,7 +59,17 @@ namespace Iot.Device.CharacterLcd
 
             public override bool EightBitMode => true;
 
-            public override bool BacklightOn { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public override bool BacklightOn 
+            {
+                get
+                {
+                    // Not implemented / Not supported, but don't throw exceptions here
+                    return true;
+                }
+                set
+                {
+                }
+            }
 
             public override void SendCommand(byte command)
             {

--- a/src/devices/CharacterLcd/LcdInterface.I2c4Bit.cs
+++ b/src/devices/CharacterLcd/LcdInterface.I2c4Bit.cs
@@ -106,14 +106,13 @@ namespace Iot.Device.CharacterLcd
 
             private void Write4Bits(byte command)
             {
-                // _device.WriteByte((byte)(command | BacklightFlag));
                 _device.WriteByte((byte)(command | ENABLE | BacklightFlag));
                 _device.WriteByte((byte)((command & ~ENABLE) | BacklightFlag));
             }
 
             public override void SendCommands(ReadOnlySpan<byte> commands)
             {
-                foreach(var c in commands)
+                foreach (var c in commands)
                 {
                     SendCommand(c);
                 }

--- a/src/devices/CharacterLcd/LcdInterface.I2c4Bit.cs
+++ b/src/devices/CharacterLcd/LcdInterface.I2c4Bit.cs
@@ -101,7 +101,7 @@ namespace Iot.Device.CharacterLcd
             public override void SendCommand(byte command)
             {
                 Write4Bits((byte)(0x00 | (command & 0xF0)));
-                Write4Bits((byte)(0x00 | (command << 4 & 0xF0)));
+                Write4Bits((byte)(0x00 | ((command << 4) & 0xF0)));
             }
 
             private void Write4Bits(byte command)
@@ -121,7 +121,7 @@ namespace Iot.Device.CharacterLcd
             public override void SendData(byte value)
             {
                 Write4Bits((byte)(REGISTERSELECT | (value & 0xF0)));
-                Write4Bits((byte)(REGISTERSELECT | (value << 4 & 0xF0)));
+                Write4Bits((byte)(REGISTERSELECT | ((value << 4) & 0xF0)));
             }
 
             public override void SendData(ReadOnlySpan<byte> values)
@@ -129,7 +129,7 @@ namespace Iot.Device.CharacterLcd
                 foreach (var c in values)
                 {
                     Write4Bits((byte)(REGISTERSELECT | (c & 0xF0)));
-                    Write4Bits((byte)(REGISTERSELECT | (c << 4 & 0xF0)));
+                    Write4Bits((byte)(REGISTERSELECT | ((c << 4) & 0xF0)));
                 }
             }
         }

--- a/src/devices/CharacterLcd/LcdInterface.I2c4Bit.cs
+++ b/src/devices/CharacterLcd/LcdInterface.I2c4Bit.cs
@@ -1,0 +1,138 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Device.I2c;
+using System.Threading;
+
+namespace Iot.Device.CharacterLcd
+{
+    public abstract partial class LcdInterface : IDisposable
+    {
+        /// <summary>
+        /// Built-in I2c access to the Hd44780 compatible controller. The Philips/NXP LCD driver ICs
+        /// (such as the PCF2119x) are examples of this support. 
+        /// This driver uses 4-Bit access (each character/command is split into 2x4 bits for transmission)
+        /// </summary>
+        private class I2c4Bit : LcdInterface
+        {
+            const byte ENABLE = 0b0000_0100;
+            const byte READWRITE = 0b0000_0010;
+            const byte REGISTERSELECT = 0b0000_0001;
+
+            const byte LCD_BACKLIGHT = 0x08;
+            const byte LCD_FUNCTIONSET = 0x20;
+            const byte LCD_DISPLAYCONTROL = 0x08;
+            const byte LCD_CLEARDISPLAY = 0x01;
+            const byte LCD_DISPLAYON = 0x04;
+            const byte LCD_2LINE = 0x08;
+            const byte LCD_5x8DOTS = 0x00;
+            const byte LCD_ENTRYMODESET = 0x04;
+            const byte LCD_ENTRYLEFT = 0x02;
+            const byte LCD_4BITMODE = 0x00;
+
+            private readonly I2cDevice _device;
+            private bool _backlightOn;
+
+            public I2c4Bit(I2cDevice device)
+            {
+                _device = device;
+                _backlightOn = true;
+                InitDisplay();
+            }
+
+            public override bool EightBitMode => false;
+
+            /// <summary>
+            /// This Display supports enabling/disabling the backlight. 
+            /// The text on the display is not affected by disabling the backlight - it is just very hard to read.
+            /// </summary>
+            public override bool BacklightOn 
+            {
+                get
+                {
+                    return _backlightOn;
+                }
+                set
+                {
+                    _backlightOn = value;
+                    // Need to send a command to make this happen immediately.
+                    SendCommand(0);
+                }
+            }
+
+            private byte BacklightFlag
+            {
+                get
+                {
+                    if (BacklightOn)
+                    {
+                        return LCD_BACKLIGHT;
+                    }
+                    else
+                    {
+                        return 0;
+                    }
+                }
+            }
+
+            private void InitDisplay()
+            {
+                // This sequence (copied from a python example) completely resets the display (if it was 
+                // previously erroneously used with 8 bit access, it may not return to normal operation otherwise)
+                SendCommandAndWait(0x3);
+                SendCommandAndWait(0x3);
+                SendCommandAndWait(0x3);
+                SendCommandAndWait(0x2);
+                SendCommandAndWait(LCD_FUNCTIONSET | LCD_2LINE | LCD_5x8DOTS | LCD_4BITMODE);
+                SendCommandAndWait(LCD_DISPLAYCONTROL | LCD_DISPLAYON);
+                SendCommandAndWait(LCD_CLEARDISPLAY);
+                SendCommandAndWait(LCD_ENTRYMODESET | LCD_ENTRYLEFT);
+            }
+
+            private void SendCommandAndWait(byte command)
+            {
+                // Must not run the init sequence to fast or undefined behavior may occur
+                SendCommand(command);
+                Thread.Sleep(1);
+            }
+
+            public override void SendCommand(byte command)
+            {
+                Write4Bits((byte)(0x00 | (command & 0xF0)));
+                Write4Bits((byte)(0x00 | (command << 4 & 0xF0)));
+            }
+
+            private void Write4Bits(byte command)
+            {
+                // _device.WriteByte((byte)(command | BacklightFlag));
+                _device.WriteByte((byte)(command | ENABLE | BacklightFlag));
+                _device.WriteByte((byte)((command & ~ENABLE) | BacklightFlag));
+            }
+
+            public override void SendCommands(ReadOnlySpan<byte> commands)
+            {
+                foreach(var c in commands)
+                {
+                    SendCommand(c);
+                }
+            }
+
+            public override void SendData(byte value)
+            {
+                Write4Bits((byte)(REGISTERSELECT | (value & 0xF0)));
+                Write4Bits((byte)(REGISTERSELECT | (value << 4 & 0xF0)));
+            }
+
+            public override void SendData(ReadOnlySpan<byte> values)
+            {
+                foreach (var c in values)
+                {
+                    Write4Bits((byte)(REGISTERSELECT | (c & 0xF0)));
+                    Write4Bits((byte)(REGISTERSELECT | (c << 4 & 0xF0)));
+                }
+            }
+        }
+    }
+}

--- a/src/devices/CharacterLcd/LcdInterface.cs
+++ b/src/devices/CharacterLcd/LcdInterface.cs
@@ -133,9 +133,17 @@ namespace Iot.Device.CharacterLcd
         /// This is for on-chip I2c support. For connecting via I2c GPIO expanders, use the GPIO interface <see cref="CreateGpio(int, int, int[], int, float, int, GpioController)"/>.
         /// </remarks>
         /// <param name="device">The I2c device for the LCD.</param>
-        public static LcdInterface CreateI2c(I2cDevice device)
+        /// <param name="uses8Bit">True if the device uses 8 Bit commands, false if it handles only 4 bit commands.</param>
+        public static LcdInterface CreateI2c(I2cDevice device, bool uses8Bit)
         {
-            return new I2c(device);
+            if (uses8Bit)
+            {
+                return new I2c(device);
+            }
+            else
+            {
+                return new I2c4Bit(device);
+            }
         }
     }
 }

--- a/src/devices/CharacterLcd/LcdInterface.cs
+++ b/src/devices/CharacterLcd/LcdInterface.cs
@@ -134,7 +134,7 @@ namespace Iot.Device.CharacterLcd
         /// </remarks>
         /// <param name="device">The I2c device for the LCD.</param>
         /// <param name="uses8Bit">True if the device uses 8 Bit commands, false if it handles only 4 bit commands.</param>
-        public static LcdInterface CreateI2c(I2cDevice device, bool uses8Bit)
+        public static LcdInterface CreateI2c(I2cDevice device, bool uses8Bit = true)
         {
             if (uses8Bit)
             {

--- a/src/devices/CharacterLcd/LcdRgb.cs
+++ b/src/devices/CharacterLcd/LcdRgb.cs
@@ -39,10 +39,10 @@ namespace Iot.Device.CharacterLcd
         /// Initializes a new HD44780 LCD with an RGB Backlight.
         /// </summary>
         /// <param name="size">Size of the device in characters. Usually 16x2 or 20x4.</param>
-        /// <param name="interface">Interface to the display.</param>
+        /// <param name="lcdInterface">Interface to the display.</param>
         /// <param name="rgbDevice">The I2C device to control RGB backlight.</param>
-        public LcdRgb(Size size, LcdInterface @interface, I2cDevice rgbDevice)
-            : base(size, @interface)
+        public LcdRgb(Size size, LcdInterface lcdInterface, I2cDevice rgbDevice)
+            : base(size, lcdInterface)
         {
             _rgbDevice = rgbDevice;
 

--- a/src/devices/CharacterLcd/LcdRgb.cs
+++ b/src/devices/CharacterLcd/LcdRgb.cs
@@ -9,12 +9,12 @@ using System.Drawing;
 namespace Iot.Device.CharacterLcd
 {
     /// <summary>
-    /// Supports I2c LCDs with I2c RGB backlight, such as the Grove - LCD RGB Backlight (16x2 LCD character display with RGB backlight).
+    /// Supports I2c LCDs with I2c RGB backlight, such as the Grove - LCD RGB Backlight (i.e. 16x2 LCD character display with RGB backlight).
     /// </summary>
     /// <remarks>
     /// This implementation was drawn from numerous libraries such as Grove_LCD_RGB_Backlight.
     /// </remarks>
-    public class LcdRgb1602 : Lcd1602
+    public class LcdRgb : Hd44780
     {
         private readonly I2cDevice _rgbDevice;
 
@@ -24,10 +24,11 @@ namespace Iot.Device.CharacterLcd
         /// <summary>
         /// Initializes a new HD44780 LCD controller.
         /// </summary>
+        /// <param name="size">Size of the device in characters. Usually 16x2 or 20x4.</param>
         /// <param name="lcdDevice">The I2C device to control LCD display.</param>
         /// <param name="rgbDevice">The I2C device to control RGB backlight.</param>
-        public LcdRgb1602(I2cDevice lcdDevice, I2cDevice rgbDevice)
-            : base(lcdDevice, true)
+        public LcdRgb(Size size, I2cDevice lcdDevice, I2cDevice rgbDevice)
+            : base(size, LcdInterface.CreateI2c(lcdDevice, true))
         {
             _rgbDevice = rgbDevice;
 
@@ -37,10 +38,11 @@ namespace Iot.Device.CharacterLcd
         /// <summary>
         /// Initializes a new HD44780 LCD with an RGB Backlight.
         /// </summary>
+        /// <param name="size">Size of the device in characters. Usually 16x2 or 20x4.</param>
         /// <param name="interface">Interface to the display.</param>
         /// <param name="rgbDevice">The I2C device to control RGB backlight.</param>
-        public LcdRgb1602(LcdInterface @interface, I2cDevice rgbDevice)
-            : base(@interface)
+        public LcdRgb(Size size, LcdInterface @interface, I2cDevice rgbDevice)
+            : base(size, @interface)
         {
             _rgbDevice = rgbDevice;
 

--- a/src/devices/CharacterLcd/LcdRgb1602.cs
+++ b/src/devices/CharacterLcd/LcdRgb1602.cs
@@ -27,7 +27,20 @@ namespace Iot.Device.CharacterLcd
         /// <param name="lcdDevice">The I2C device to control LCD display.</param>
         /// <param name="rgbDevice">The I2C device to control RGB backlight.</param>
         public LcdRgb1602(I2cDevice lcdDevice, I2cDevice rgbDevice)
-            : base(lcdDevice)
+            : base(lcdDevice, true)
+        {
+            _rgbDevice = rgbDevice;
+
+            InitRgb();
+        }
+
+        /// <summary>
+        /// Initializes a new HD44780 LCD with an RGB Backlight.
+        /// </summary>
+        /// <param name="interface">Interface to the display.</param>
+        /// <param name="rgbDevice">The I2C device to control RGB backlight.</param>
+        public LcdRgb1602(LcdInterface @interface, I2cDevice rgbDevice)
+            : base(@interface)
         {
             _rgbDevice = rgbDevice;
 

--- a/src/devices/CharacterLcd/samples/CharacterLcd.Sample.cs
+++ b/src/devices/CharacterLcd/samples/CharacterLcd.Sample.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Threading;
 using System.Device.Gpio;
 using System.Device.I2c;
+using System.Globalization;
 using Iot.Device.Mcp23xxx;
 
 namespace Iot.Device.CharacterLcd.Samples
@@ -17,11 +20,12 @@ namespace Iot.Device.CharacterLcd.Samples
         static void Main(string[] args)
         {
             // Sets up a 16x2 character LCD with a hardwired or no backlight.
-            using (Lcd1602 lcd = new Lcd1602(registerSelectPin: 22, enablePin: 17, dataPins: new int[] { 25, 24, 23, 18 }))
-            {
-                lcd.Clear();
-                lcd.Write("Hello World");
-            }
+            //using (Lcd1602 lcd = new Lcd1602(registerSelectPin: 22, enablePin: 17, dataPins: new int[] { 25, 24, 23, 18 }))
+            //{
+            //    lcd.Clear();
+            //    lcd.Write("Hello World");
+            //}
+            UsingHd44780OverI2C();
         }
 
         /// <summary>
@@ -45,6 +49,24 @@ namespace Iot.Device.CharacterLcd.Samples
                 lcd.SetCursorPosition(0, 1);
                 lcd.Write(".NET Core");
             }
+        }
+
+        static void UsingHd44780OverI2C()
+        {
+            using (I2cDevice i2CDevice = I2cDevice.Create(new I2cConnectionSettings(1, 0x27)))
+            {
+                LcdInterface lcdInterface = LcdInterface.CreateI2c(i2CDevice, false);
+                using (Hd44780 hd44780 = new Lcd2004(lcdInterface))
+                {
+                    hd44780.UnderlineCursorVisible = false;
+                    hd44780.BacklightOn = true;
+                    hd44780.DisplayOn = true;
+                    hd44780.Clear();
+                    ExtendedSample.Test(hd44780);
+                    
+                }
+            }
+
         }
     }
 }

--- a/src/devices/CharacterLcd/samples/CharacterLcd.Sample.cs
+++ b/src/devices/CharacterLcd/samples/CharacterLcd.Sample.cs
@@ -19,13 +19,22 @@ namespace Iot.Device.CharacterLcd.Samples
         /// <param name="args">Should be empty</param>
         static void Main(string[] args)
         {
-            // Sets up a 16x2 character LCD with a hardwired or no backlight.
-            //using (Lcd1602 lcd = new Lcd1602(registerSelectPin: 22, enablePin: 17, dataPins: new int[] { 25, 24, 23, 18 }))
-            //{
-            //    lcd.Clear();
-            //    lcd.Write("Hello World");
-            //}
+            // Choose the right setup for your display:
+            // UsingGpioPins()
+            // UsingMcp()
             UsingHd44780OverI2C();
+        }
+
+        /// <summary>
+        /// This sets up a 16x2 character LCD, directly connected to a set of GPIO pins, with a hardwired or no backlight and 4 Bit commands
+        /// </summary>
+        static void UsingGpioPins()
+        {
+            using (Lcd1602 lcd = new Lcd1602(registerSelectPin: 22, enablePin: 17, dataPins: new int[] { 25, 24, 23, 18 }))
+            {
+                lcd.Clear();
+                lcd.Write("Hello World");
+            }
         }
 
         /// <summary>
@@ -51,6 +60,10 @@ namespace Iot.Device.CharacterLcd.Samples
             }
         }
 
+        /// <summary>
+        /// This method will use I2C commands to talk to the display. The display is expected to be at address 0x27 and accept 4 bit commands. 
+        /// This runs a full test suite against the display. 
+        /// </summary>
         static void UsingHd44780OverI2C()
         {
             using (I2cDevice i2CDevice = I2cDevice.Create(new I2cConnectionSettings(1, 0x27)))
@@ -63,7 +76,6 @@ namespace Iot.Device.CharacterLcd.Samples
                     hd44780.DisplayOn = true;
                     hd44780.Clear();
                     ExtendedSample.Test(hd44780);
-                    
                 }
             }
 

--- a/src/devices/CharacterLcd/samples/Hd44780.ExtendedSample.cs
+++ b/src/devices/CharacterLcd/samples/Hd44780.ExtendedSample.cs
@@ -55,9 +55,7 @@ namespace Iot.Device.CharacterLcd.Samples
             TestPrompt("Wrap", lcd, l => l.Write(new string('*', 80) + ">>>>>"));
             TestPrompt("Perf", lcd, PerfTests);
 
-#if USERGB
             TestPrompt("Colors", lcd, SetBacklightColorTest);
-#endif
 
             // Now to something at least a bit usable...
             lcd.Clear();
@@ -217,8 +215,13 @@ namespace Iot.Device.CharacterLcd.Samples
             Console.WriteLine(result);
         }
 
-        static void SetBacklightColorTest(LcdRgb1602 lcd)
+        static void SetBacklightColorTest(Hd44780 lcd)
         {
+            var colorLcd = lcd as LcdRgb;
+            if (colorLcd == null)
+            {
+                Console.WriteLine("Color backlight not supported");
+            }
             Color[] colors = { Color.Red, Color.Green, Color.Blue, Color.Aqua, Color.Azure,
                 Color.Brown, Color.Chocolate, Color.LemonChiffon, Color.Lime, Color.Tomato, Color.Yellow };
 
@@ -227,12 +230,12 @@ namespace Iot.Device.CharacterLcd.Samples
                 lcd.Clear();
                 lcd.Write(color.Name);
 
-                lcd.SetBacklightColor(color);
+                colorLcd.SetBacklightColor(color);
                 System.Threading.Thread.Sleep(1000);
             }
 
             lcd.Clear();
-            lcd.SetBacklightColor(Color.White);
+            colorLcd.SetBacklightColor(Color.White);
         }
 
         static void TestPrompt<T>(string test, T lcd, Action<T> action) where T : Hd44780

--- a/src/devices/CharacterLcd/samples/Pcf8574tSample.cs
+++ b/src/devices/CharacterLcd/samples/Pcf8574tSample.cs
@@ -208,7 +208,7 @@ namespace Iot.Device.CharacterLcd.Samples
             Console.WriteLine(result);
         }
 
-        static void SetBacklightColorTest(LcdRgb1602 lcd)
+        static void SetBacklightColorTest(LcdRgb lcd)
         {
             Color[] colors = { Color.Red, Color.Green, Color.Blue, Color.Aqua, Color.Azure,
                 Color.Brown, Color.Chocolate, Color.LemonChiffon, Color.Lime, Color.Tomato, Color.Yellow };


### PR DESCRIPTION
This adds support for character LCD displays that are only connected trough 4 of the 8 data lines. 

This was tested with this display: https://www.joy-it.net/de/products/SBC-LCD20x4 which uses an I2C interface, but works only with 4-bit commands. 
