### PR TITLE
Add static modifier to Tm1637.MaxSegments

### DIFF
--- a/src/devices/Tm1637/Tm1637.cs
+++ b/src/devices/Tm1637/Tm1637.cs
@@ -20,7 +20,7 @@ namespace Iot.Device.Tm1637
         /// <summary>
         /// The number of segments that the TM1637 can handle
         /// </summary>
-        public byte MaxSegments => 6;
+        public static byte MaxSegments => 6;
 
         // According to the doc, the clock pulse width minimum is 400 ns
         // And waiting time between clk up and down is 1 µs


### PR DESCRIPTION
`Tm1637.MaxSegments` should be referable without instantiation.