### PR TITLE
Fix Pull Up/Down intermittently not working

### DIFF
--- a/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.Linux.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.Linux.cs
@@ -27,18 +27,24 @@ namespace System.Device.Gpio.Tests
         [Fact]
         public void InputPullResistorsWork()
         {
-            RetryHelper.Execute(() =>
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
             {
-                using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+                controller.OpenPin(OpenPin, PinMode.InputPullUp);
+                Assert.Equal(PinValue.High, controller.Read(OpenPin));
+
+                for (int i = 0; i < 100; i++)
                 {
-                    controller.OpenPin(OpenPin, PinMode.InputPullUp);
-                    Assert.Equal(PinValue.High, controller.Read(OpenPin));
                     controller.SetPinMode(OpenPin, PinMode.InputPullDown);
                     Assert.Equal(PinValue.Low, controller.Read(OpenPin));
+
                     controller.SetPinMode(OpenPin, PinMode.InputPullUp);
                     Assert.Equal(PinValue.High, controller.Read(OpenPin));
                 }
-            });
+
+                // change one more time so that when running test in a loop we start with the inverted option
+                controller.SetPinMode(OpenPin, PinMode.InputPullDown);
+                Assert.Equal(PinValue.Low, controller.Read(OpenPin));
+            }
         }
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -229,6 +229,12 @@ namespace System.Device.Gpio.Drivers
         [MethodImpl(MethodImplOptions.NoOptimization)]
         private void SetInputPullMode(int pinNumber, PinMode mode)
         {
+            /*
+             * NoOptimization is needed to force wait time to be at least minimum required cycles.
+             * Also to ensure that pointer operations optimizations won't be using any locals
+             * which would introduce time period where multiple threads could override value set
+             * to this register.
+             */
             if (IsPi4)
             {
                 SetInputPullModePi4(pinNumber, mode);
@@ -276,6 +282,9 @@ namespace System.Device.Gpio.Drivers
             for (int i = 0; i < 150; i++)
                 ;
 
+            // Spec calls to reset clock after the control signal
+            // Since context switch between those two instructions can potentially
+            // change pull up/down value we reset the clock first.
             *gppudclkPointer &= ~pinBit;
             *gppudPointer &= ~0b11U;
 

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -263,7 +263,6 @@ namespace System.Device.Gpio.Drivers
             *gppudPointer |= modeToPullMode;
 
             // Wait 150 cycles – this provides the required set-up time for the control signal
-            // Thread.SpinWait(150);
             for (int i = 0; i < 150; i++)
                 ;
 
@@ -274,7 +273,6 @@ namespace System.Device.Gpio.Drivers
             *gppudclkPointer |= pinBit;
 
             // Wait 150 cycles – this provides the required hold time for the control signal
-            // Thread.SpinWait(150);
             for (int i = 0; i < 150; i++)
                 ;
 

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -288,6 +288,9 @@ namespace System.Device.Gpio.Drivers
             *gppudclkPointer &= ~pinBit;
             *gppudPointer &= ~0b11U;
 
+            // This timeout is not documented in the spec
+            // but lack of it is causing intermittent failures when
+            // pull up/down is changed frequently.
             for (int i = 0; i < 150; i++)
                 ;
         }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -226,6 +226,7 @@ namespace System.Device.Gpio.Drivers
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         /// <param name="mode">The mode of a pin to set the resistor pull up/down mode.</param>
+        [MethodImpl(MethodImplOptions.NoOptimization)]
         private void SetInputPullMode(int pinNumber, PinMode mode)
         {
             if (IsPi4)
@@ -258,28 +259,30 @@ namespace System.Device.Gpio.Drivers
              */
 
             uint* gppudPointer = &_registerViewPointer->GPPUD;
-            uint register = *gppudPointer;
-            register &= ~0b11U;
-            register |= modeToPullMode;
-            *gppudPointer = register;
+            *gppudPointer &= ~0b11U;
+            *gppudPointer |= modeToPullMode;
 
             // Wait 150 cycles – this provides the required set-up time for the control signal
-            Thread.SpinWait(150);
+            // Thread.SpinWait(150);
+            for (int i = 0; i < 150; i++)
+                ;
 
             int index = pinNumber / 32;
             int shift = pinNumber % 32;
             uint* gppudclkPointer = &_registerViewPointer->GPPUDCLK[index];
-            register = *gppudclkPointer;
-            register |= 1U << shift;
-            *gppudclkPointer = register;
+            uint pinBit = 1U << shift;
+            *gppudclkPointer |= pinBit;
 
             // Wait 150 cycles – this provides the required hold time for the control signal
-            Thread.SpinWait(150);
+            // Thread.SpinWait(150);
+            for (int i = 0; i < 150; i++)
+                ;
 
-            register = *gppudPointer;
-            register &= ~0b11U;
-            *gppudPointer = register;
-            *gppudclkPointer = 0;
+            *gppudclkPointer &= ~pinBit;
+            *gppudPointer &= ~0b11U;
+
+            for (int i = 0; i < 150; i++)
+                ;
         }
 
         /// <summary>

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.Linux.cs
@@ -270,7 +270,8 @@ namespace System.Device.Gpio.Drivers
 
             // Wait 150 cycles – this provides the required set-up time for the control signal
             for (int i = 0; i < 150; i++)
-                ;
+            {
+            }
 
             int index = pinNumber / 32;
             int shift = pinNumber % 32;
@@ -280,7 +281,8 @@ namespace System.Device.Gpio.Drivers
 
             // Wait 150 cycles – this provides the required hold time for the control signal
             for (int i = 0; i < 150; i++)
-                ;
+            {
+            }
 
             // Spec calls to reset clock after the control signal
             // Since context switch between those two instructions can potentially
@@ -292,7 +294,8 @@ namespace System.Device.Gpio.Drivers
             // but lack of it is causing intermittent failures when
             // pull up/down is changed frequently.
             for (int i = 0; i < 150; i++)
-                ;
+            {
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #943
Contributes to #941

Did couple of changes before all failures were gone. Out of 50 CI runs 1 failed and issue was unrelated (the other intermittent failure from #941).

Tested only on Release build.

When testing number of iterations in the test was increased to 10k

Changes made:
- added zeroing clock (this fixed most of the problems)
- operating directly on pointer
- despite spec order zeroing clock happens first since that seem to have causing intermittent issues as well
- SpinWait was replaced with regular loop and optimizations in that method were disabled - we can optimize that in the future but I wasn't able to get no intermittent failures without this also was paranoid that pointer operations might get optimized in some way to use local in some hidden away - not sure if that made any difference

cc: @pgrawehr 