### PR TITLE
Update pins used by tests to reflect new lab setup

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -13,9 +13,9 @@ namespace System.Device.Gpio.Tests
 {
     public abstract class GpioControllerTestBase
     {
-        private const int LedPin = 18;
-        private const int OutputPin = 16;
-        private const int InputPin = 12;
+        private const int LedPin = 5;
+        private const int OutputPin = 5;
+        private const int InputPin = 6;
         private static readonly int WaitMilliseconds = 1000;
 
         [Fact]


### PR DESCRIPTION
Setup of the lab was updated today and now different pins are connected to each other.

This PR only updates pins to unblock CI, I will make proper upgrade by merging https://github.com/dotnet/iot/pull/758