### PR TITLE
Fix TM1637 sample to refer correct enum member

### DIFF
--- a/src/devices/Tm1637/samples/Tm1637.sample.cs
+++ b/src/devices/Tm1637/samples/Tm1637.sample.cs
@@ -52,7 +52,7 @@ namespace Tm1637Sample
             Thread.Sleep(3000);
             for (int i = 0; i < 6; i++)
             {
-                rawData[i] = (Character)Enum.Parse(typeof(Character), $"Char{i}");
+                rawData[i] = (Character)Enum.Parse(typeof(Character), $"Digit{i}");
             }
 
             tm1637.Display(rawData);
@@ -72,10 +72,10 @@ namespace Tm1637Sample
             while (!Console.KeyAvailable)
             {
                 var dt = DateTime.Now;
-                toDisplay[0] = (Character)Enum.Parse(typeof(Character), $"Char{dt.Minute / 10}");
-                toDisplay[1] = (Character)Enum.Parse(typeof(Character), $"Char{dt.Minute % 10}") | Character.Dot;
-                toDisplay[2] = (Character)Enum.Parse(typeof(Character), $"Char{dt.Second / 10}");
-                toDisplay[3] = (Character)Enum.Parse(typeof(Character), $"Char{dt.Second % 10}");
+                toDisplay[0] = (Character)Enum.Parse(typeof(Character), $"Digit{dt.Minute / 10}");
+                toDisplay[1] = (Character)Enum.Parse(typeof(Character), $"Digit{dt.Minute % 10}") | Character.Dot;
+                toDisplay[2] = (Character)Enum.Parse(typeof(Character), $"Digit{dt.Second / 10}");
+                toDisplay[3] = (Character)Enum.Parse(typeof(Character), $"Digit{dt.Second % 10}");
                 tm1637.Brightness = (byte)(bright++ % 8);
                 tm1637.Display(toDisplay);
                 Thread.Sleep(100);


### PR DESCRIPTION
The sample for TM1637 throws an exception.

It attempts to parse non existent enum member `Character.Char0`.
It must parse `Character.Digit0`.

```
$ cd src/devices/Tm1637/samples/
$ dotnet build
$ dotnet ./bin/Debug/netcoreapp2.1/Tm1637.sample.dll 
Hello Tm1637!

Unhandled Exception: System.ArgumentException: Requested value 'Char0' was not found.
   at System.Enum.TryParseEnum(Type enumType, String value, Boolean ignoreCase, EnumResult& parseResult)
   at System.Enum.Parse(Type enumType, String value, Boolean ignoreCase)
   at System.Enum.Parse(Type enumType, String value)
   at Tm1637Sample.Program.Main(String[] args) in /home/pi/iot/src/devices/Tm1637/samples/Tm1637.sample.cs:line 55
```