### PR TITLE
Fixes #183: Allow reading output pins

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -116,6 +116,16 @@ namespace System.Device.Gpio.Tests
         }
 
         [Fact]
+        public void CanReadFromOutputPin()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(OutputPin, PinMode.Output);
+                Assert.Equal(PinValue.Low, controller.Read(OutputPin));
+            }
+        }
+
+        [Fact]
         [Trait("SkipOnTestRun", "Windows_NT")] // Currently, the Windows Driver is defaulting to InputPullDown instead of Input when Closed/Opened.
         public void OpenPinDefaultsModeToInput()
         {

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -121,7 +121,12 @@ namespace System.Device.Gpio.Tests
             using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
             {
                 controller.OpenPin(OutputPin, PinMode.Output);
+
+                controller.Write(OutputPin, PinValue.Low);
                 Assert.Equal(PinValue.Low, controller.Read(OutputPin));
+
+                controller.Write(OutputPin, PinValue.High);
+                Assert.Equal(PinValue.High, controller.Read(OutputPin));
             }
         }
 

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -116,16 +116,6 @@ namespace System.Device.Gpio.Tests
         }
 
         [Fact]
-        public void ThrowsIfReadingFromOutputPin()
-        {
-            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
-            {
-                controller.OpenPin(OutputPin, PinMode.Output);
-                Assert.Throws<InvalidOperationException>(() => controller.Read(OutputPin));
-            }
-        }
-
-        [Fact]
         [Trait("SkipOnTestRun", "Windows_NT")] // Currently, the Windows Driver is defaulting to InputPullDown instead of Input when Closed/Opened.
         public void OpenPinDefaultsModeToInput()
         {

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -172,11 +172,6 @@ namespace System.Device.Gpio
                 throw new InvalidOperationException("Can not read from a pin that is not open.");
             }
 
-            if (_driver.GetPinMode(logicalPinNumber) == PinMode.Output)
-            {
-                throw new InvalidOperationException("Can not read from a pin that is set to Output mode.");
-            }
-
             return _driver.Read(logicalPinNumber);
         }
 


### PR DESCRIPTION
Fixes #183
Per #183, this PR removes the arbitrary restriction on `GpioController`'s ability to `Read()` from a pin currently set to `PinMode.Output`.

I took the path that @buyaa-n's [comment](https://github.com/dotnet/iot/issues/183#issuecomment-467940757) suggested, of moving the appropriate place for handling this to the driver level.

That said, this PR does not add this restriction to any particular drivers, as the only devices I have to test with (Raspberry Pi v2 and v3) both work as expected with the ability to read pin values when their `direction` is set to `out`.

EDIT (@krwq): added "Fixes #183" so that github automatically closes the issue after merging