### PR TITLE
Fix bug #884 in TimeEnvelope of samples/led-more-blinking-lights

### DIFF
--- a/samples/led-more-blinking-lights/TimeEnvelope.cs
+++ b/samples/led-more-blinking-lights/TimeEnvelope.cs
@@ -58,31 +58,16 @@ internal class TimeEnvelope
 
     public bool IsFirstMultiple(int value)
     {
-        if (_time == value)
-        {
-            return true;
-        }
-
-        return false;
+        return _time == value;
     }
 
     public bool IsLastMultiple(int value)
     {
-        if (_time - value == 0)
-        {
-            return true;
-        }
-
-        return false;
+        return _count - value == _time;
     }
 
     public bool IsMultiple(int value)
     {
-        if (_time % value == 0)
-        {
-            return true;
-        }
-
-        return false;
+        return _time % value == 0;
     }
 }


### PR DESCRIPTION
Fixes #884

- the method IsLastMultiple(int value) did not use _count to correctly decide when the value is last multiple. 
-  simplified all methods returning bool, instead of returning true/false, it returns directly result of if check.
- it was tested against code snippet included in the bug description to test expected behavior.
```csharp
var te = new TimeEnvelope(1000);
var multiple = 0;
te.AddTime(100);
while(te.Time != 0)  {
  if (te.IsMultiple(200)) {
     multiple++;
    Console.Writeline($"Multiple Hit {multiple}");
  }   
  if (te.IsFirstMultiple(200)) {
     Console.Writeline("First Multiple Hit");
  }
  if (te.IsLastMultiple(200)) {
    Console.Writeline("Last Multiple Hit");
  }
  te.AddTime(100);
}
```
ScreenShot of expected behaviour after my changes:
<img width="198" alt="Screenshot 2020-02-25 at 12 29 46" src="https://user-images.githubusercontent.com/16934959/75245424-f6474700-57cd-11ea-9e2c-725a8447a94c.png">

ScreenShot of the original behaviour before my changes:
<img width="185" alt="Screenshot 2020-02-25 at 12 58 57" src="https://user-images.githubusercontent.com/16934959/75245798-bdf43880-57ce-11ea-9991-8baa6cd0ad80.png">
