### PR TITLE
Fix wrong command in Tm1637.DisplayRaw(byte, byte)

### DIFF
--- a/src/devices/Tm1637/Tm1637.cs
+++ b/src/devices/Tm1637/Tm1637.cs
@@ -310,8 +310,8 @@ namespace Iot.Device.Tm1637
             WriteByte((byte)DataCommand.FixAddress);
             StopTransmission();
             StartTransmission();
-            // Fix address with the address
-            WriteByte((byte)(DataCommand.FixAddress + segmentAddress));
+            // Set the address to transfer
+            WriteByte((byte)(DataCommand.AddressCommandSetting + segmentAddress));
             // Transfer the byte
             WriteByte(rawData);
             StopTransmission();

--- a/src/devices/Tm1637/samples/Tm1637.sample.cs
+++ b/src/devices/Tm1637/samples/Tm1637.sample.cs
@@ -78,6 +78,9 @@ namespace Tm1637Sample
 
             Thread.Sleep(3000);
 
+            // Revert order of the segments
+            tm1637.SegmentOrder = new byte[] { 0, 1, 2, 3, 4, 5 };
+
             // Blink the screen by switching on and off
             for (int i = 0; i < 10; i++)
             {

--- a/src/devices/Tm1637/samples/Tm1637.sample.cs
+++ b/src/devices/Tm1637/samples/Tm1637.sample.cs
@@ -26,6 +26,17 @@ namespace Tm1637Sample
             tm1637.Display(toDisplay);
             Thread.Sleep(3000);
 
+            // Display a character at a specific segment position
+            // If you have a 4 display, only the fisrt 4 will be displayed as like as [0123]
+            // on a 6 segment one, all 6 will be displayed as like as [012345]
+            tm1637.Display(0, Character.Digit0);
+            tm1637.Display(1, Character.Digit1);
+            tm1637.Display(2, Character.Digit2);
+            tm1637.Display(3, Character.Digit3);
+            tm1637.Display(4, Character.Digit4);
+            tm1637.Display(5, Character.Digit5);
+            Thread.Sleep(3000);
+
             // Changing order of the segments
             tm1637.SegmentOrder = new byte[] { 2, 1, 0, 5, 4, 3 };
 
@@ -56,6 +67,15 @@ namespace Tm1637Sample
             }
 
             tm1637.Display(rawData);
+            Thread.Sleep(3000);
+
+            // If you have a 4 display, only the fisrt 4 will be displayed, as like as [6549]
+            // on a 6 segment one, all 6 will be displayed, as like as [654987]
+            for (int i = 0; i < 6; i++)
+            {
+                tm1637.Display((byte)i, (Character)Enum.Parse(typeof(Character), $"Digit{4 + i}"));
+            }
+
             Thread.Sleep(3000);
 
             // Blink the screen by switching on and off


### PR DESCRIPTION
`Tm1637.DisplayRaw(byte segmentAddress, byte rawData)` is sending incorrect command.
With current implementation, it always displays `rawData` to the first segment, regardless of the parameter `segmentAddress`. (See repro code and image below)

`DisplayRaw` must send `DataCommand.AddressCommandSetting + segmentAddress` to set the display address, not `DataCommand.FixAddress + segmentAddress`.

Repro code:
```cs
using System;
using System.Device.Gpio;
using Iot.Device.Tm1637;

class Program
{
  static void Main(string[] args)
  {
    var display = new Tm1637(
      pinDio: 16,
      pinClk: 18,
      pinNumberingScheme: PinNumberingScheme.Board
    );

    display.Brightness = 7;
    display.ScreenOn = true;
    display.ClearDisplay();

    display.Display(0, Character.Digit0);
    display.Display(1, Character.Digit1);
    display.Display(2, Character.Digit2);
    display.Display(3, Character.Digit3);
    display.Display(4, Character.Digit4);
    display.Display(5, Character.Digit5);
  }
}
```

This code displays characters like below.
![TM1637-broken](https://user-images.githubusercontent.com/553926/71270996-451fcd00-2396-11ea-99b9-3afcaf805ffe.jpg)

Fixed implementation displays characters like below as expected.
![TM1637-fixed](https://user-images.githubusercontent.com/553926/71271005-4bae4480-2396-11ea-8bbb-48a9be7af132.jpg)
