### PR TITLE
Make System.Device.Gpio work on Mono

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -41,12 +41,22 @@ namespace System.Device.Gpio.Drivers
             }
             else
             {
-                _internalDriver = new Windows10Driver();
+                _internalDriver = CreateWindows10GpioDriver();
                 _setSetRegister = (value) => throw new PlatformNotSupportedException();
                 _setClearRegister = (value) => throw new PlatformNotSupportedException();
                 _getSetRegister = () => throw new PlatformNotSupportedException();
                 _getClearRegister = () => throw new PlatformNotSupportedException();
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static GpioDriver CreateWindows10GpioDriver()
+        {
+            // This wrapper is needed to prevent Mono from loading Windows10Driver
+            // which causes all fields to be loaded - one of such fields is WinRT type which does not
+            // exist on Linux which causes TypeLoadException.
+            // Using NoInlining and no explicit type prevents this from happening.
+            return new Windows10Driver();
         }
 
         /// <inheritdoc/>

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Device.I2c
 {
     /// <summary>
@@ -67,12 +69,22 @@ namespace System.Device.I2c
         {
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
-                return new Windows10I2cDevice(settings);
+                return CreateWindows10I2cDevice(settings);
             }
             else
             {
                 return new UnixI2cDevice(settings);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static I2cDevice CreateWindows10I2cDevice(I2cConnectionSettings settings)
+        {
+            // This wrapper is needed to prevent Mono from loading Windows10I2cDevice
+            // which causes all fields to be loaded - one of such fields is WinRT type which does not
+            // exist on Linux which causes TypeLoadException.
+            // Using NoInlining and no explicit type prevents this from happening.
+            return new Windows10I2cDevice(settings);
         }
 
         /// <inheritdoc cref="IDisposable.Dispose"/>

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Device.Pwm
 {
     /// <summary>
@@ -61,7 +63,7 @@ namespace System.Device.Pwm
         {
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
-                return new Channels.Windows10PwmChannel(
+                return CreateWindows10PwmChannel(
                     chip,
                     channel,
                     frequency,
@@ -75,6 +77,20 @@ namespace System.Device.Pwm
                     frequency,
                     dutyCyclePercentage);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static PwmChannel CreateWindows10PwmChannel(int chip, int channel, int frequency, double dutyCyclePercentage)
+        {
+            // This wrapper is needed to prevent Mono from loading Windows10PwmChannel
+            // which causes all fields to be loaded - one of such fields is WinRT type which does not
+            // exist on Linux which causes TypeLoadException.
+            // Using NoInlining and no explicit type prevents this from happening.
+            return new Channels.Windows10PwmChannel(
+                    chip,
+                    channel,
+                    frequency,
+                    dutyCyclePercentage);
         }
     }
 }

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Device.Spi
 {
     /// <summary>
@@ -60,12 +62,22 @@ namespace System.Device.Spi
         {
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
-                return new Windows10SpiDevice(settings);
+                return CreateWindows10SpiDevice(settings);
             }
             else
             {
                 return new UnixSpiDevice(settings);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static SpiDevice CreateWindows10SpiDevice(SpiConnectionSettings settings)
+        {
+            // This wrapper is needed to prevent Mono from loading Windows10SpiDevice
+            // which causes all fields to be loaded - one of such fields is WinRT type which does not
+            // exist on Linux which causes TypeLoadException.
+            // Using NoInlining and no explicit type prevents this from happening.
+            return new Windows10SpiDevice(settings);
         }
 
         /// <inheritdoc cref="IDisposable.Dispose"/>


### PR DESCRIPTION
Fixes https://github.com/dotnet/iot/issues/1089

Use workaround provided by Mono for the type loading issue.

cc: @Ellerbach 