### PR TITLE
Make HCSR04 more reliable

### DIFF
--- a/src/devices/Hcsr04/samples/Hcsr04.Sample.cs
+++ b/src/devices/Hcsr04/samples/Hcsr04.Sample.cs
@@ -22,7 +22,7 @@ namespace Iot.Device.Hcsr04.Samples
                 while (true)
                 {
                     Console.WriteLine($"Distance: {sonar.Distance} cm");
-                    System.Threading.Thread.Sleep(1000);
+                    Thread.Sleep(1000);
                 }
             }
         }

--- a/src/devices/Hcsr04/samples/README.md
+++ b/src/devices/Hcsr04/samples/README.md
@@ -16,12 +16,12 @@ The fritz diagram above depicts how you should wire your RPi in order to run the
 
 ## Code
 ```C#
-using(var sonar = new Hcsr04(4, 17))
+using (var sonar = new Hcsr04(4, 17))
 {
-    while(true)
+    while (true)
     {
         Console.WriteLine($"Distance: {sonar.Distance} cm");
-        System.Threading.Thread.Sleep(1000);
+        Thread.Sleep(1000);
     }
 }
 ```


### PR DESCRIPTION
Fixes https://github.com/dotnet/iot/issues/860

Issue is caused by the first call to `_controller.Read` being to slow (due to JITting), that is causing missing the echo pulse and endless looping.

This change is:
- adding protection against indefinite looping
- adding protection against invalid reading (more than 400cm which is max supported distance)
- 10 retries on failed attempt, later we throw InvalidOperationException (unsure about which exception type, please comment if you have better suggestion)
- JITting `Read` in the constructor to avoid always retrying after starting the app
- add constructor taking GpioController

cc: @mringl @Kash0321