### PR TITLE
Update README.md

### DIFF
--- a/src/devices/Dhtxx/README.md
+++ b/src/devices/Dhtxx/README.md
@@ -26,6 +26,8 @@ using (Dht11 dht = new Dht11(26))
 }
 ```
 
+Note:  1-wire will not work with Win 10 IoT-Core as the OS cannot switch the pin fast enough between output and input (or viz).
+
 ### I2C Protocol
 
 Only DHT12 can use I2C protocol.


### PR DESCRIPTION
 1-wire will not work with Win 10 IoT-Core as the OS cannot switch the pin fast enough between output and input (or viz). as per #1010

- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/master/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
