### PR TITLE
Fix for pre-configured GPIOs

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -115,6 +115,7 @@ namespace System.Device.Gpio.Tests
             }
         }
 
+/*
         [Fact]
         public void ThrowsIfReadingFromOutputPin()
         {
@@ -124,6 +125,7 @@ namespace System.Device.Gpio.Tests
                 Assert.Throws<InvalidOperationException>(() => controller.Read(OutputPin));
             }
         }
+*/
 
         [Fact]
         [Trait("SkipOnTestRun", "Windows_NT")] // Currently, the Windows Driver is defaulting to InputPullDown instead of Input when Closed/Opened.

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -172,11 +172,6 @@ namespace System.Device.Gpio
                 throw new InvalidOperationException("Can not read from a pin that is not open.");
             }
 
-            if (_driver.GetPinMode(logicalPinNumber) == PinMode.Output)
-            {
-                throw new InvalidOperationException("Can not read from a pin that is set to Output mode.");
-            }
-
             return _driver.Read(logicalPinNumber);
         }
 


### PR DESCRIPTION
* GPIO "unexport" is not possible when the pin is configured by a device-tree overlay.
* The "edge" file only exists for input pins.
* Read pin value is also possible for output pins.
* Added new method to SysFsDriver.Linux to set the ActiveLow state of a GPIO pin.

-----------------------
By using device-tree overlays, GPIOs are all "exported" by the Linux system itself at startup and therefore cannot be "unexported" by writing to the corresponding files. Because of this, the File.WriteAllText at ClosePin() will throw an IOException.

The ClosePin() method calls the SetPinEventsToDetect() which tries to write to the "edge" file in order to disable any events. But this file only exists for Input pins and not for outputs (at least on my system, a Beaglebone Black). This will then of course lead to an FileNotFoundException.

Also to note, when using a device-tree overlay it is possible to disable the ability to change the direction of a pin, which then will of course also lead to an Exception when trying to use the SetPinMode() method.

-----------------------
I also added a new method "SetActiveLow()". Since I'm new to this project, I'm not sure if this is the correct way to implement a new feature. So feel free to remove this.