### PR TITLE
StyleCop, some remaining issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,9 @@ indent_size = 2
 
 # C# files
 [*.cs]
+# Character Set: UTF-8 with byte order mark (see also StyleCop rule SA1412)
+charset = utf-8-bom
+
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true

--- a/eng/StyleCop.Analyzers.ruleset
+++ b/eng/StyleCop.Analyzers.ruleset
@@ -7,7 +7,7 @@
     <Rule Id="SA1001" Action="Error" />
     <Rule Id="SA1002" Action="Error" />
     <Rule Id="SA1003" Action="Error" />
-    <Rule Id="SA1004" Action="None" /> <!-- Documentation line should begin with a space -->
+    <Rule Id="SA1004" Action="Error" /> <!-- Documentation line should begin with a space -->
     <Rule Id="SA1005" Action="Error" />
     <Rule Id="SA1006" Action="Error" />
     <Rule Id="SA1007" Action="Error" />

--- a/eng/StyleCop.Analyzers.ruleset
+++ b/eng/StyleCop.Analyzers.ruleset
@@ -86,7 +86,7 @@
     <Rule Id="SA1213" Action="Error" />
     <Rule Id="SA1214" Action="Error" />
     <Rule Id="SA1216" Action="Error" />
-    <Rule Id="SA1217" Action="None" /> <!-- Using statements should be ordered by alphabet -->
+    <Rule Id="SA1217" Action="Error" /> <!-- Using statements should be ordered by alphabet -->
     <Rule Id="SA1300" Action="Error" />
     <Rule Id="SA1302" Action="Error" />
     <Rule Id="SA1303" Action="Error" />
@@ -111,8 +111,8 @@
     <Rule Id="SA1407" Action="None" /> <!-- Arithmetic expressions must declare precedence -->
     <Rule Id="SA1408" Action="Error" />
     <Rule Id="SA1410" Action="Error" />
-    <Rule Id="SA1411" Action="None" /> <!-- Attribute Constructor Must Not Use Unnecessary Parenthesis -->
-    <Rule Id="SA1412" Action="None" /> <!-- Store files as UTF-8 -->
+    <Rule Id="SA1411" Action="Error" /> <!-- Attribute Constructor Must Not Use Unnecessary Parenthesis -->
+    <Rule Id="SA1412" Action="Error" /> <!-- Store files as UTF-8 -->
     <Rule Id="SA1413" Action="None" /> <!-- Use trailing comma in multi-line initializers -->
     <Rule Id="SA1500" Action="Error" /> 
     <Rule Id="SA1501" Action="Error" />

--- a/eng/StyleCop.Analyzers.ruleset
+++ b/eng/StyleCop.Analyzers.ruleset
@@ -177,7 +177,7 @@
     <Rule Id="SA1649" Action="None" /> <!-- Maybe todo: File name should match first type name -->
     <Rule Id="SA1651" Action="Error" />
     <Rule Id="SA1652" Action="Error" />
-    <Rule Id="SX1101" Action="None" /> <!-- Maybe todo: Do not prefix local members with this -->
+    <Rule Id="SX1101" Action="Error" /> <!-- Do not prefix local members with this -->
 	<Rule Id="SX1309" Action="Error" /> <!-- Members should be prefixed with _ -->
   </Rules>
 </RuleSet>

