### PR TITLE
Fix path typos to point at correct READMEs in release notes

### DIFF
--- a/src/devices/README.md
+++ b/src/devices/README.md
@@ -12,188 +12,188 @@ Our vision: the majority of .NET bindings are written completely in .NET languag
 
 ### Analog/Digital converters
 
-* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw\README.md)
-* [ADS1115 - Analog to Digital Converter](Ads1115\README.md)
-* [Mcp3428 - Analog to Digital Converter (I2C)](Mcp3428\README.md)
-* [MCP3xxx family of Analog to Digital Converters](Mcp3xxx\README.md)
+* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw/README.md)
+* [ADS1115 - Analog to Digital Converter](Ads1115/README.md)
+* [Mcp3428 - Analog to Digital Converter (I2C)](Mcp3428/README.md)
+* [MCP3xxx family of Analog to Digital Converters](Mcp3xxx/README.md)
 
 ### Accelerometers
 
-* [ADXL345 - Accelerometer](Adxl345\README.md)
-* [BNO055 - inertial measurement unit](Bno055\README.md)
-* [LSM9DS1 - 3D accelerometer, gyroscope and magnetometer](Lsm9Ds1\README.md)
-* [Sense HAT](SenseHat\README.md)
+* [ADXL345 - Accelerometer](Adxl345/README.md)
+* [BNO055 - inertial measurement unit](Bno055/README.md)
+* [LSM9DS1 - 3D accelerometer, gyroscope and magnetometer](Lsm9Ds1/README.md)
+* [Sense HAT](SenseHat/README.md)
 
 ### Volatile Organic Compound sensors
 
-* [AGS01DB - MEMS VOC Gas Sensor](Ags01db\README.md)
-* [BMxx80 Device Family](Bmxx80\README.md)
+* [AGS01DB - MEMS VOC Gas Sensor](Ags01db/README.md)
+* [BMxx80 Device Family](Bmxx80/README.md)
 
 ### Gas sensors
 
-* [AGS01DB - MEMS VOC Gas Sensor](Ags01db\README.md)
-* [BMxx80 Device Family](Bmxx80\README.md)
+* [AGS01DB - MEMS VOC Gas Sensor](Ags01db/README.md)
+* [BMxx80 Device Family](Bmxx80/README.md)
 
 ### Light sensor
 
-* [BH1750FVI - Ambient Light Sensor](Bh1750fvi\README.md)
-* [MAX44009 - Ambient Light Sensor](Max44009\README.md)
-* [TCS3472x Sensors](Tcs3472x\README.md)
+* [BH1750FVI - Ambient Light Sensor](Bh1750fvi/README.md)
+* [MAX44009 - Ambient Light Sensor](Max44009/README.md)
+* [TCS3472x Sensors](Tcs3472x/README.md)
 
 ### Barometers
 
-* [BMP180 - barometer, altitude and temperature sensor](Bmp180\README.md)
-* [BMxx80 Device Family](Bmxx80\README.md)
-* [LPS25H - Piezoresistive pressure and thermometer sensor](Lps25h\README.md)
-* [Sense HAT](SenseHat\README.md)
+* [BMP180 - barometer, altitude and temperature sensor](Bmp180/README.md)
+* [BMxx80 Device Family](Bmxx80/README.md)
+* [LPS25H - Piezoresistive pressure and thermometer sensor](Lps25h/README.md)
+* [Sense HAT](SenseHat/README.md)
 
 ### Altimeters
 
-* [BMP180 - barometer, altitude and temperature sensor](Bmp180\README.md)
-* [BMxx80 Device Family](Bmxx80\README.md)
+* [BMP180 - barometer, altitude and temperature sensor](Bmp180/README.md)
+* [BMxx80 Device Family](Bmxx80/README.md)
 
 ### Thermometers
 
-* [BMP180 - barometer, altitude and temperature sensor](Bmp180\README.md)
-* [BMxx80 Device Family](Bmxx80\README.md)
-* [Cpu Temperature](CpuTemperature\README.md)
-* [DHTxx - Digital-Output Relative Humidity & Temperature Sensor Module](Dhtxx\README.md)
-* [HTS221 - Capacitive digital sensor for relative humidity and temperature](Hts221\README.md)
-* [LM75 - Digital Temperature Sensor](Lm75\README.md)
-* [LPS25H - Piezoresistive pressure and thermometer sensor](Lps25h\README.md)
-* [MLX90614 - Infra Red Thermometer](Mlx90614\README.md)
-* [Sense HAT](SenseHat\README.md)
-* [SHT3x - Temperature & Humidity Sensor](Sht3x\README.md)
-* [Si7021 - Temperature & Humidity Sensor](Si7021\README.md)
+* [BMP180 - barometer, altitude and temperature sensor](Bmp180/README.md)
+* [BMxx80 Device Family](Bmxx80/README.md)
+* [Cpu Temperature](CpuTemperature/README.md)
+* [DHTxx - Digital-Output Relative Humidity & Temperature Sensor Module](Dhtxx/README.md)
+* [HTS221 - Capacitive digital sensor for relative humidity and temperature](Hts221/README.md)
+* [LM75 - Digital Temperature Sensor](Lm75/README.md)
+* [LPS25H - Piezoresistive pressure and thermometer sensor](Lps25h/README.md)
+* [MLX90614 - Infra Red Thermometer](Mlx90614/README.md)
+* [Sense HAT](SenseHat/README.md)
+* [SHT3x - Temperature & Humidity Sensor](Sht3x/README.md)
+* [Si7021 - Temperature & Humidity Sensor](Si7021/README.md)
 
 ### Gyroscopes
 
