### PR TITLE
Update ReadMe Issue Fixes #1022

### DIFF
--- a/src/devices/Dhtxx/README.md
+++ b/src/devices/Dhtxx/README.md
@@ -25,7 +25,7 @@ using (Dht11 dht = new Dht11(26))
     double humidity = dht.Humidity;
 }
 ```
-**Note:** _Specifically on the RPi with teh DHT22, 1-Wire works using Raspian but not with IoT-Core. The device has to switch the 1-wire pin between input and output and viz. It seems that becuase of the non-deterministic nature of the Windows OS, , it can't switch the pin quick enough. There have been suggestions for using two pins; one for input and one for output. This solution has not been implemented here but here are some links to solutions:_
+**Note:** _Specifically on the RPi with the DHT22, 1-Wire works using Raspian but not with IoT-Core. The device has to switch the 1-wire pin between input and output and vice versa. It seems that Windows IoT-Core OS can't switch the pin direction quick enough. There have been suggestions for using two pins; one for input and one for output. This solution has not been implemented here, but these are some handy links that may help setting that up:_
 - https://github.com/ms-iot/samples/tree/develop/GpioOneWire
 - And on Hackster.io (https://www.hackster.io/porrey/go-native-c-with-the-dht22-a8e8eb
 _These are UWP projecs though._

--- a/src/devices/Dhtxx/README.md
+++ b/src/devices/Dhtxx/README.md
@@ -28,7 +28,6 @@ using (Dht11 dht = new Dht11(26))
 **Note:** _Specifically on the RPi with the DHT22, 1-Wire works using Raspian but not with IoT-Core. The device has to switch the 1-wire pin between input and output and vice versa. It seems that Windows IoT-Core OS can't switch the pin direction quick enough. There have been suggestions for using two pins; one for input and one for output. This solution has not been implemented here, but these are some handy links that may help setting that up:_
 - https://github.com/ms-iot/samples/tree/develop/GpioOneWire
 - And on Hackster.io (https://www.hackster.io/porrey/go-native-c-with-the-dht22-a8e8eb
-_These are UWP projecs though._
 
 ### I2C Protocol
 

--- a/src/devices/Dhtxx/README.md
+++ b/src/devices/Dhtxx/README.md
@@ -25,6 +25,10 @@ using (Dht11 dht = new Dht11(26))
     double humidity = dht.Humidity;
 }
 ```
+**Note:** _Specifically on the RPi with teh DHT22, 1-Wire works using Raspian but not with IoT-Core. The device has to switch the 1-wire pin between input and output and viz. It seems that becuase of the non-deterministic nature of the Windows OS, , it can't switch the pin quick enough. There have been suggestions for using two pins; one for input and one for output. This solution has not been implemented here but here are some links to solutions:_
+- https://github.com/ms-iot/samples/tree/develop/GpioOneWire
+- And on Hackster.io (https://www.hackster.io/porrey/go-native-c-with-the-dht22-a8e8eb
+_These are UWP projecs though._
 
 ### I2C Protocol
 


### PR DESCRIPTION
This addresses the issue wrt 1-wire not working with IoT-Core. Specifically for the RPi and DHT22. This replaces the previous update on the matter by myself.

- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/master/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