--- a/samples/led-more-blinking-lights/TimeEnvelope.cs
+++ b/samples/led-more-blinking-lights/TimeEnvelope.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/samples/led-more-blinking-lights/Volume.cs
+++ b/samples/led-more-blinking-lights/Volume.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.Linux.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.Linux.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio.Tests/SysFsDriverTests.Linux.cs
+++ b/src/System.Device.Gpio.Tests/SysFsDriverTests.Linux.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.access.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.access.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.close.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.close.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_create.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_create.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_ctl.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_ctl.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_wait.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_wait.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.lseek.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.lseek.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.mmap.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.mmap.cs
@@ -41,55 +41,55 @@ internal enum MemoryMappedFlags
 [StructLayout(LayoutKind.Explicit)]
 internal unsafe struct RegisterView
 {
-    ///<summary>GPIO Function Select, 6x32 bits, R/W.</summary>
+    /// <summary>GPIO Function Select, 6x32 bits, R/W.</summary>
     [FieldOffset(0x00)]
     public fixed uint GPFSEL[6];
 
-    ///<summary>GPIO Pin Output Set, 2x32 bits, W.</summary>
+    /// <summary>GPIO Pin Output Set, 2x32 bits, W.</summary>
     [FieldOffset(0x1C)]
     public fixed uint GPSET[2];
 
-    ///<summary>GPIO Pin Output Clear, 2x32 bits, W.</summary>
+    /// <summary>GPIO Pin Output Clear, 2x32 bits, W.</summary>
     [FieldOffset(0x28)]
     public fixed uint GPCLR[2];
 
-    ///<summary>GPIO Pin Level, 2x32 bits, R.</summary>
+    /// <summary>GPIO Pin Level, 2x32 bits, R.</summary>
     [FieldOffset(0x34)]
     public fixed uint GPLEV[2];
 
-    ///<summary>GPIO Pin Event Detect Status, 2x32 bits, R/W.</summary>
+    /// <summary>GPIO Pin Event Detect Status, 2x32 bits, R/W.</summary>
     [FieldOffset(0x40)]
     public fixed uint GPEDS[2];
 
-    ///<summary>GPIO Pin Rising Edge Detect Enable, 2x32 bits, R/W.</summary>
+    /// <summary>GPIO Pin Rising Edge Detect Enable, 2x32 bits, R/W.</summary>
     [FieldOffset(0x4C)]
     public fixed uint GPREN[2];
 
-    ///<summary>GPIO Pin Falling Edge Detect Enable, 2x32 bits, R/W.</summary>
+    /// <summary>GPIO Pin Falling Edge Detect Enable, 2x32 bits, R/W.</summary>
     [FieldOffset(0x58)]
     public fixed uint GPFEN[2];
 
-    ///<summary>GPIO Pin High Detect Enable, 2x32 bits, R/W.</summary>
+    /// <summary>GPIO Pin High Detect Enable, 2x32 bits, R/W.</summary>
     [FieldOffset(0x64)]
     public fixed uint GPHEN[2];
 
-    ///<summary>GPIO Pin Low Detect Enable, 2x32 bits, R/W.</summary>
+    /// <summary>GPIO Pin Low Detect Enable, 2x32 bits, R/W.</summary>
     [FieldOffset(0x70)]
     public fixed uint GPLEN[2];
 
-    ///<summary>GPIO Pin Async. Rising Edge Detect, 2x32 bits, R/W.</summary>
+    /// <summary>GPIO Pin Async. Rising Edge Detect, 2x32 bits, R/W.</summary>
     [FieldOffset(0x7C)]
     public fixed uint GPAREN[2];
 
-    ///<summary>GPIO Pin Async. Falling Edge Detect, 2x32 bits, R/W.</summary>
+    /// <summary>GPIO Pin Async. Falling Edge Detect, 2x32 bits, R/W.</summary>
     [FieldOffset(0x88)]
     public fixed uint GPAFEN[2];
 
-    ///<summary>GPIO Pin Pull-up/down Enable, 32 bits, R/W.</summary>
+    /// <summary>GPIO Pin Pull-up/down Enable, 32 bits, R/W.</summary>
     [FieldOffset(0x94)]
     public uint GPPUD;
 
-    ///<summary>GPIO Pin Pull-up/down Enable Clock, 2x32 bits, R/W.</summary>
+    /// <summary>GPIO Pin Pull-up/down Enable Clock, 2x32 bits, R/W.</summary>
     [FieldOffset(0x98)]
     public fixed uint GPPUDCLK[2];
 

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.open.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.open.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.read.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.read.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio/System/Device/Spi/DataFlow.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/DataFlow.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Device.Gpio/System/Device/SysFsHelpers.Unix.cs
+++ b/src/System.Device.Gpio/System/Device/SysFsHelpers.Unix.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Ak8963/samples/Ak8963.sample.cs
+++ b/src/devices/Ak8963/samples/Ak8963.sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Bh1745/samples/Bh1745CustomConfiguration.Sample.cs
+++ b/src/devices/Bh1745/samples/Bh1745CustomConfiguration.Sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Bmp180/Bmp180.cs
+++ b/src/devices/Bmp180/Bmp180.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Bmp180/Register.cs
+++ b/src/devices/Bmp180/Register.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Bmxx80/Bme680Mask.cs
+++ b/src/devices/Bmxx80/Bme680Mask.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Bmxx80/CalibrationData/Bmp280CalibrationData.cs
+++ b/src/devices/Bmxx80/CalibrationData/Bmp280CalibrationData.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/BrickPi3/Extensions/EnumExtension.cs
+++ b/src/devices/BrickPi3/Extensions/EnumExtension.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/BrickPi3/Movement/Vehicle.cs
+++ b/src/devices/BrickPi3/Movement/Vehicle.cs
@@ -30,7 +30,7 @@ namespace Iot.Device.BrickPi3.Movement
         /// <param name="right">Motor port for right motor</param>
         public Vehicle(Brick brick, BrickPortMotor left, BrickPortMotor right)
         {
-            this._brick = brick;
+            _brick = brick;
             PortLeft = left;
             PortRight = right;
         }

--- a/src/devices/BrickPi3/Sensors/EV3IRSensor.cs
+++ b/src/devices/BrickPi3/Sensors/EV3IRSensor.cs
@@ -172,9 +172,9 @@ namespace Iot.Device.BrickPi3.Sensors
 
             internal set
             {
-                if (value != this._value)
+                if (value != _value)
                 {
-                    this._value = value;
+                    _value = value;
                     OnPropertyChanged(nameof(Value));
                 }
             }

--- a/src/devices/BrickPi3/Sensors/ISensor.cs
+++ b/src/devices/BrickPi3/Sensors/ISensor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Buzzer/samples/Enums.cs
+++ b/src/devices/Buzzer/samples/Enums.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Buzzer/samples/MelodyElement.cs
+++ b/src/devices/Buzzer/samples/MelodyElement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Buzzer/samples/MelodyPlayer.cs
+++ b/src/devices/Buzzer/samples/MelodyPlayer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Buzzer/samples/NoteElement.cs
+++ b/src/devices/Buzzer/samples/NoteElement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Buzzer/samples/PauseElement.cs
+++ b/src/devices/Buzzer/samples/PauseElement.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/CharacterLcd/LcdRgb.cs
+++ b/src/devices/CharacterLcd/LcdRgb.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/CharacterLcd/Registers.cs
+++ b/src/devices/CharacterLcd/Registers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Common/Iot/Device/Common/NumberHelper.cs
+++ b/src/devices/Common/Iot/Device/Common/NumberHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/DCMotor/DCMotor.cs
+++ b/src/devices/DCMotor/DCMotor.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/DCMotor/DCMotor2PinNoEnable.cs
+++ b/src/devices/DCMotor/DCMotor2PinNoEnable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/DCMotor/DCMotor3Pin.cs
+++ b/src/devices/DCMotor/DCMotor3Pin.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/DCMotor/samples/Program.cs
+++ b/src/devices/DCMotor/samples/Program.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Dhtxx/DhtBase.cs
+++ b/src/devices/Dhtxx/DhtBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Dhtxx/samples/DhtSensor.sample.cs
+++ b/src/devices/Dhtxx/samples/DhtSensor.sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Hmc5883l/MeasurementConfiguration.cs
+++ b/src/devices/Hmc5883l/MeasurementConfiguration.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Hmc5883l/SamplesAmount.cs
+++ b/src/devices/Hmc5883l/SamplesAmount.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Hmc5883l/Status.cs
+++ b/src/devices/Hmc5883l/Status.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using System;

--- a/src/devices/Interop/Unix/Libc/Interop.libc.cs
+++ b/src/devices/Interop/Unix/Libc/Interop.libc.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Interop/Unix/ThreadHelper.cs
+++ b/src/devices/Interop/Unix/ThreadHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Max7219/IFont.cs
+++ b/src/devices/Max7219/IFont.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Max7219/MatrixGraphics.cs
+++ b/src/devices/Max7219/MatrixGraphics.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Max7219/Max7219.cs
+++ b/src/devices/Max7219/Max7219.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Max7219/samples/Max7219.sample.cs
+++ b/src/devices/Max7219/samples/Max7219.sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Mcp23xxx/Mcp23xxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23xxx.cs
@@ -363,7 +363,7 @@ namespace Iot.Device.Mcp23xxx
         }
 
         /// <summary>
