### PR TITLE
Fixed spelling in SoftwarePwmChannel

### DIFF
--- a/src/devices/SoftPwm/SoftwarePwmChannel.cs
+++ b/src/devices/SoftPwm/SoftwarePwmChannel.cs
@@ -48,7 +48,7 @@ namespace System.Device.Pwm.Drivers
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, "Value must note be negative.");
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "Value must not be negative.");
                 }
                 _frequency = value;
                 _pulseFrequency = (_frequency > 0) ? 1 / _frequency * 1000.0 : 0.0;


### PR DESCRIPTION
Fixed a spelling mistake in ArgumentOutOfRangeException message when setting Frequency

- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/master/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
