### PR TITLE
Unseal 3 BMxx80 classes to match 1.0

### DIFF
--- a/src/devices/Bmxx80/Bme280.cs
+++ b/src/devices/Bmxx80/Bme280.cs
@@ -12,7 +12,7 @@ namespace Iot.Device.Bmxx80
     /// <summary>
     /// Represents a BME280 temperature, barometric pressure and humidity sensor.
     /// </summary>
-    public sealed class Bme280 : Bmx280Base
+    public class Bme280 : Bmx280Base
     {
         /// <summary>
         /// The expected chip ID of the BME280.

--- a/src/devices/Bmxx80/Bme680.cs
+++ b/src/devices/Bmxx80/Bme680.cs
@@ -17,7 +17,7 @@ namespace Iot.Device.Bmxx80
     /// <summary>
     /// Represents a BME680 temperature, pressure, relative humidity and VOC gas sensor.
     /// </summary>
-    public sealed class Bme680 : Bmxx80Base
+    public class Bme680 : Bmxx80Base
     {
         /// <summary>
         /// Default I2C bus address.

--- a/src/devices/Bmxx80/Bmp280.cs
+++ b/src/devices/Bmxx80/Bmp280.cs
@@ -9,7 +9,7 @@ namespace Iot.Device.Bmxx80
     /// <summary>
     /// Represents a BME280 temperature and barometric pressure sensor.
     /// </summary>
-    public sealed class Bmp280 : Bmx280Base
+    public class Bmp280 : Bmx280Base
     {
         /// <summary>
         /// The expected chip ID of the BMP280.


### PR DESCRIPTION
Fix 3 ApiCompat warnings about compat differences with 1.0.

We do not have good reason to seal them.