-        ///Reads the value of a set of pins
+        /// Reads the value of a set of pins
         /// </summary>
         protected void Read(Span<PinValuePair> pinValuePairs)
         {

--- a/src/devices/Mcp23xxx/tests/RegisterTests.cs
+++ b/src/devices/Mcp23xxx/tests/RegisterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Mcp25xxx/tests/Mcp25xxxTests.cs
+++ b/src/devices/Mcp25xxx/tests/Mcp25xxxTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Mcp3xxx/Mcp3Base.cs
+++ b/src/devices/Mcp3xxx/Mcp3Base.cs
@@ -94,13 +94,13 @@ namespace Iot.Device.Adc
         /// </summary>
         protected enum InputType
         {
-            ///<summary>The value is measured as the voltage on a single pin</summary>
+            /// <summary>The value is measured as the voltage on a single pin</summary>
             SingleEnded = 0,
 
-            ///<summary>The value is the difference in voltage between two pins with the first pin being the positive one</summary>
+            /// <summary>The value is the difference in voltage between two pins with the first pin being the positive one</summary>
             Differential = 1,
 
-            ///<summary>The value is the difference in voltage between two pins with the second pin being the positive one</summary>
+            /// <summary>The value is the difference in voltage between two pins with the second pin being the positive one</summary>
             InvertedDifferential = 2
         }
 

--- a/src/devices/Mcp3xxx/samples/Mcp3008.Sample.cs
+++ b/src/devices/Mcp3xxx/samples/Mcp3008.Sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Mpr121/ChannelStatusesChangedEventArgs.cs
+++ b/src/devices/Mpr121/ChannelStatusesChangedEventArgs.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Mpr121/Channels.cs
+++ b/src/devices/Mpr121/Channels.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Mpr121/Mpr121Configuration.cs
+++ b/src/devices/Mpr121/Mpr121Configuration.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Mpr121/Registers.cs
+++ b/src/devices/Mpr121/Registers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Mpu9250/samples/Mpu9250.sample.cs
+++ b/src/devices/Mpu9250/samples/Mpu9250.sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Pca9685/samples/Pca9685.Sample.cs
+++ b/src/devices/Pca9685/samples/Pca9685.Sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/RGBLedMatrix/Gpio.cs
+++ b/src/devices/RGBLedMatrix/Gpio.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/RGBLedMatrix/PinMapping.cs
+++ b/src/devices/RGBLedMatrix/PinMapping.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/RGBLedMatrix/RgbLedMatrix.cs
+++ b/src/devices/RGBLedMatrix/RgbLedMatrix.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Seesaw/SeesawAdc.cs
+++ b/src/devices/Seesaw/SeesawAdc.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Seesaw/samples/Volume.cs
+++ b/src/devices/Seesaw/samples/Volume.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/ServoMotor/samples/ServoMotor.Sample.cs
+++ b/src/devices/ServoMotor/samples/ServoMotor.Sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/ServoMotor/tests/ServoMotorTests.cs
+++ b/src/devices/ServoMotor/tests/ServoMotorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Si7021/Si7021.cs
+++ b/src/devices/Si7021/Si7021.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/SocketCan/CanFrame.cs
+++ b/src/devices/SocketCan/CanFrame.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/SocketCan/CanId.cs
+++ b/src/devices/SocketCan/CanId.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/SoftPwm/samples/SoftPwm.sample.cs
+++ b/src/devices/SoftPwm/samples/SoftPwm.sample.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/devices/Units/Pressure.cs
+++ b/src/devices/Units/Pressure.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 


### PR DESCRIPTION
Fix the remaining open issues as per https://github.com/dotnet/iot/issues/816#issuecomment-567625504

Note: This will show a lot of changes of line 1 of several files, without visible difference. The only change is that the byte-order mark for UTF-8 was added to the files, which prevents usage with a wrong code table. 
