### PR TITLE
[3.0] Update pins used by tests to reflect new lab setup

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -13,9 +13,9 @@ namespace System.Device.Gpio.Tests
 {
     public abstract class GpioControllerTestBase
     {
-        private const int LedPin = 18;
-        private const int OutputPin = 16; // CI should fail now
-        private const int InputPin = 12;
+        private const int LedPin = 5;
+        private const int OutputPin = 5;
+        private const int InputPin = 6;
         private static readonly int WaitMilliseconds = 1000;
 
         [Fact]

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -14,7 +14,7 @@ namespace System.Device.Gpio.Tests
     public abstract class GpioControllerTestBase
     {
         private const int LedPin = 18;
-        private const int OutputPin = 16;
+        private const int OutputPin = 16; // CI should fail now
         private const int InputPin = 12;
         private static readonly int WaitMilliseconds = 1000;
 


### PR DESCRIPTION
Setup of the lab was updated today and now different pins are connected to each other

On first iteration CI is expected to fail
On second iteration I will fix up the pin numbers