### PR TITLE
Make DhtBase.Temperature return default(Temperature) on unsuccessful reads

### DIFF
--- a/src/devices/Dhtxx/DhtBase.cs
+++ b/src/devices/Dhtxx/DhtBase.cs
@@ -65,7 +65,7 @@ namespace Iot.Device.DHTxx
             get
             {
                 ReadData();
-                return IsLastReadSuccessful ? GetTemperature(_readBuff) : Temperature.FromDegreesCelsius(double.NaN);
+                return IsLastReadSuccessful ? GetTemperature(_readBuff) : default(Temperature);
             }
         }
 


### PR DESCRIPTION
Update DhtBase.Temperature to do what it is documented to do. Currently it's doing:

```
System.ArgumentException: NaN is not a valid number. (Parameter 'val')
   at UnitsNet.InternalHelpers.Guard.EnsureValidNumber(Double value, String paramName)
   at UnitsNet.QuantityValue..ctor(Double val)
   at UnitsNet.QuantityValue.op_Implicit(Double val)
   at Iot.Device.DHTxx.DhtBase.get_Temperature()
```

Reported by: @Ellerbach , not sure if there is an issue.