### PR TITLE
Add IWritablePinSegment

### DIFF
--- a/src/devices/Common/Iot/Device/Common/GpioPinSegment.cs
+++ b/src/devices/Common/Iot/Device/Common/GpioPinSegment.cs
@@ -43,9 +43,9 @@ namespace Iot.Device.Common
         public int Length => _pins.Length;
 
         /// <summary>
-        /// Write operation to the underlying GpioController.
+        /// Writes a PinValue to the underlying GpioController.
         /// </summary>
-        public void Write(int pin, int value)
+        public void Write(int pin, PinValue value)
         {
             _controller.Write(_pins[pin], value);
         }

--- a/src/devices/Common/Iot/Device/Common/GpioPinSegment.cs
+++ b/src/devices/Common/Iot/Device/Common/GpioPinSegment.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Device.Gpio;
+
+namespace Iot.Device.Common
+{
+    /// <summary>
+    /// IWritablePinSegment implementation that uses GpioController.
+    /// </summary>
+    public class GpioSegment : IWritablePinSegment
+    {
+        private GpioController _controller;
+        private int[] _pins;
+
+        /// <summary>
+        /// IWritablePinSegment implementation that uses GpioController.
+        /// </summary>
+        /// <param name="pins">The GPIO pins that should be used and are connected.</param>
+        /// <param name="gpioController">The GpioController to use. If one isn't provided, one will be created.</param>
+        public GpioSegment(int[] pins, GpioController gpioController = null)
+        {
+            _pins = pins;
+
+            if (gpioController is null)
+            {
+                gpioController = new GpioController();
+            }
+
+            _controller = gpioController;
+
+            foreach (var pin in _pins)
+            {
+                _controller.OpenPin(pin, PinMode.Output);
+            }
+        }
+
+        /// <summary>
+        /// The length of the segment; the number of GPIO pins it exposes.
+        /// </summary>
+        public int Length => _pins.Length;
+
+        /// <summary>
+        /// Write operation to the underlying GpioController.
+        /// </summary>
+        public void Write(int pin, int value)
+        {
+            _controller.Write(_pins[pin], value);
+        }
+
+        /// <summary>
+        /// Disposes the underlying GpioController.
+        /// </summary>
+        public void Dispose()
+        {
+            ((IDisposable)_controller).Dispose();
+        }
+    }
+}

--- a/src/devices/Common/Iot/Device/Common/IWritablePinSegment.cs
+++ b/src/devices/Common/Iot/Device/Common/IWritablePinSegment.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Iot.Device.Common
+{
+    /// <summary>
+    /// Interface that abstracts pin multiplexing.
+    /// </summary>
+    public interface IWritablePinSegment
+    {
+        /// <summary>
+        /// Length of segment (number of pins)
+        /// </summary>
+        int Length { get; }
+
+        /// <summary>
+        /// Writes a high or low value to pin
+        /// </summary>
+        void Write(int pin, int value);
+    }
+}

--- a/src/devices/Common/Iot/Device/Common/IWritablePinSegment.cs
+++ b/src/devices/Common/Iot/Device/Common/IWritablePinSegment.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Device.Gpio;
 
 namespace Iot.Device.Common
 {
@@ -17,8 +18,8 @@ namespace Iot.Device.Common
         int Length { get; }
 
         /// <summary>
-        /// Writes a high or low value to pin
+        /// Writes a PinValue
         /// </summary>
-        void Write(int pin, int value);
+        void Write(int pin, PinValue value);
     }
 }


### PR DESCRIPTION
I've been working on enabling [LED animations](https://github.com/richlander/iot/blob/samples-update/samples/led-bar-graph/AnimateLeds.cs) to work over a variety of pin multiplexing schemes. That's what this interface is for.

I'm not enamored by this particular interface name. It would be good is someone could come up with something better.

Reading and writing is very similar when using GPIO controller pins directly. As you move to more exotic multiplexing options, reading and writing require different approaches. Reading may be done via polling. Also, many scenarios don't require reading. So, I'm proposing to make this interface for writing only. If people want reading, I'd suggest we make another interface for reading. Implementations can implement one or both.

I also have an interface implementation for a shift register @ https://github.com/richlander/iot/blob/samples-update/samples/led-bar-graph/ShiftRegisterSegment.cs. It is waiting on #1104 to be merged. Otherwise, it would be part of this PR.

I updated my test program to use the shift register implementation. Creating the implementation and switching to it took about 10mins. That was a good proof case for the idea. The program, at least visually, does the same thing as the prior GPIO-based implementation. There are other implementations we could make, like charlieplexing.

I don't know if this repo/namespace location is the correct one. I just put it there to start. Looking for input on that. It's also an open question of whether the interface and its implementations should be in the same place. I don't think they should.