### PR TITLE
Adding Retry helper to InputPullResistorsWork test since it may fail sometimes

### DIFF
--- a/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.Linux.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.Linux.cs
@@ -27,15 +27,18 @@ namespace System.Device.Gpio.Tests
         [Fact]
         public void InputPullResistorsWork()
         {
-            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            RetryHelper.Execute(() =>
             {
-                controller.OpenPin(OpenPin, PinMode.InputPullUp);
-                Assert.Equal(PinValue.High, controller.Read(OpenPin));
-                controller.SetPinMode(OpenPin, PinMode.InputPullDown);
-                Assert.Equal(PinValue.Low, controller.Read(OpenPin));
-                controller.SetPinMode(OpenPin, PinMode.InputPullUp);
-                Assert.Equal(PinValue.High, controller.Read(OpenPin));
-            }
+                using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+                {
+                    controller.OpenPin(OpenPin, PinMode.InputPullUp);
+                    Assert.Equal(PinValue.High, controller.Read(OpenPin));
+                    controller.SetPinMode(OpenPin, PinMode.InputPullDown);
+                    Assert.Equal(PinValue.Low, controller.Read(OpenPin));
+                    controller.SetPinMode(OpenPin, PinMode.InputPullUp);
+                    Assert.Equal(PinValue.High, controller.Read(OpenPin));
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
cc: @krwq @pgrawehr 

Contributes to #941 

This will try to mitigate CI failures by adding 5 retries in case this test fails until it ultimately fails the test and throws.