### PR TITLE
Hardware PWM Fixes / Improvements

### DIFF
--- a/src/System.Device.Gpio/System/Device/Pwm/55-pwm.rules
+++ b/src/System.Device.Gpio/System/Device/Pwm/55-pwm.rules
@@ -1,0 +1,4 @@
+SUBSYSTEM=="pwm*", PROGRAM="/bin/sh -c '\
+        chown -R root:gpio /sys/class/pwm && chmod -R 770 /sys/class/pwm;\
+        chown -R root:gpio /sys/devices/platform/soc/*.pwm/pwm/pwmchip* && chmod -R 770 /sys/devices/platform/soc/*.pwm/pwm/pwmchip*\
+'"


### PR DESCRIPTION
- This fixes a crash when changing the frequency while the duty-cycle is high (check this command-line sequence):
```
oot@raspberrypi:/sys/class/pwm/pwmchip0/pwm0# echo 1 > enable
root@raspberrypi:/sys/class/pwm/pwmchip0/pwm0# echo 25000 > period
root@raspberrypi:/sys/class/pwm/pwmchip0/pwm0# echo 25000 > duty_cycle # the LED goes on now
root@raspberrypi:/sys/class/pwm/pwmchip0/pwm0# echo 10000 > period # fails, because duty_cycle > period
bash: echo: write error: Invalid argument
root@raspberrypi:/sys/class/pwm/pwmchip0/pwm0# echo 0 > duty_cycle # the LED goes off
root@raspberrypi:/sys/class/pwm/pwmchip0/pwm0# echo 10000 > period # period can be set
root@raspberrypi:/sys/class/pwm/pwmchip0/pwm0# echo 5000 > duty_cycle # and enable LED again
root@raspberrypi:/sys/class/pwm/pwmchip0/pwm0# 
```
- Adds the udev rule to access /sys/class/pwm as non-root (copy the file 55-pwm.rules to /etc/udev/rules.d and reboot) See also #813 
- To make the above really work, a few retries are necessary while opening the hardware PWM device, to make sure the permissions are updated. See also #811 

