### PR TITLE
LibGpiodDriver: Use process name as consumer name

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.Linux.cs
@@ -19,6 +19,8 @@ namespace System.Device.Gpio.Drivers
 
         protected internal override int PinCount => Interop.libgpiod.gpiod_chip_num_lines(_chip);
 
+        private string consumerName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+
         public LibGpiodDriver(int gpioChip = 0)
         {
             try
@@ -157,14 +159,13 @@ namespace System.Device.Gpio.Drivers
             int requestResult = -1;
             if (_pinNumberToSafeLineHandle.TryGetValue(pinNumber, out SafeLineHandle pinHandle))
             {
-                string consumer = pinNumber.ToString();
                 if (mode == PinMode.Input)
                 {
-                    requestResult = Interop.libgpiod.gpiod_line_request_input(pinHandle, consumer);
+                    requestResult = Interop.libgpiod.gpiod_line_request_input(pinHandle, consumerName);
                 }
                 else
                 {
-                    requestResult = Interop.libgpiod.gpiod_line_request_output(pinHandle, consumer);
+                    requestResult = Interop.libgpiod.gpiod_line_request_output(pinHandle, consumerName);
                 }
 
                 pinHandle.PinMode = mode;

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.Linux.cs
@@ -19,7 +19,7 @@ namespace System.Device.Gpio.Drivers
 
         protected internal override int PinCount => Interop.libgpiod.gpiod_chip_num_lines(_chip);
 
-        private string consumerName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+        private static string s_consumerName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
 
         public LibGpiodDriver(int gpioChip = 0)
         {
@@ -161,11 +161,11 @@ namespace System.Device.Gpio.Drivers
             {
                 if (mode == PinMode.Input)
                 {
-                    requestResult = Interop.libgpiod.gpiod_line_request_input(pinHandle, consumerName);
+                    requestResult = Interop.libgpiod.gpiod_line_request_input(pinHandle, s_consumerName);
                 }
                 else
                 {
-                    requestResult = Interop.libgpiod.gpiod_line_request_output(pinHandle, consumerName);
+                    requestResult = Interop.libgpiod.gpiod_line_request_output(pinHandle, s_consumerName);
                 }
 
                 pinHandle.PinMode = mode;

--- a/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.Linux.cs
@@ -22,6 +22,8 @@ namespace System.Device.Gpio.Drivers
 
         private bool _disposing = false;
 
+        private string consumerName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+
         public LibGpiodDriverEventHandler(int pinNumber, SafeLineHandle safeLineHandle)
         {
             _pinNumber = pinNumber;
@@ -32,7 +34,7 @@ namespace System.Device.Gpio.Drivers
 
         private void SubscribeForEvent(SafeLineHandle pinHandle)
         {
-            int eventSuccess = Interop.libgpiod.gpiod_line_request_both_edges_events(pinHandle, $"Listen {_pinNumber} for both edge event");
+            int eventSuccess = Interop.libgpiod.gpiod_line_request_both_edges_events(pinHandle, consumerName);
 
             if (eventSuccess < 0)
             {

--- a/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.Linux.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.Linux.cs
@@ -22,7 +22,7 @@ namespace System.Device.Gpio.Drivers
 
         private bool _disposing = false;
 
-        private string consumerName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+        private static string s_consumerName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
 
         public LibGpiodDriverEventHandler(int pinNumber, SafeLineHandle safeLineHandle)
         {
@@ -34,7 +34,7 @@ namespace System.Device.Gpio.Drivers
 
         private void SubscribeForEvent(SafeLineHandle pinHandle)
         {
-            int eventSuccess = Interop.libgpiod.gpiod_line_request_both_edges_events(pinHandle, consumerName);
+            int eventSuccess = Interop.libgpiod.gpiod_line_request_both_edges_events(pinHandle, s_consumerName);
 
             if (eventSuccess < 0)
             {


### PR DESCRIPTION
The pin number that are in use we already have by the gpiolib interface.
For purposes of description, it is more valuable to have the process
name, that are using the resource, as consumer name.

This way we have the info about who are using the pin.

Signed-off-by: Matheus Castello <matheus@castello.eng.br>
