### PR TITLE
Fixing exception in decoding credit card information

### DIFF
--- a/src/devices/Card/CreditCard/BerSplitter.cs
+++ b/src/devices/Card/CreditCard/BerSplitter.cs
@@ -43,7 +43,7 @@ namespace Iot.Device.Card.CreditCardProcessing
                     index += resSize.Item1;
 
                 }
-                catch (ArgumentOutOfRangeException)
+                catch (Exception ex) when (ex is ArgumentOutOfRangeException || ex is OverflowException)
                 {
                     // We may have a non supported Tag
                     break;


### PR DESCRIPTION
- Fixing an exception trapping to be a bit more broader. 
- Adding OverFlowException which happens time to time when the element is mal formed in a specific way