-* [BNO055 - inertial measurement unit](Bno055\README.md)
-* [LSM9DS1 - 3D accelerometer, gyroscope and magnetometer](Lsm9Ds1\README.md)
-* [Sense HAT](SenseHat\README.md)
+* [BNO055 - inertial measurement unit](Bno055/README.md)
+* [LSM9DS1 - 3D accelerometer, gyroscope and magnetometer](Lsm9Ds1/README.md)
+* [Sense HAT](SenseHat/README.md)
 
 ### Compasses
 
-* [BNO055 - inertial measurement unit](Bno055\README.md)
-* [HMC5883L - 3 Axis Digital Compass](Hmc5883l\README.md)
+* [BNO055 - inertial measurement unit](Bno055/README.md)
+* [HMC5883L - 3 Axis Digital Compass](Hmc5883l/README.md)
 
 ### Lego related devices
 
-* [BrickPi3](BrickPi3\README.md)
+* [BrickPi3](BrickPi3/README.md)
 
 ### Motor controllers/drivers
 
-* [28BYJ-48 Stepper Motor 5V 4-Phase 5-Wire & ULN2003 Driver Board](Uln2003\README.md)
-* [DC Motor Controller](DCMotor\README.md)
-* [Servo Motor](ServoMotor\README.md)
+* [28BYJ-48 Stepper Motor 5V 4-Phase 5-Wire & ULN2003 Driver Board](Uln2003/README.md)
+* [DC Motor Controller](DCMotor/README.md)
+* [Servo Motor](ServoMotor/README.md)
 
 ### Inertial Measurement Units
 
-* [BNO055 - inertial measurement unit](Bno055\README.md)
-* [LSM9DS1 - 3D accelerometer, gyroscope and magnetometer](Lsm9Ds1\README.md)
-* [Sense HAT](SenseHat\README.md)
+* [BNO055 - inertial measurement unit](Bno055/README.md)
+* [LSM9DS1 - 3D accelerometer, gyroscope and magnetometer](Lsm9Ds1/README.md)
+* [Sense HAT](SenseHat/README.md)
 
 ### Magnetometers
 
-* [BNO055 - inertial measurement unit](Bno055\README.md)
-* [HMC5883L - 3 Axis Digital Compass](Hmc5883l\README.md)
-* [LSM9DS1 - 3D accelerometer, gyroscope and magnetometer](Lsm9Ds1\README.md)
-* [Sense HAT](SenseHat\README.md)
+* [BNO055 - inertial measurement unit](Bno055/README.md)
+* [HMC5883L - 3 Axis Digital Compass](Hmc5883l/README.md)
+* [LSM9DS1 - 3D accelerometer, gyroscope and magnetometer](Lsm9Ds1/README.md)
+* [Sense HAT](SenseHat/README.md)
 
 ### Liquid Crystal Displays
 
-* [Character LCD (Liquid Crystal Display)](CharacterLcd\README.md)
+* [Character LCD (Liquid Crystal Display)](CharacterLcd/README.md)
 
 ### Hygrometers
 
-* [BMxx80 Device Family](Bmxx80\README.md)
-* [DHTxx - Digital-Output Relative Humidity & Temperature Sensor Module](Dhtxx\README.md)
-* [HTS221 - Capacitive digital sensor for relative humidity and temperature](Hts221\README.md)
-* [Sense HAT](SenseHat\README.md)
-* [SHT3x - Temperature & Humidity Sensor](Sht3x\README.md)
-* [Si7021 - Temperature & Humidity Sensor](Si7021\README.md)
+* [BMxx80 Device Family](Bmxx80/README.md)
+* [DHTxx - Digital-Output Relative Humidity & Temperature Sensor Module](Dhtxx/README.md)
+* [HTS221 - Capacitive digital sensor for relative humidity and temperature](Hts221/README.md)
+* [Sense HAT](SenseHat/README.md)
+* [SHT3x - Temperature & Humidity Sensor](Sht3x/README.md)
+* [Si7021 - Temperature & Humidity Sensor](Si7021/README.md)
 
 ### Clocks
 
-* [Realtime Clock](Rtc\README.md)
+* [Realtime Clock](Rtc/README.md)
 
 ### Sonars
 
-* [HC-SR04 - Ultrasonic Ranging Module](Hcsr04\README.md)
+* [HC-SR04 - Ultrasonic Ranging Module](Hcsr04/README.md)
 
 ### Distance sensors
 
