### PR TITLE
Adding TimeoutHelper in order to make sure that long running test eventually times out.

### DIFF
--- a/src/System.Device.Gpio.Tests/TimeoutHelper.cs
+++ b/src/System.Device.Gpio.Tests/TimeoutHelper.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+
+namespace System.Device.Gpio.Tests
+{
+    public static class TimeoutHelper
+    {
+        public static void CompletesInTime(Action test, TimeSpan timeout)
+        {
+            Task task = Task.Run(test);
+            bool completedInTime = Task.WaitAll(new[] { task }, timeout);
+
+            if (task.Exception != null)
+            {
+                if (task.Exception.InnerExceptions.Count == 1)
+                {
+                    throw task.Exception.InnerExceptions[0];
+                }
+
+                throw task.Exception;
+            }
+
+            if (!completedInTime)
+            {
+                throw new TimeoutException($"Test did not complete in the specified timeout: {timeout.TotalSeconds} seconds.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
cc @krwq 

Lately, CI has been flaky and when doing an analysis on Kusto I found that most of the failures come from this test being stuck and hanging till the full build time run times out, causing the test process to crash and for us to not get accurate info on the test run. In order to get more accurate metrics, this timeout helper will help to fail the test after trying to run for 30 seconds, at which time we will then be able to get more diagnostics into tests fail/pass rates so that we can correlate when is the test failing the most and if there is a correlation with a different test failing the same run as well.
