### PR TITLE
fixing DHT sensor issue with GrovePi firmware 1.4

### DIFF
--- a/src/devices/GrovePi/Sensors/DhtSensor.cs
+++ b/src/devices/GrovePi/Sensors/DhtSensor.cs
@@ -69,6 +69,7 @@ namespace Iot.Device.GrovePiDevice.Sensors
             {
                 _grovePi.WriteCommand(GrovePiCommand.DhtTemp, _port, (byte)DhtType, 0);
             }
+            
             // Wait a little bit to read the result
             // Delay from source code, line 90 in the Grove Pi firmware repository
             // This is needed for firmware 1.4.0 and also working for previous versions

--- a/src/devices/GrovePi/Sensors/DhtSensor.cs
+++ b/src/devices/GrovePi/Sensors/DhtSensor.cs
@@ -15,7 +15,7 @@ namespace Iot.Device.GrovePiDevice.Sensors
     public class DhtSensor
     {
         private GrovePi _grovePi;
-        private readonly double[] _lastTemHum = new double[2];
+        private readonly double[] _lastTemHum = new double[2] { double.NaN, double.NaN };
 
         /// <summary>
         /// grove sensor port
@@ -63,9 +63,16 @@ namespace Iot.Device.GrovePiDevice.Sensors
         /// </summary>
         public void Read()
         {
-            _grovePi.WriteCommand(GrovePiCommand.DhtTemp, _port, (byte)DhtType, 0);
+            // Fix for the firmware 1.4.0, you can request a new measurement only if you got data
+            // from the previous one
+            if (!(double.IsNaN(_lastTemHum[0]) && double.IsNaN(_lastTemHum[1])))
+            {
+                _grovePi.WriteCommand(GrovePiCommand.DhtTemp, _port, (byte)DhtType, 0);
+            }
             // Wait a little bit to read the result
-            Thread.Sleep(50);
+            // Delay from source code, line 90 in the Grove Pi firmware repository
+            // This is needed for firmware 1.4.0 and also working for previous versions
+            Thread.Sleep(300);
             var retArray = _grovePi.ReadCommand(GrovePiCommand.DhtTemp, _port);
             _lastTemHum[0] = BitConverter.ToSingle(retArray.AsSpan(1, 4));
             _lastTemHum[1] = BitConverter.ToSingle(retArray.AsSpan(5, 4));


### PR DESCRIPTION
Fixing issue "DhtSensor DhtType.Dht11 always returns NaN on .net core running a GrovePi+": https://github.com/dotnet/iot/issues/850
Tested with firmware 1.2.2 and 1.4.0