-* [HC-SR04 - Ultrasonic Ranging Module](Hcsr04\README.md)
-* [VL53L0X - distance sensor](Vl53L0X\README.md)
+* [HC-SR04 - Ultrasonic Ranging Module](Hcsr04/README.md)
+* [VL53L0X - distance sensor](Vl53L0X/README.md)
 
 ### Passive InfraRed (motion) sensors
 
-* [HC-SR501 - PIR Motion Sensor](Hcsr501\README.md)
+* [HC-SR501 - PIR Motion Sensor](Hcsr501/README.md)
 
 ### Motion sensors
 
-* [HC-SR501 - PIR Motion Sensor](Hcsr501\README.md)
+* [HC-SR501 - PIR Motion Sensor](Hcsr501/README.md)
 
 ### Displays
 
-* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw\README.md)
-* [Max7219 (LED Matrix driver)](Max7219\README.md)
-* [RGBLedMatrix - RGB LED Matrix](RGBLedMatrix\README.md)
-* [Sense HAT](SenseHat\README.md)
-* [Solomon Systech Ssd1306 OLED display](Ssd13xx\README.md)
-* [Solomon Systech Ssd1351 - CMOS OLED](Ssd1351\README.md)
-* [TM1637 - Segment Display](Tm1637\README.md)
-* [Ws28xx LED drivers](Ws28xx\README.md)
+* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw/README.md)
+* [Max7219 (LED Matrix driver)](Max7219/README.md)
+* [RGBLedMatrix - RGB LED Matrix](RGBLedMatrix/README.md)
+* [Sense HAT](SenseHat/README.md)
+* [Solomon Systech Ssd1306 OLED display](Ssd13xx/README.md)
+* [Solomon Systech Ssd1351 - CMOS OLED](Ssd1351/README.md)
+* [TM1637 - Segment Display](Tm1637/README.md)
+* [Ws28xx LED drivers](Ws28xx/README.md)
 
 ### GPIO Expanders
 
-* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw\README.md)
-* [Mcp23xxx - I/O Expander device family](Mcp23xxx\README.md)
-* [NXP/TI PCx857x](Pcx857x\README.md)
-* [Pca95x4 - I2C GPIO Expander](Pca95x4\README.md)
+* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw/README.md)
+* [Mcp23xxx - I/O Expander device family](Mcp23xxx/README.md)
+* [NXP/TI PCx857x](Pcx857x/README.md)
+* [Pca95x4 - I2C GPIO Expander](Pca95x4/README.md)
 
 ### CAN BUS libraries/modules
 
-* [Mcp25xxx device family - CAN bus](Mcp25xxx\README.md)
-* [SocketCan - CAN BUS library (Linux only)](SocketCan\README.md)
+* [Mcp25xxx device family - CAN bus](Mcp25xxx/README.md)
+* [SocketCan - CAN BUS library (Linux only)](SocketCan/README.md)
 
 ### Proximity sensors
 
-* [MPR121 - Proximity Capacitive Touch Sensor Controller](Mpr121\README.md)
+* [MPR121 - Proximity Capacitive Touch Sensor Controller](Mpr121/README.md)
 
 ### Touch sensors
 
-* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw\README.md)
-* [MPR121 - Proximity Capacitive Touch Sensor Controller](Mpr121\README.md)
+* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw/README.md)
+* [MPR121 - Proximity Capacitive Touch Sensor Controller](Mpr121/README.md)
 
 ### Wireless communication modules
 
-* [nRF24L01 - Single Chip 2.4 GHz Transceiver](Nrf24l01\README.md)
-* [Radio Receiver](RadioReceiver\README.md)
-* [Radio Transmitter](RadioTransmitter\README.md)
+* [nRF24L01 - Single Chip 2.4 GHz Transceiver](Nrf24l01/README.md)
+* [Radio Receiver](RadioReceiver/README.md)
+* [Radio Transmitter](RadioTransmitter/README.md)
 
 ### PWM libraries/modules
 
-* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw\README.md)
-* [Pca9685 - I2C PWM Driver](Pca9685\README.md)
-* [Software PWM](SoftPwm\README.md)
+* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw/README.md)
+* [Pca9685 - I2C PWM Driver](Pca9685/README.md)
+* [Software PWM](SoftPwm/README.md)
 
 ### Joysticks
 
-* [Sense HAT](SenseHat\README.md)
+* [Sense HAT](SenseHat/README.md)
 
 ### Color sensors
 
-* [TCS3472x Sensors](Tcs3472x\README.md)
+* [TCS3472x Sensors](Tcs3472x/README.md)
 
 ### LED drivers
 
-* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw\README.md)
-* [Ws28xx LED drivers](Ws28xx\README.md)
+* [Adafruit Seesaw - extension board (ADC, PWM, GPIO expander)](Seesaw/README.md)
+* [Ws28xx LED drivers](Ws28xx/README.md)
 
 ### SPI libraries/modules
 
-* [Software implementation of SPI](SoftwareSpi\README.md)
+* [Software implementation of SPI](SoftwareSpi/README.md)
 
 </categorizedDevices>
 


### PR DESCRIPTION
I noticed that the links to the READMEs was incorrect because of a path typo, fixed it. Hope that's OK! I had to keep changing the URL when reading each link. 😄 