### PR TITLE
Fix Dot enum for Large4Digit7SegmentDisplay

### DIFF
--- a/src/devices/Display/Dot.cs
+++ b/src/devices/Display/Dot.cs
@@ -26,17 +26,17 @@ namespace Iot.Device.Display
         /// <summary>
         /// Left colon
         /// </summary>
-        LeftColon = LeftLower | LeftUpper,
-
-        /// <summary>
-        /// Left lower dot
-        /// </summary>
-        LeftLower = 0b0000_0100,
+        LeftColon = LeftUpper | LeftLower,
 
         /// <summary>
         /// Left upper dot
         /// </summary>
-        LeftUpper = 0b0000_1000,
+        LeftUpper = 0b0000_0100,
+
+        /// <summary>
+        /// Left lower dot
+        /// </summary>
+        LeftLower = 0b0000_1000,
 
         /// <summary>
         /// Decimal point (between third and fourth digits)


### PR DESCRIPTION
The values for LeftUpper and LeftLower dots were interchanged

I discovered this while testing my project that uses this library.

I did not notice this error during my original contribution because I did not use these dots separately until now in my project and even though they are all separately enumerated in the sample I just failed to notice that they lit up in the wrong order (manual testing ¯\_(ツ)_/¯).