### PR TITLE
[WIP] Board abstraction

### DIFF
--- a/src/System.Device.Gpio/System.Device.Gpio.csproj
+++ b/src/System.Device.Gpio/System.Device.Gpio.csproj
@@ -5,6 +5,7 @@
     <LangVersion>preview</LangVersion>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <RootNamespace></RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="winmd\**" />

--- a/src/System.Device.Gpio/System/Device/Analog/AnalogController.cs
+++ b/src/System.Device.Gpio/System/Device/Analog/AnalogController.cs
@@ -1,0 +1,214 @@
+﻿using System.Collections.Generic;
+using System.Device.Gpio;
+
+namespace System.Device.Analog
+{
+    public sealed class AnalogController : IDisposable
+    {
+        private readonly AnalogControllerDriver _driver;
+        private readonly HashSet<int> _openPins;
+
+        public event ValueChangeEventHandler ValueChanged;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GpioController"/> class that will use the specified numbering scheme and driver.
+        /// </summary>
+        /// <param name="numberingScheme">The numbering scheme used to represent pins provided by the controller.</param>
+        /// <param name="driver">The driver that manages all of the pin operations for the controller.</param>
+        public AnalogController(PinNumberingScheme numberingScheme, AnalogControllerDriver driver)
+        {
+            _driver = driver;
+            NumberingScheme = numberingScheme;
+            _openPins = new HashSet<int>();
+            _driver.ValueChanged += DriverOnValueChanged;
+        }
+
+        /// <summary>
+        /// The numbering scheme used to represent pins provided by the controller.
+        /// </summary>
+        public PinNumberingScheme NumberingScheme { get; }
+
+        /// <summary>
+        /// The number of pins provided by the controller.
+        /// </summary>
+        public int PinCount => _driver.PinCount;
+
+        /// <summary>
+        /// Reference voltage (the maximum voltage measurable).
+        /// For some hardware, it might be necessary to manually set this value for the <see cref="ReadVoltage"/> method to return correct values.
+        /// </summary>
+        public double VoltageReference
+        {
+            get
+            {
+                return _driver.VoltageReference;
+            }
+            set
+            {
+                _driver.VoltageReference = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the logical pin number in the controller's numbering scheme.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <returns>The logical pin number in the controller's numbering scheme.</returns>
+        private int GetLogicalPinNumber(int pinNumber)
+        {
+            return (NumberingScheme == PinNumberingScheme.Logical) ? pinNumber : _driver.ConvertPinNumberToLogicalNumberingScheme(pinNumber);
+        }
+
+        /// <summary>
+        /// Opens a pin in order for it to be ready to use.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        public void OpenPin(int pinNumber)
+        {
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            if (!_driver.SupportsAnalogInput(logicalPinNumber))
+            {
+                throw new NotSupportedException($"Pin {pinNumber} is not supporting analog input.");
+            }
+
+            if (_openPins.Contains(logicalPinNumber))
+            {
+                throw new InvalidOperationException("The selected pin is already open.");
+            }
+
+            _driver.OpenPin(logicalPinNumber);
+            _openPins.Add(logicalPinNumber);
+        }
+
+        /// <summary>
+        /// Closes an open pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        public void ClosePin(int pinNumber)
+        {
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            if (!_openPins.Contains(logicalPinNumber))
+            {
+                throw new InvalidOperationException("Can not close a pin that is not open.");
+            }
+
+            _driver.ClosePin(logicalPinNumber);
+            _openPins.Remove(logicalPinNumber);
+        }
+
+        /// <summary>
+        /// Checks if a specific pin is open.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <returns>The status if the pin is open or closed.</returns>
+        public bool IsPinOpen(int pinNumber)
+        {
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            return _openPins.Contains(logicalPinNumber);
+        }
+
+        /// <summary>
+        /// Checks if a pin supports a specific mode.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="mode">The mode to check.</param>
+        /// <returns>The status if the pin supports the mode.</returns>
+        public bool IsPinModeSupported(int pinNumber, PinMode mode)
+        {
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            return _driver.SupportsAnalogInput(logicalPinNumber);
+        }
+
+        /// <summary>
+        /// Reads the current raw value of a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <returns>The raw value of the pin. Note that the return value is not sign-extended when the value is negative</returns>
+        public uint ReadRaw(int pinNumber)
+        {
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            if (!_openPins.Contains(logicalPinNumber))
+            {
+                throw new InvalidOperationException("Can not read from a pin that is not open.");
+            }
+
+            return _driver.ReadRaw(logicalPinNumber);
+        }
+
+        /// <summary>
+        /// Reads the current raw value of a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <returns>The voltage at the given pin. Depending on the hardware, the reference voltage must have been properly set. <seealso cref="VoltageReference"/>.</returns>
+        public double ReadVoltage(int pinNumber)
+        {
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            if (!_openPins.Contains(logicalPinNumber))
+            {
+                throw new InvalidOperationException("Can not read from a pin that is not open.");
+            }
+
+            return _driver.ReadVoltage(logicalPinNumber);
+        }
+
+        /// <summary>
+        /// Enables the <see cref="ValueChanged"/> event.
+        /// Depending on the hardware, an external masterController is required to trigger input interrupts.
+        /// </summary>
+        /// <remarks>
+        /// The event might report events for other pins as well, so clients must check whether the event received matches
+        /// the pin required.
+        /// </remarks>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="masterController">The external interrupt controller (if needed)</param>
+        /// <param name="masterPin">The pin number on the external interrupt controller to check</param>
+        public void EnableAnalogValueChangedEvent(int pinNumber, GpioController masterController, int masterPin)
+        {
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            if (!_openPins.Contains(logicalPinNumber))
+            {
+                throw new InvalidOperationException("Can not enable callback for a pin that is not open.");
+            }
+
+            _driver.EnableAnalogValueChangedEvent(logicalPinNumber, masterController, masterPin);
+        }
+
+        private void DriverOnValueChanged(object sender, ValueChangedEventArgs pinValueChangedEventArgs)
+        {
+            ValueChanged?.Invoke(sender, pinValueChangedEventArgs);
+        }
+
+        /// <summary>
+        /// Disables the <see cref="ValueChanged"/> event
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        public void DisableAnalogValueChangedEvent(int pinNumber)
+        {
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            if (!_openPins.Contains(logicalPinNumber))
+            {
+                throw new InvalidOperationException("Can not disable callback for a pin that is not open.");
+            }
+
+            _driver.DisableAnalogValueChangedEvent(logicalPinNumber);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            foreach (int pin in _openPins)
+            {
+                _driver.ClosePin(pin);
+            }
+
+            _openPins.Clear();
+            _driver.ValueChanged -= DriverOnValueChanged;
+            _driver.Dispose();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Analog/AnalogControllerDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Analog/AnalogControllerDriver.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Device.Gpio;
+
+namespace System.Device.Analog
+{
+    public abstract class AnalogControllerDriver : IDisposable
+    {
+        public event ValueChangeEventHandler ValueChanged;
+
+        public abstract int PinCount
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The reference voltage level, if externally supplied.
+        /// Not supported by all boards.
+        /// While the Arduino does have an external analog input reference pin, Firmata doesn't allow configuring it.
+        /// </summary>
+        public double VoltageReference
+        {
+            get;
+            set;
+        }
+
+        protected internal abstract int ConvertPinNumberToLogicalNumberingScheme(int pinNumber);
+
+        protected internal abstract int ConvertLogicalNumberingSchemeToPinNumber(int logicalPinNumber);
+
+        public abstract void OpenPin(int pinNumber);
+        public abstract void ClosePin(int pinNumber);
+
+        /// <summary>
+        /// Return the resolution of an analog input pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number</param>
+        /// <param name="numberOfBits">Returns the resolution of the ADC in number of bits, including the sign bit (if applicable)</param>
+        /// <param name="minVoltage">Minimum measurable voltage</param>
+        /// <param name="maxVoltage">Maximum measurable voltage</param>
+        public abstract void QueryResolution(int pinNumber, out int numberOfBits, out double minVoltage, out double maxVoltage);
+
+        public abstract uint ReadRaw(int pinNumber);
+
+        public virtual double ReadVoltage(int pinNumber)
+        {
+            uint raw = ReadRaw(pinNumber);
+            return ConvertToVoltage(pinNumber, raw);
+        }
+
+        public virtual double ConvertToVoltage(int pinNumber, uint rawValue)
+        {
+            QueryResolution(pinNumber, out int numberOfBits, out double minVoltage, out double maxVoltage);
+            if (minVoltage >= 0)
+            {
+                // The ADC can handle only positive values
+                int maxRawValue = (1 << numberOfBits) - 1;
+                double voltage = ((double)rawValue / maxRawValue) * maxVoltage;
+                return voltage;
+            }
+            else
+            {
+                // The ADC also handles negative values. This means that the number of bits includes the sign.
+                uint maxRawValue = (uint)((1 << (numberOfBits - 1)) - 1);
+                if (rawValue < maxRawValue)
+                {
+                    double voltage = ((double)rawValue / maxRawValue) * maxVoltage;
+                    return voltage;
+                }
+                else
+                {
+                    // This is a bitmask which has all the bits 1 that are not used in the data.
+                    // We use this to sign-extend our raw value. The mask also includes the sign bit itself,
+                    // but we know that this is already 1
+                    uint topBits = ~maxRawValue;
+                    rawValue |= topBits;
+                    int raw2 = (int)rawValue;
+                    double voltage = ((double)raw2 / maxRawValue) * maxVoltage;
+                    return voltage; // This is now negative
+                }
+            }
+        }
+
+        public abstract bool SupportsAnalogInput(int pinNumber);
+
+        public abstract void EnableAnalogValueChangedEvent(int pinNumber, GpioController masterController, int masterPin);
+
+        public abstract void DisableAnalogValueChangedEvent(int pinNumber);
+
+        protected void FireValueChanged(ValueChangedEventArgs eventArgs)
+        {
+            ValueChanged?.Invoke(this, eventArgs);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Analog/TriggerReason.cs
+++ b/src/System.Device.Gpio/System/Device/Analog/TriggerReason.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Device.Analog
+{
+    /// <summary>
+    /// Gives the reason why a new value was provided
+    /// </summary>
+    public enum TriggerReason
+    {
+        /// <summary>
+        /// The reason for the new message is unknown
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// A new value is available
+        /// </summary>
+        NewMeasurement,
+
+        /// <summary>
+        /// A new value is read with a specific frequency
+        /// </summary>
+        Timed,
+
+        /// <summary>
+        /// A value is provided when certain thresholds are exceeded
+        /// </summary>
+        LimitExceeded
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Analog/ValueChangeEventHandler.cs
+++ b/src/System.Device.Gpio/System/Device/Analog/ValueChangeEventHandler.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Device.Analog
+{
+    /// <summary>
+    /// Delegate that defines the structure for callbacks when the value of a measurement (i.e. analog input) changes.
+    /// </summary>
+    /// <param name="sender">The sender of the event.</param>
+    /// <param name="pinValueChangedEventArgs">The pin value changed arguments from the event.</param>
+    public delegate void ValueChangeEventHandler(object sender, ValueChangedEventArgs pinValueChangedEventArgs);
+}

--- a/src/System.Device.Gpio/System/Device/Analog/ValueChangedEventArgs.cs
+++ b/src/System.Device.Gpio/System/Device/Analog/ValueChangedEventArgs.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Device.Analog
+{
+    /// <summary>
+    /// Arguments passed in when an event is triggered by the GPIO.
+    /// </summary>
+    public class ValueChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueChangedEventArgs"/> class.
+        /// </summary>
+        /// <param name="rawValue">The raw analog sensor reading</param>
+        /// <param name="newValue">The analog sensor reading, converted to voltage.</param>
+        /// <param name="pinNumber">The pin number that triggered the event.</param>
+        /// <param name="triggerReason">The reason for the event</param>
+        public ValueChangedEventArgs(uint rawValue, double newValue, int pinNumber, TriggerReason triggerReason)
+        {
+            RawValue = rawValue;
+            Value = newValue;
+            PinNumber = pinNumber;
+            TriggerReason = triggerReason;
+        }
+
+        public uint RawValue
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The change type that triggered the event.
+        /// </summary>
+        public double Value
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The pin number that triggered the event.
+        /// </summary>
+        public int PinNumber
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The reason that triggered this message.
+        /// </summary>
+        public TriggerReason TriggerReason { get; }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Board.cs
+++ b/src/System.Device.Gpio/System/Device/Board.cs
@@ -1,0 +1,246 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Device.Analog;
+using System.Device.Boards;
+using System.Device.Gpio;
+using System.Device.I2c;
+using System.Device.Pwm;
+using System.Device.Spi;
+using System.IO;
+using System.Text;
+
+namespace System.Device
+{
+    public abstract class Board : MarshalByRefObject, IDisposable
+    {
+        private readonly PinNumberingScheme _defaultNumberingScheme;
+        private readonly object _pinReservationsLock;
+        private readonly Dictionary<int, PinReservation> _pinReservations;
+        private bool _initialized;
+        private bool _disposed;
+
+        protected Board(PinNumberingScheme defaultNumberingScheme)
+        {
+            _defaultNumberingScheme = defaultNumberingScheme;
+            _pinReservations = new Dictionary<int, PinReservation>();
+            _pinReservationsLock = new object();
+            _initialized = false;
+            _disposed = false;
+        }
+
+        ~Board()
+        {
+            Dispose(false);
+        }
+
+        public event Action<string, Exception> LogMessages;
+
+        protected bool Initialized
+        {
+            get
+            {
+                return _initialized;
+            }
+        }
+
+        protected bool Disposed
+        {
+            get
+            {
+                return _disposed;
+            }
+        }
+
+        public PinNumberingScheme DefaultPinNumberingScheme
+        {
+            get
+            {
+                return _defaultNumberingScheme;
+            }
+        }
+
+        protected void Log(string message, Exception exception = null)
+        {
+            LogMessages?.Invoke(message, null);
+        }
+
+        /// <summary>
+        /// Converts pin numbers in the active <see cref="PinNumberingScheme"/> to logical pin numbers.
+        /// Does nothing if <see cref="PinNumberingScheme"/> is logical
+        /// </summary>
+        /// <param name="pinNumber">Pin numbers</param>
+        /// <returns>The logical pin number</returns>
+        public abstract int ConvertPinNumberToLogicalNumberingScheme(int pinNumber);
+
+        /// <summary>
+        /// Converts logical pin numbers to the active numbering scheme.
+        /// This is the opposite of <see cref="ConvertPinNumberToLogicalNumberingScheme"/>.
+        /// </summary>
+        /// <param name="pinNumber">Logical pin number</param>
+        /// <returns>The pin number in the given pin numbering scheme</returns>
+        public abstract int ConvertLogicalNumberingSchemeToPinNumber(int pinNumber);
+
+        /// <summary>
+        /// Reserves a pin for a specific usage. This is done automatically if a known interface (i.e. GpioController) is
+        /// used to open the pin, but may be used to block a pin explicitly, i.e. for UART.
+        /// </summary>
+        /// <param name="pinNumber">The pin number, in the boards default numbering scheme</param>
+        /// <param name="usage">Intended usage of the pin</param>
+        /// <param name="owner">Class that owns the pin (use "this")</param>
+        public virtual void ReservePin(int pinNumber, PinUsage usage, object owner)
+        {
+            if (!_initialized)
+            {
+                Initialize();
+            }
+
+            int logicalPin = ConvertPinNumberToLogicalNumberingScheme(pinNumber);
+            lock (_pinReservationsLock)
+            {
+                if (_pinReservations.TryGetValue(logicalPin, out var reservation))
+                {
+                    throw new InvalidOperationException($"Pin {pinNumber} has already been reserved for {reservation.Usage} by class {reservation.Owner}.");
+                }
+
+                PinReservation rsv = new PinReservation(logicalPin, usage, owner);
+                _pinReservations.Add(logicalPin, rsv);
+            }
+
+            ActivatePinMode(logicalPin, usage);
+        }
+
+        public virtual void ReleasePin(int pinNumber, PinUsage usage, object owner)
+        {
+            if (!_initialized)
+            {
+                throw new InvalidOperationException("Cannot release a pin if board is not initialized.");
+            }
+
+            int logicalPin = ConvertPinNumberToLogicalNumberingScheme(pinNumber);
+            lock (_pinReservationsLock)
+            {
+                if (_pinReservations.TryGetValue(logicalPin, out var reservation))
+                {
+                    if (reservation.Owner != owner || reservation.Usage != usage)
+                    {
+                        throw new InvalidOperationException($"Cannot release Pin {pinNumber}, because you are not the owner or the usage is wrong. Class {reservation.Owner} has reserved the Pin for {reservation.Usage}");
+                    }
+
+                    _pinReservations.Remove(logicalPin);
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Cannot release Pin {pinNumber}, because it is not reserved.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Override this method if something special needs to be done to use the pin for the given device.
+        /// Many devices support multiple functions per Pin, but not at the same time, so that some kind of
+        /// multiplexer needs to be set accordingly.
+        /// </summary>
+        /// <param name="pinNumber">The logical pin number to use.</param>
+        /// <param name="usage">The intended usage</param>
+        protected virtual void ActivatePinMode(int pinNumber, PinUsage usage)
+        {
+        }
+
+        public virtual void Initialize()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(ToString());
+            }
+
+            _initialized = true;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            _disposed = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private sealed class PinReservation
+        {
+            public PinReservation(int pin, PinUsage usage, object owner)
+            {
+                Pin = pin;
+                Usage = usage;
+                Owner = owner;
+            }
+
+            public int Pin { get; }
+            public PinUsage Usage { get; }
+
+            /// <summary>
+            /// Component that owns the pin (used mainly for debugging)
+            /// </summary>
+            public object Owner { get; }
+        }
+
+        public abstract GpioController CreateGpioController(PinNumberingScheme pinNumberingScheme);
+        public abstract I2cDevice CreateI2cDevice(I2cConnectionSettings connectionSettings);
+
+        public abstract SpiDevice CreateSpiDevice(SpiConnectionSettings settings);
+
+        public abstract PwmChannel CreatePwmChannel(
+            int chip,
+            int channel,
+            int frequency = 400,
+            double dutyCyclePercentage = 0.5);
+
+        public abstract AnalogController CreateAnalogController(int chip);
+
+        public static Board DetermineOptimalBoardForHardware(PinNumberingScheme defaultNumberingScheme = PinNumberingScheme.Logical)
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                Board board = null;
+                try
+                {
+                    board = new RaspberryPiBoard(defaultNumberingScheme, true);
+                    board.Initialize();
+                }
+                catch (Exception x) when ((x is NotSupportedException) || (x is IOException))
+                {
+                    board?.Dispose();
+                    board = null;
+                }
+
+                if (board != null)
+                {
+                    return board;
+                }
+
+                try
+                {
+                    board = new UnixBoard(defaultNumberingScheme, true);
+                    board.Initialize();
+                }
+                catch (Exception x) when ((x is NotSupportedException) || (x is IOException))
+                {
+                    board?.Dispose();
+                    board = null;
+                }
+
+                if (board != null)
+                {
+                    return board;
+                }
+            }
+            else
+            {
+                // TODO: Create WindowsBoard()
+            }
+
+            throw new PlatformNotSupportedException("Could not find a matching board driver for this hardware");
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Boards/RaspberryPiBoard.cs
+++ b/src/System.Device.Gpio/System/Device/Boards/RaspberryPiBoard.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Device.Analog;
+using System.Device.Gpio;
+using System.Device.Gpio.Drivers;
+using System.Device.I2c;
+using System.Device.Pwm;
+using System.Device.Spi;
+using System.Text;
+
+namespace System.Device.Boards
+{
+    public class RaspberryPiBoard : UnixBoard
+    {
+        public RaspberryPiBoard(PinNumberingScheme defaultNumberingScheme, bool useLibgpiod = true)
+            : base(defaultNumberingScheme, useLibgpiod)
+        {
+        }
+
+        public override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            return pinNumber switch
+            {
+                3 => 2,
+                5 => 3,
+                7 => 4,
+                8 => 14,
+                10 => 15,
+                11 => 17,
+                12 => 18,
+                13 => 27,
+                15 => 22,
+                16 => 23,
+                18 => 24,
+                19 => 10,
+                21 => 9,
+                22 => 25,
+                23 => 11,
+                24 => 8,
+                26 => 7,
+                27 => 0,
+                28 => 1,
+                29 => 5,
+                31 => 6,
+                32 => 12,
+                33 => 13,
+                35 => 19,
+                36 => 16,
+                37 => 26,
+                38 => 20,
+                40 => 21,
+                _ => throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber))
+            };
+        }
+
+        public override int ConvertLogicalNumberingSchemeToPinNumber(int pinNumber)
+        {
+            return pinNumber switch
+            {
+                2 => 3,
+                3 => 5,
+                4 => 7,
+                14 => 8,
+                15 => 10,
+                17 => 11,
+                18 => 12,
+                27 => 13,
+                22 => 15,
+                23 => 16,
+                24 => 18,
+                10 => 19,
+                9 => 21,
+                25 => 22,
+                11 => 23,
+                8 => 24,
+                7 => 26,
+                0 => 27,
+                1 => 28,
+                5 => 29,
+                6 => 31,
+                12 => 23,
+                13 => 33,
+                19 => 35,
+                16 => 36,
+                26 => 37,
+                20 => 38,
+                21 => 40,
+                _ => throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber))
+            };
+        }
+
+        protected override GpioDriver CreateGpioDriver()
+        {
+            return new RaspberryPi3Driver(this);
+        }
+
+        /// <summary>
+        /// Creates an I2C device object for the given bus and device id.
+        /// See the Raspberry Pi manual for possible bus-to-pin assignments.
+        /// </summary>
+        /// <param name="connectionSettings">I2C connection settings</param>
+        /// <returns>An <see cref="I2cDevice"/> instance</returns>
+        public override I2cDevice CreateI2cDevice(I2cConnectionSettings connectionSettings)
+        {
+            int scl = -1;
+            int sda = -1;
+            switch (connectionSettings.BusId)
+            {
+                case 0:
+                {
+                    // Bus 0 is the one on logical pins 0 and 1. According to the docs, it should not
+                    // be used by application software and instead is reserved for HATs, but who does really care?
+                    scl = 1;
+                    sda = 0;
+                    break;
+                }
+
+                case 1:
+                {
+                    // This is the bus commonly used by application software.
+                    sda = 2;
+                    scl = 3;
+                    break;
+                }
+
+                default:
+                {
+                    // Lets assume here the user knows what he's doing. Otherwise, it will just fail later (or he'll not get any
+                    // reply from the device
+                    sda = connectionSettings.SdaPin;
+                    scl = connectionSettings.SclPin;
+                    break;
+                }
+            }
+
+            if (scl == -1 || sda == -1)
+            {
+                throw new ArgumentException("For I2C buses other than 0 and 1, the SDA and SCL pins must be explicitly specified", nameof(connectionSettings));
+            }
+
+            connectionSettings = new I2cConnectionSettings(connectionSettings.BusId, connectionSettings.DeviceAddress, sda, scl);
+            return new UnixI2cDevice(connectionSettings, this);
+        }
+
+        protected override void ActivatePinMode(int pinNumber, PinUsage usage)
+        {
+            // TODO: Set extended pin modes (ALT0-ALT5)
+            base.ActivatePinMode(pinNumber, usage);
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Boards/UnixBoard.cs
+++ b/src/System.Device.Gpio/System/Device/Boards/UnixBoard.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Device.Analog;
+using System.Device.Gpio;
+using System.Device.Gpio.Drivers;
+using System.Device.I2c;
+using System.Device.Pwm;
+using System.Device.Pwm.Channels;
+using System.Device.Spi;
+using System.Text;
+
+namespace System.Device.Boards
+{
+    /// <summary>
+    /// A generic board for Unix platforms
+    /// </summary>
+    public class UnixBoard : Board
+    {
+        private GpioDriver _internalDriver;
+        private bool _useLibgpiod;
+
+        public UnixBoard(PinNumberingScheme defaultNumberingScheme, bool useLibgpiod = true)
+            : base(defaultNumberingScheme)
+        {
+            _internalDriver = null;
+            _useLibgpiod = useLibgpiod;
+        }
+
+        /// <summary>
+        /// True if the Libgpiod driver is used, false if SysFs is used.
+        /// Returns false until <seealso cref="Initialize"/> is called.
+        /// </summary>
+        public bool LibGpiodDriverUsed
+        {
+            get
+            {
+                return _internalDriver is LibGpiodDriver;
+            }
+        }
+
+        public override GpioController CreateGpioController(PinNumberingScheme pinNumberingScheme)
+        {
+            var driver = CreateGpioDriver();
+            return new GpioController(DefaultPinNumberingScheme, driver, this);
+        }
+
+        protected virtual GpioDriver CreateGpioDriver()
+        {
+            if (_useLibgpiod == false)
+            {
+                return new SysFsDriver(this);
+            }
+
+            UnixDriver driver = null;
+            try
+            {
+                driver = new LibGpiodDriver(this);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                driver = new SysFsDriver(this);
+            }
+
+            return driver;
+        }
+
+        public override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            return pinNumber;
+        }
+
+        public override int ConvertLogicalNumberingSchemeToPinNumber(int pinNumber)
+        {
+            return pinNumber;
+        }
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            if (Environment.OSVersion.Platform != PlatformID.Unix)
+            {
+                // Something is really wrong here.
+                throw new PlatformNotSupportedException("This board type is only supported on linux/unix.");
+            }
+
+            // Try to create a GpioController - if that succeeds, we're probably on compatible hardware
+            try
+            {
+                UnixDriver driver = UnixDriver.Create(this);
+                driver.Initialize();
+                _internalDriver = driver;
+            }
+            catch (Exception x) when (!(x is NullReferenceException))
+            {
+                throw new PlatformNotSupportedException($"Unable to open GPIO device: {x.Message}", x);
+            }
+        }
+
+        public override I2cDevice CreateI2cDevice(I2cConnectionSettings connectionSettings)
+        {
+            return new UnixI2cDevice(connectionSettings, this);
+        }
+
+        public override SpiDevice CreateSpiDevice(SpiConnectionSettings settings)
+        {
+            return new UnixSpiDevice(settings, this);
+        }
+
+        public override PwmChannel CreatePwmChannel(int chip, int channel, int frequency = 400, double dutyCyclePercentage = 0.5)
+        {
+            return new UnixPwmChannel(this, chip, channel, frequency, dutyCyclePercentage);
+        }
+
+        public override AnalogController CreateAnalogController(int chip)
+        {
+            throw new NotSupportedException("The Raspberry Pi has no on-board analog inputs.");
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_internalDriver != null)
+                {
+                    _internalDriver.Dispose();
+                    _internalDriver = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Boards/WindowsBoard.cs
+++ b/src/System.Device.Gpio/System/Device/Boards/WindowsBoard.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Device.Analog;
+using System.Device.Gpio;
+using System.Device.Gpio.Drivers;
+using System.Device.I2c;
+using System.Device.Pwm;
+using System.Device.Spi;
+using System.Text;
+
+namespace System.Device.Boards
+{
+    public class WindowsBoard : Board
+    {
+        public WindowsBoard(PinNumberingScheme defaultNumberingScheme)
+            : base(defaultNumberingScheme)
+        {
+            if (defaultNumberingScheme != PinNumberingScheme.Board)
+            {
+                throw new NotSupportedException("This board only supports logical pin numbering");
+            }
+        }
+
+        public override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            return pinNumber;
+        }
+
+        public override int ConvertLogicalNumberingSchemeToPinNumber(int pinNumber)
+        {
+            return pinNumber;
+        }
+
+        public override GpioController CreateGpioController(PinNumberingScheme pinNumberingScheme)
+        {
+            return new GpioController(DefaultPinNumberingScheme, new Windows10Driver(this), this);
+        }
+
+        public override I2cDevice CreateI2cDevice(I2cConnectionSettings connectionSettings)
+        {
+            return new Windows10I2cDevice(connectionSettings, this);
+        }
+
+        public override SpiDevice CreateSpiDevice(SpiConnectionSettings settings)
+        {
+            return new Windows10SpiDevice(settings, this);
+        }
+
+        public override PwmChannel CreatePwmChannel(int chip, int channel, int frequency = 400, double dutyCyclePercentage = 0.5)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override AnalogController CreateAnalogController(int chip)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.cs
@@ -20,13 +20,19 @@ namespace System.Device.Gpio.Drivers
         private Windows10Driver _internalDriver;
 
         public HummingBoardDriver()
+            : this(null)
+        {
+        }
+
+        public HummingBoardDriver(Board board)
+        : base(board)
         {
             if (Environment.OSVersion.Platform != PlatformID.Win32NT)
             {
                 throw new PlatformNotSupportedException($"{GetType().Name} is only supported on Windows.");
             }
 
-            _internalDriver = new Windows10Driver();
+            _internalDriver = new Windows10Driver(null);
         }
 
         /// <inheritdoc/>

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/InterruptSysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/InterruptSysFsDriver.cs
@@ -15,8 +15,8 @@ namespace System.Device.Gpio.Drivers
     internal class InterruptSysFsDriver : SysFsDriver
     {
         private GpioDriver _gpioDriver;
-        public InterruptSysFsDriver(GpioDriver gpioDriver)
-            : base()
+        public InterruptSysFsDriver(Board board, GpioDriver gpioDriver)
+            : base(board)
         {
             if (Environment.OSVersion.Platform != PlatformID.Unix)
             {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
@@ -42,7 +42,8 @@ namespace System.Device.Gpio.Drivers
             GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_UP = (1UL << 5)
         }
 
-        public LibGpiodDriver(int gpioChip = 0)
+        public LibGpiodDriver(Board board, int gpioChip = 0)
+        : base(board)
         {
             if (Environment.OSVersion.Platform != PlatformID.Unix)
             {
@@ -66,6 +67,12 @@ namespace System.Device.Gpio.Drivers
             {
                 throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.LibGpiodNotInstalled);
             }
+        }
+
+        [Obsolete("Use Board.CreateGpioController instead")]
+        public LibGpiodDriver(int gpioChip = 0)
+            : this(null, gpioChip)
+        {
         }
 
         protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -25,10 +25,16 @@ namespace System.Device.Gpio.Drivers
         private readonly Get_Register _getClearRegister;
 
         public RaspberryPi3Driver()
+        : this(null)
+        {
+        }
+
+        internal RaspberryPi3Driver(Board board)
+        : base(board)
         {
             if (Environment.OSVersion.Platform == PlatformID.Unix)
             {
-                _internalDriver = new RaspberryPi3LinuxDriver();
+                _internalDriver = new RaspberryPi3LinuxDriver(board);
                 RaspberryPi3LinuxDriver linuxDriver = _internalDriver as RaspberryPi3LinuxDriver;
                 _setSetRegister = (value) => linuxDriver.SetRegister = value;
                 _setClearRegister = (value) => linuxDriver.ClearRegister = value;
@@ -37,7 +43,7 @@ namespace System.Device.Gpio.Drivers
             }
             else
             {
-                _internalDriver = new Windows10Driver();
+                _internalDriver = new Windows10Driver(board);
                 _setSetRegister = (value) => throw new PlatformNotSupportedException();
                 _setClearRegister = (value) => throw new PlatformNotSupportedException();
                 _getSetRegister = () => throw new PlatformNotSupportedException();
@@ -57,6 +63,11 @@ namespace System.Device.Gpio.Drivers
         /// <inheritdoc/>
         protected internal override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
         {
+            if (Board != null)
+            {
+                return Board.ConvertPinNumberToLogicalNumberingScheme(pinNumber);
+            }
+
             return pinNumber switch
             {
                 3 => 2,
@@ -117,6 +128,12 @@ namespace System.Device.Gpio.Drivers
 
         /// <inheritdoc/>
         protected internal override void Write(int pinNumber, PinValue value) => _internalDriver.Write(pinNumber, value);
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            _internalDriver.Initialize();
+        }
 
         protected ulong SetRegister
         {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
@@ -38,7 +38,8 @@ namespace System.Device.Gpio.Drivers
         /// <summary>
         /// Returns true if this is a Raspberry Pi4
         /// </summary>
-        public RaspberryPi3LinuxDriver()
+        public RaspberryPi3LinuxDriver(Board board)
+        : base(board)
         {
             _pinModes = new PinState[PinCount];
         }
@@ -484,15 +485,15 @@ namespace System.Device.Gpio.Drivers
         {
             try
             {
-                _interruptDriver = new LibGpiodDriver(0);
+                _interruptDriver = new LibGpiodDriver(Board);
             }
             catch (PlatformNotSupportedException)
             {
-                _interruptDriver = new InterruptSysFsDriver(this);
+                _interruptDriver = new InterruptSysFsDriver(Board, this);
             }
         }
 
-        private void Initialize()
+        public override void Initialize()
         {
             uint gpioRegisterOffset = 0;
             int fileDescriptor;

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
@@ -62,6 +62,7 @@ namespace System.Device.Gpio.Drivers
         /// <summary>
         /// Initializes a new instance of the <see cref="SysFsDriver"/> class.
         /// </summary>
+        [Obsolete]
         public SysFsDriver()
         {
             if (Environment.OSVersion.Platform != PlatformID.Unix)
@@ -69,6 +70,15 @@ namespace System.Device.Gpio.Drivers
                 throw new PlatformNotSupportedException($"{GetType().Name} is only supported on Linux/Unix.");
             }
 
+            _eventThreadCancellationTokenSource = new CancellationTokenSource();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SysFsDriver"/> class.
+        /// </summary>
+        public SysFsDriver(Board board)
+            : base(board)
+        {
             _eventThreadCancellationTokenSource = new CancellationTokenSource();
         }
 

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.cs
@@ -6,6 +6,7 @@ namespace System.Device.Gpio.Drivers
 {
     public abstract class UnixDriver : GpioDriver
     {
+        [Obsolete]
         protected UnixDriver()
         {
             if (Environment.OSVersion.Platform != PlatformID.Unix)
@@ -14,7 +15,17 @@ namespace System.Device.Gpio.Drivers
             }
         }
 
+        protected UnixDriver(Board board)
+        : base(board)
+        {
+            if (Environment.OSVersion.Platform != PlatformID.Unix)
+            {
+                throw new PlatformNotSupportedException(GetType().Name + " is only supported on Linux/Unix");
+            }
+        }
+
         // TODO: remove try catch after https://github.com/dotnet/corefx/issues/32015 deployed
+        [Obsolete("Use Board.CreateI2cDevice instead")]
         public static UnixDriver Create()
         {
             UnixDriver driver = null;
@@ -25,6 +36,21 @@ namespace System.Device.Gpio.Drivers
             catch (PlatformNotSupportedException)
             {
                 driver = new SysFsDriver();
+            }
+
+            return driver;
+        }
+
+        internal static UnixDriver Create(Board board)
+        {
+            UnixDriver driver = null;
+            try
+            {
+                driver = new LibGpiodDriver(board);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                driver = new SysFsDriver(board);
             }
 
             return driver;

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.cs
@@ -21,6 +21,7 @@ namespace System.Device.Gpio.Drivers
         /// <summary>
         /// Initializes a new instance of the <see cref="Windows10Driver"/> class.
         /// </summary>
+        [Obsolete]
         public Windows10Driver()
         {
             if (Environment.OSVersion.Platform != PlatformID.Win32NT)
@@ -31,6 +32,15 @@ namespace System.Device.Gpio.Drivers
             if (s_winGpioController == null)
             {
                 throw new NotSupportedException("No GPIO controllers exist on this system.");
+            }
+        }
+
+        public Windows10Driver(Board board)
+        : base(board)
+        {
+            if (s_winGpioController == null)
+            {
+                throw new PlatformNotSupportedException("No GPIO controllers exist on this system.");
             }
         }
 
@@ -79,7 +89,15 @@ namespace System.Device.Gpio.Drivers
         /// <param name="pinNumber">The board pin number to convert.</param>
         /// <returns>The pin number in the driver's logical numbering scheme.</returns>
         protected internal override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
-            => throw new PlatformNotSupportedException($"The {GetType().Name} driver does not support physical (board) numbering, since it's generic.");
+        {
+            if (Board != null)
+            {
+                return Board.ConvertPinNumberToLogicalNumberingScheme(pinNumber);
+            }
+
+            throw new PlatformNotSupportedException(
+                $"The {GetType().Name} driver does not support physical (board) numbering, since it's generic.");
+        }
 
         /// <summary>
         /// Gets the mode of a pin.

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
@@ -9,17 +9,64 @@ namespace System.Device.Gpio
 {
     public abstract class GpioDriver : IDisposable
     {
+        [Obsolete("Available for backwards compatibility only")]
+        protected GpioDriver()
+        {
+            Board = null;
+        }
+
+        protected GpioDriver(Board board)
+        {
+            Board = board;
+        }
+
+        protected Board Board
+        {
+            get;
+        }
+
         /// <summary>
         /// The number of pins provided by the driver.
         /// </summary>
         protected internal abstract int PinCount { get; }
 
         /// <summary>
+        /// Explicitly initializes the driver (instead of waiting for the first pin to be opened)
+        /// </summary>
+        public virtual void Initialize()
+        {
+        }
+
+        /// <summary>
         /// Converts a board pin number to the driver's logical numbering scheme.
         /// </summary>
         /// <param name="pinNumber">The board pin number to convert.</param>
         /// <returns>The pin number in the driver's logical numbering scheme.</returns>
-        protected internal abstract int ConvertPinNumberToLogicalNumberingScheme(int pinNumber);
+        protected internal virtual int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            if (Board != null)
+            {
+                return Board.ConvertPinNumberToLogicalNumberingScheme(pinNumber);
+            }
+            else
+            {
+                // Somebody used the obsolete ctor while not overriding this method
+                throw new InvalidOperationException("Board must not be null when this implementation is used.");
+            }
+        }
+
+        protected internal virtual int ConvertLogicalNumberingSchemeToPinNumber(int pinNumber)
+        {
+            if (Board != null)
+            {
+                return Board.ConvertLogicalNumberingSchemeToPinNumber(pinNumber);
+            }
+            else
+            {
+                // Somebody used the obsolete ctor while not overriding this method
+                throw new InvalidOperationException("Board must not be null when this implementation is used.");
+            }
+        }
 
         /// <summary>
         /// Opens a pin in order for it to be ready to use.

--- a/src/System.Device.Gpio/System/Device/I2c/Devices/UnixI2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Devices/UnixI2cDevice.cs
@@ -13,7 +13,6 @@ namespace System.Device.I2c
     internal class UnixI2cDevice : I2cDevice
     {
         private const string DefaultDevicePath = "/dev/i2c";
-        private readonly I2cConnectionSettings _settings;
         private int _deviceFileDescriptor = -1;
         private I2cFunctionalityFlags _functionalities;
         private static readonly object s_initializationLock = new object();
@@ -24,9 +23,21 @@ namespace System.Device.I2c
         /// <param name="settings">
         /// The connection settings of a device on an I2C bus.
         /// </param>
+        [Obsolete("Use Board.CreateI2cDevice() instead")]
         public UnixI2cDevice(I2cConnectionSettings settings)
+        : base(settings, null)
         {
-            _settings = settings;
+            DevicePath = DefaultDevicePath;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnixI2cDevice"/> class that will use the specified settings to communicate with the I2C device.
+        /// </summary>
+        /// <param name="settings">The connection settings of a device on an I2C bus.</param>
+        /// <param name="board">The board on which this is opened</param>
+        internal UnixI2cDevice(I2cConnectionSettings settings, Board board)
+            : base(settings, board)
+        {
             DevicePath = DefaultDevicePath;
         }
 
@@ -35,12 +46,6 @@ namespace System.Device.I2c
         /// </summary>
         public string DevicePath { get; set; }
 
-        /// <summary>
-        /// The connection settings of a device on an I2C bus. The connection settings are immutable after the device is created
-        /// so the object returned will be a clone of the settings object.
-        /// </summary>
-        public override I2cConnectionSettings ConnectionSettings => new I2cConnectionSettings(_settings);
-
         private unsafe void Initialize()
         {
             if (_deviceFileDescriptor >= 0)
@@ -48,7 +53,7 @@ namespace System.Device.I2c
                 return;
             }
 
-            string deviceFileName = $"{DevicePath}-{_settings.BusId}";
+            string deviceFileName = $"{DevicePath}-{ConnectionSettings.BusId}";
             lock (s_initializationLock)
             {
                 if (_deviceFileDescriptor >= 0)
@@ -97,7 +102,7 @@ namespace System.Device.I2c
                 messagesPtr[messageCount++] = new i2c_msg()
                 {
                     flags = I2cMessageFlags.I2C_M_WR,
-                    addr = (ushort)_settings.DeviceAddress,
+                    addr = (ushort)ConnectionSettings.DeviceAddress,
                     len = (ushort)writeBufferLength,
                     buf = writeBuffer
                 };
@@ -108,7 +113,7 @@ namespace System.Device.I2c
                 messagesPtr[messageCount++] = new i2c_msg()
                 {
                     flags = I2cMessageFlags.I2C_M_RD,
-                    addr = (ushort)_settings.DeviceAddress,
+                    addr = (ushort)ConnectionSettings.DeviceAddress,
                     len = (ushort)readBufferLength,
                     buf = readBuffer
                 };
@@ -129,7 +134,7 @@ namespace System.Device.I2c
 
         private unsafe void FileInterfaceTransfer(byte* writeBuffer, byte* readBuffer, int writeBufferLength, int readBufferLength)
         {
-            int result = Interop.ioctl(_deviceFileDescriptor, (uint)I2cSettings.I2C_SLAVE_FORCE, (ulong)_settings.DeviceAddress);
+            int result = Interop.ioctl(_deviceFileDescriptor, (uint)I2cSettings.I2C_SLAVE_FORCE, (ulong)ConnectionSettings.DeviceAddress);
             if (result < 0)
             {
                 throw new IOException($"Error {Marshal.GetLastWin32Error()} performing I2C data transfer.");

--- a/src/System.Device.Gpio/System/Device/I2c/Devices/Windows10I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Devices/Windows10I2cDevice.cs
@@ -19,7 +19,9 @@ namespace System.Device.I2c
         /// Initializes a new instance of the <see cref="Windows10I2cDevice"/> class that will use the specified settings to communicate with the I2C device.
         /// </summary>
         /// <param name="settings">The connection settings of a device on an I2C bus.</param>
-        public Windows10I2cDevice(I2cConnectionSettings settings)
+        /// <param name="board">The board providing this connection</param>
+        internal Windows10I2cDevice(I2cConnectionSettings settings, Board board)
+        : base(settings, board)
         {
             _settings = settings;
             var winSettings = new WinI2c.I2cConnectionSettings(settings.DeviceAddress);
@@ -40,11 +42,11 @@ namespace System.Device.I2c
             }
         }
 
-        /// <summary>
-        /// The connection settings of a device on an I2C bus. The connection settings are immutable after the device is created
-        /// so the object returned will be a clone of the settings object.
-        /// </summary>
-        public override I2cConnectionSettings ConnectionSettings => new I2cConnectionSettings(_settings);
+        [Obsolete]
+        public Windows10I2cDevice(I2cConnectionSettings settings)
+        : this(settings, null)
+        {
+        }
 
         /// <summary>
         /// Reads a byte from the I2C device.

--- a/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace System.Device.I2c
 {
     /// <summary>
@@ -22,12 +25,32 @@ namespace System.Device.I2c
         {
             BusId = busId;
             DeviceAddress = deviceAddress;
+            SdaPin = -1;
+            SclPin = -1;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="I2cConnectionSettings"/> class.
+        /// </summary>
+        /// <param name="busId">The bus ID the I2C device is connected to.</param>
+        /// <param name="deviceAddress">The bus address of the I2C device.</param>
+        /// <param name="sdaPin">The physical or logical pin designation for the sda pin of the given bus.
+        /// The Raspberry Pi4 can use different sets of physical pins for I2C buses 3 to 6</param>
+        /// <param name="sclPin">The physical or logical pin designation for the scl pin of the given bus.</param>
+        public I2cConnectionSettings(int busId, int deviceAddress, int sdaPin, int sclPin)
+        {
+            BusId = busId;
+            DeviceAddress = deviceAddress;
+            SdaPin = sdaPin;
+            SclPin = sclPin;
         }
 
         internal I2cConnectionSettings(I2cConnectionSettings other)
         {
             BusId = other.BusId;
             DeviceAddress = other.DeviceAddress;
+            SdaPin = other.SdaPin;
+            SclPin = other.SclPin;
         }
 
         /// <summary>
@@ -39,5 +62,15 @@ namespace System.Device.I2c
         /// The bus address of the I2C device.
         /// </summary>
         public int DeviceAddress { get; }
+
+        public int SdaPin
+        {
+            get;
+        }
+
+        public int SclPin
+        {
+            get;
+        }
     }
 }

--- a/src/System.Device.Gpio/System/Device/PinUsage.cs
+++ b/src/System.Device.Gpio/System/Device/PinUsage.cs
@@ -1,0 +1,48 @@
+﻿namespace System.Device
+{
+    /// <summary>
+    /// Designated (or active) usage of a pin
+    /// </summary>
+    public enum PinUsage
+    {
+        /// <summary>
+        /// Pin not currently used (or usage unknown)
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Pin used for GPIO (input or output)
+        /// </summary>
+        Gpio = 1,
+
+        /// <summary>
+        /// Pin used for I2C
+        /// </summary>
+        I2c = 2,
+
+        /// <summary>
+        /// Pin used for SPI
+        /// </summary>
+        Spi = 3,
+
+        /// <summary>
+        /// Pin used for PWM (or analog out)
+        /// </summary>
+        Pwm = 4,
+
+        /// <summary>
+        /// Pin used for RS-232
+        /// </summary>
+        Uart = 5,
+
+        /// <summary>
+        /// Pin used for analog input
+        /// </summary>
+        AnalogIn = 6,
+
+        /// <summary>
+        /// Reserved usage, other than the above
+        /// </summary>
+        Other = -1
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.cs
@@ -30,11 +30,23 @@ namespace System.Device.Pwm.Channels
         /// <param name="channel">The PWM channel number.</param>
         /// <param name="frequency">The frequency in hertz.</param>
         /// <param name="dutyCycle">The duty cycle represented as a value between 0.0 and 1.0.</param>
+        [Obsolete]
         public UnixPwmChannel(
             int chip,
             int channel,
             int frequency = 400,
             double dutyCycle = 0.5)
+        : this(null, chip, channel, frequency, dutyCycle)
+        {
+        }
+
+        public UnixPwmChannel(
+            Board board,
+            int chip,
+            int channel,
+            int frequency = 400,
+            double dutyCycle = 0.5)
+        : base(board)
         {
             _chip = chip;
             _channel = channel;

--- a/src/System.Device.Gpio/System/Device/Pwm/Channels/Windows10PwmChannel.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Channels/Windows10PwmChannel.cs
@@ -25,11 +25,23 @@ namespace System.Device.Pwm.Channels
         /// <param name="channel">The PWM channel number.</param>
         /// <param name="frequency">The frequency in hertz.</param>
         /// <param name="dutyCycle">The duty cycle percentage represented as a value between 0.0 and 1.0.</param>
+        [Obsolete]
         public Windows10PwmChannel(
             int chip,
             int channel,
             int frequency = 400,
             double dutyCycle = 0.5)
+        : this(null, chip, channel, frequency, dutyCycle)
+        {
+        }
+
+        public Windows10PwmChannel(
+            Board board,
+            int chip,
+            int channel,
+            int frequency = 400,
+            double dutyCycle = 0.5)
+        : base(board)
         {
             // When running on Hummingboard we require to use the default chip.
             var deviceInfo = new EasClientDeviceInformation();

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.cs
@@ -7,8 +7,15 @@ namespace System.Device.Pwm
     /// <summary>
     /// Represents a single PWM channel.
     /// </summary>
-    public abstract partial class PwmChannel : IDisposable
+    public abstract class PwmChannel : IDisposable
     {
+        public Board Board { get; }
+
+        protected PwmChannel(Board board)
+        {
+            Board = board;
+        }
+
         /// <summary>
         /// The frequency in hertz.
         /// </summary>
@@ -48,6 +55,7 @@ namespace System.Device.Pwm
         /// <param name="frequency">The frequency in hertz.</param>
         /// <param name="dutyCyclePercentage">The duty cycle percentage represented as a value between 0.0 and 1.0.</param>
         /// <returns>A PWM channel running on Windows 10 IoT.</returns>
+        [Obsolete("Use Board.CreatePwmChannel instead")]
         public static PwmChannel Create(
             int chip,
             int channel,

--- a/src/System.Device.Gpio/System/Device/Spi/Devices/Windows10SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Devices/Windows10SpiDevice.cs
@@ -13,24 +13,22 @@ namespace System.Device.Spi
     /// </summary>
     internal class Windows10SpiDevice : SpiDevice
     {
-        private readonly SpiConnectionSettings _settings;
         private WinSpi.SpiDevice _winDevice;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Windows10SpiDevice"/> class that will use the specified settings to communicate with the SPI device.
         /// </summary>
-        /// <param name="settings">
-        /// The connection settings of a device on a SPI bus.
-        /// </param>
-        public Windows10SpiDevice(SpiConnectionSettings settings)
+        /// <param name="settings"> The connection settings of a device on a SPI bus. </param>
+        /// <param name="board">The board that created this instance</param>
+        public Windows10SpiDevice(SpiConnectionSettings settings, Board board)
+        : base(settings, board)
         {
             if (settings.DataFlow != DataFlow.MsbFirst || settings.ChipSelectLineActiveState != PinValue.Low)
             {
                 throw new PlatformNotSupportedException($"Changing {nameof(settings.DataFlow)} or {nameof(settings.ChipSelectLineActiveState)} options is not supported on the current platform.");
             }
 
-            _settings = settings;
-            var winSettings = new WinSpi.SpiConnectionSettings(_settings.ChipSelectLine)
+            var winSettings = new WinSpi.SpiConnectionSettings(settings.ChipSelectLine)
             {
                 Mode = ToWinMode(settings.Mode),
                 DataBitLength = settings.DataBitLength,
@@ -49,11 +47,11 @@ namespace System.Device.Spi
             _winDevice = WinSpi.SpiDevice.FromIdAsync(deviceInformationCollection[0].Id, winSettings).WaitForCompletion();
         }
 
-        /// <summary>
-        /// The connection settings of a device on a SPI bus. The connection settings are immutable after the device is created
-        /// so the object returned will be a clone of the settings object.
-        /// </summary>
-        public override SpiConnectionSettings ConnectionSettings => new SpiConnectionSettings(_settings);
+        [Obsolete]
+        public Windows10SpiDevice(SpiConnectionSettings settings)
+            : this(settings, null)
+        {
+        }
 
         /// <summary>
         /// Reads a byte from the SPI device.

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
@@ -7,13 +7,23 @@ namespace System.Device.Spi
     /// <summary>
     /// The communications channel to a device on a SPI bus.
     /// </summary>
-    public abstract partial class SpiDevice : IDisposable
+    public abstract class SpiDevice : IDisposable
     {
+        public SpiDevice(SpiConnectionSettings settings, Board board)
+        {
+            ConnectionSettings = settings;
+            Board = board;
+        }
+
         /// <summary>
-        /// The connection settings of a device on a SPI bus. The connection settings are immutable after the device is created
-        /// so the object returned will be a clone of the settings object.
+        /// The connection settings of a device on a SPI bus.
         /// </summary>
-        public abstract SpiConnectionSettings ConnectionSettings { get; }
+        public SpiConnectionSettings ConnectionSettings
+        {
+            get;
+        }
+
+        public Board Board { get; }
 
         /// <summary>
         /// Reads a byte from the SPI device.
@@ -56,6 +66,7 @@ namespace System.Device.Spi
         /// </summary>
         /// <param name="settings">The connection settings of a device on a SPI bus.</param>
         /// <returns>A communications channel to a device on a SPI bus running on Windows 10 IoT.</returns>
+        [Obsolete]
         public static SpiDevice Create(SpiConnectionSettings settings)
         {
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)


### PR DESCRIPTION
Fixes #878 and #974 

This is a suggestion/preview how everything should come together for #878. 

This PR includes #1039 and #1038, because these three (big) changes somewhat depend on each other. Please leave specific comments on Arduino and Platform-Independent build on those PRs. The relevant changes for this PR are all in the System.Device.Gpio assembly and the base classes defined there:
- New `Board` class abstracting a piece of hardware with different interfaces (for now: GPIO, SPI, I2C, PWM, Analog In).
- Implementations for Raspberry, generic Unix, Windows and Arduino/Firmata prepared (more TBD, also things like MCP23xxx or ADS1115 possible, and of course FT4222)
- The `Board` should now be used for creating all interface elements (GpioController, I2cDevice, etc.) This ensures consistent access and allows verification of pin usage - both for error checking (attempting to use a pin for I2C and GPIO at the same time) and setting the proper pin mode, if required (i.e. on the Raspberry).
- This `Board` class is provided to all interface elements as back-reference, to be able to manage Pins or other common behavior like logical-to-physical pin mappings. 
- Therefore added new Ctor to the abstract I2cDevice, SpiDevice, PwmChannel classes
- Marked existing Ctors/Static Create methods obsolete, but should still work.

Some of the advantages:
- Only one place is needed to check whether a board class is compatible with the actual hardware.
- No need to repeat device scans all over the place (especially since all types of drivers are now theoretically accessible regardless of the library target OS).
- Some boards (i.e. Arduino) require one common master component anyway.
- Chaining components (Reading from a DHT11 connection to an MCP23017 to an arduino to a Raspi) is much cleaner to do for a client. (Requires #1016 as well). 
- and more...

