### PR TITLE
Fix NRE in HCSR501 when no events are registered

### DIFF
--- a/src/devices/Hcsr501/Hcsr501.cs
+++ b/src/devices/Hcsr501/Hcsr501.cs
@@ -61,7 +61,10 @@ namespace Iot.Device.Hcsr501
 
         private void Sensor_ValueChanged(object sender, PinValueChangedEventArgs e)
         {
-            Hcsr501ValueChanged(sender, new Hcsr501ValueChangedEventArgs(_controller.Read(_outPin)));
+            if (Hcsr501ValueChanged != null)
+            {
+                Hcsr501ValueChanged(sender, new Hcsr501ValueChangedEventArgs(_controller.Read(_outPin)));
+            }
         }
     }
 }

--- a/src/devices/Hcsr501/samples/Program.cs
+++ b/src/devices/Hcsr501/samples/Program.cs
@@ -12,41 +12,33 @@ namespace Hcsr501.Samples
 {
     internal class Program
     {
-        // HC-SR501 OUT Pin
-        private static int hcsr501Pin = 17;
-
-        // LED Pin
-        private static int ledPin = 27;
+        private const int Hcsr501Pin = 17;
+        private const int LedPin = 27;
 
         public static void Main(string[] args)
         {
-            // get the GPIO controller
-            GpioController ledController = new GpioController(PinNumberingScheme.Logical);
-            // open PIN 27 for led
-            ledController.OpenPin(ledPin, PinMode.Output);
+            GpioController ledController = new GpioController();
+            ledController.OpenPin(LedPin, PinMode.Output);
 
-            // initialize PIR sensor
             using (Iot.Device.Hcsr501.Hcsr501 sensor =
-                new Iot.Device.Hcsr501.Hcsr501(hcsr501Pin, PinNumberingScheme.Logical))
+                new Iot.Device.Hcsr501.Hcsr501(Hcsr501Pin))
             {
-                // loop
                 while (true)
                 {
                     // adjusting the detection distance and time by rotating the potentiometer on the sensor
-                    if (sensor.IsMotionDetected == true)
+                    if (sensor.IsMotionDetected)
                     {
                         // turn the led on when the sensor detected infrared heat
-                        ledController.Write(ledPin, PinValue.High);
+                        ledController.Write(LedPin, PinValue.High);
                         Console.WriteLine("Detected! Turn the LED on.");
                     }
                     else
                     {
                         // turn the led off when the sensor undetected infrared heat
-                        ledController.Write(ledPin, PinValue.Low);
+                        ledController.Write(LedPin, PinValue.Low);
                         Console.WriteLine("Undetected! Turn the LED off.");
                     }
 
-                    // wait for a second
                     Thread.Sleep(1000);
                 }
             }

--- a/src/devices/Hcsr501/samples/README.md
+++ b/src/devices/Hcsr501/samples/README.md
@@ -23,18 +23,16 @@
 
 ## Code
 ```C#
-GpioController ledController = new GpioController(PinNumberingScheme.Logical);
-// open PIN 27 for led
+GpioController ledController = new GpioController();
 ledController.OpenPin(27, PinMode.Output);
 
-using(Hcsr501 sensor = Hcsr501(17, PinNumberingScheme.Logical))
+using (Iot.Device.Hcsr501.Hcsr501 sensor =
+    new Iot.Device.Hcsr501.Hcsr501(17))
 {
-    // loop
     while (true)
     {
-        // Adjusting the detection distance and time by rotating the potentiometer on the sensor
-        // For more information, you can see the picture above or the datasheet in src/devices/Hcsr501/README.md
-        if (sensor.IsMotionDetected == true)
+        // adjusting the detection distance and time by rotating the potentiometer on the sensor
+        if (sensor.IsMotionDetected)
         {
             // turn the led on when the sensor detected infrared heat
             ledController.Write(27, PinValue.High);
@@ -47,7 +45,6 @@ using(Hcsr501 sensor = Hcsr501(17, PinNumberingScheme.Logical))
             Console.WriteLine("Undetected! Turn the LED off.");
         }
 
-        // wait for a second
         Thread.Sleep(1000);
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/iot/issues/930

Problem occurs when no events are registered and motion is detected which is exactly what the sample is doing.

Also slightly clean up the sample (remove redundant comments, fix casing of constants)

cc: @ZhangGaoxing 