### PR TITLE
adding disposable, shared controller interface and gpiocontroller interface

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -143,7 +143,7 @@ namespace System.Device.Gpio.Tests
             {
                 Assert.False(controller.IsPinOpen(LedPin));
 
-                var openPin = controller.OpenPin(LedPin, PinMode.Output);
+                var openPin = controller.OpenPinAsDisposable(LedPin, PinMode.Output);
                 Assert.True(controller.IsPinOpen(LedPin));
 
                 openPin.Dispose();
@@ -323,7 +323,7 @@ namespace System.Device.Gpio.Tests
                 {
                     risingEventOccurredCount++;
                 });
-                var callbackToDispose = controller.RegisterCallbackForPinValueChangedEvent(InputPin, PinEventTypes.Rising, Callback);
+                var callbackToDispose = controller.RegisterCallbackForPinValueChangedEventAsDisposable(InputPin, PinEventTypes.Rising, Callback);
                 controller.RegisterCallbackForPinValueChangedEvent(InputPin, PinEventTypes.Rising, (o, e) =>
                 {
                     risingEventOccurredCount++;

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -70,7 +70,7 @@ namespace System.Device.Gpio
         }
 
         /// <inheritdoc/>
-        public IDisposable OpenPin(int pinNumber)
+        public void OpenPin(int pinNumber)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (_openPins.Contains(logicalPinNumber))
@@ -80,15 +80,13 @@ namespace System.Device.Gpio
 
             _driver.OpenPin(logicalPinNumber);
             _openPins.Add(logicalPinNumber);
-            return Disposable.Create(() => ClosePin(pinNumber));
         }
 
         /// <inheritdoc/>
-        public IDisposable OpenPin(int pinNumber, PinMode mode)
+        public void OpenPin(int pinNumber, PinMode mode)
         {
             OpenPin(pinNumber);
             SetPinMode(pinNumber, mode);
-            return Disposable.Create(() => ClosePin(pinNumber));
         }
 
         /// <inheritdoc/>
@@ -219,7 +217,7 @@ namespace System.Device.Gpio
         }
 
         /// <inheritdoc/>
-        public IDisposable RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+        public void RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
@@ -228,8 +226,6 @@ namespace System.Device.Gpio
             }
 
             _driver.AddCallbackForPinValueChangedEvent(logicalPinNumber, eventTypes, callback);
-
-            return Disposable.Create(() => UnregisterCallbackForPinValueChangedEvent(pinNumber, callback));
         }
 
         /// <inheritdoc/>

--- a/src/System.Device.Gpio/System/Device/Gpio/IGpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/IGpioController.cs
@@ -26,16 +26,14 @@ namespace System.Device.Gpio
         /// Opens a pin in order for it to be ready to use.
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
-        /// <returns>A disposable that will close the pin if disposed.</returns>
-        IDisposable OpenPin(int pinNumber);
+        void OpenPin(int pinNumber);
 
         /// <summary>
         /// Opens a pin and sets it to a specific mode.
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <param name="mode">The mode to be set.</param>
-        /// <returns>A disposable that will close the pin if disposed.</returns>
-        IDisposable OpenPin(int pinNumber, PinMode mode);
+        void OpenPin(int pinNumber, PinMode mode);
 
         /// <summary>
         /// Closes an open pin.
@@ -128,8 +126,7 @@ namespace System.Device.Gpio
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="callback">The callback method that will be invoked.</param>
-        /// <returns>A disposable object that will remove the added callback </returns>
-        IDisposable RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback);
+        void RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback);
 
         /// <summary>
         /// Removes a callback that was being invoked for pin at pinNumber.

--- a/src/System.Device.Gpio/System/Device/Gpio/IGpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/IGpioController.cs
@@ -1,0 +1,153 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Device.Gpio
+{
+    /// <summary>
+    /// Represents the interface of a general-purpose I/O (GPIO) controller.
+    /// </summary>
+    public interface IGpioController : IDisposable
+    {
+        /// <summary>
+        /// The numbering scheme used to represent pins provided by the controller.
+        /// </summary>
+        PinNumberingScheme NumberingScheme { get; }
+
+        /// <summary>
+        /// The number of pins provided by the controller.
+        /// </summary>
+        int PinCount { get; }
+
+        /// <summary>
+        /// Opens a pin in order for it to be ready to use.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <returns>A disposable that will close the pin if disposed.</returns>
+        IDisposable OpenPin(int pinNumber);
+
+        /// <summary>
+        /// Opens a pin and sets it to a specific mode.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="mode">The mode to be set.</param>
+        /// <returns>A disposable that will close the pin if disposed.</returns>
+        IDisposable OpenPin(int pinNumber, PinMode mode);
+
+        /// <summary>
+        /// Closes an open pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        void ClosePin(int pinNumber);
+
+        /// <summary>
+        /// Sets the mode to a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="mode">The mode to be set.</param>
+        void SetPinMode(int pinNumber, PinMode mode);
+
+        /// <summary>
+        /// Gets the mode of a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <returns>The mode of the pin.</returns>
+        PinMode GetPinMode(int pinNumber);
+
+        /// <summary>
+        /// Checks if a specific pin is open.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <returns>The status if the pin is open or closed.</returns>
+        bool IsPinOpen(int pinNumber);
+
+        /// <summary>
+        /// Checks if a pin supports a specific mode.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="mode">The mode to check.</param>
+        /// <returns>The status if the pin supports the mode.</returns>
+        bool IsPinModeSupported(int pinNumber, PinMode mode);
+
+        /// <summary>
+        /// Reads the current value of a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <returns>The value of the pin.</returns>
+        PinValue Read(int pinNumber);
+
+        /// <summary>
+        /// Writes a value to a pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="value">The value to be written to the pin.</param>
+        void Write(int pinNumber, PinValue value);
+
+        /// <summary>
+        /// Blocks execution until an event of type eventType is received or a period of time has expired.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="timeout">The time to wait for the event.</param>
+        /// <returns>A structure that contains the result of the waiting operation.</returns>
+        WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, TimeSpan timeout);
+
+        /// <summary>
+        /// Blocks execution until an event of type eventType is received or a cancellation is requested.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
+        /// <returns>A structure that contains the result of the waiting operation.</returns>
+        WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Async call to wait until an event of type eventType is received or a period of time has expired.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="timeout">The time to wait for the event.</param>
+        /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation.</returns>
+        ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, TimeSpan timeout);
+
+        /// <summary>
+        /// Async call until an event of type eventType is received or a cancellation is requested.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="token">The cancellation token of when the operation should stop waiting for an event.</param>
+        /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
+        ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, CancellationToken token);
+
+        /// <summary>
+        /// Adds a callback that will be invoked when pinNumber has an event of type eventType.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="callback">The callback method that will be invoked.</param>
+        /// <returns>A disposable object that will remove the added callback </returns>
+        IDisposable RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback);
+
+        /// <summary>
+        /// Removes a callback that was being invoked for pin at pinNumber.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="callback">The callback method that will be invoked.</param>
+        void UnregisterCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback);
+
+        /// <summary>
+        /// Write the given pins with the given values.
+        /// </summary>
+        /// <param name="pinValuePairs">The pin/value pairs to write.</param>
+        void Write(ReadOnlySpan<PinValuePair> pinValuePairs);
+
+        /// <summary>
+        /// Read the given pins with the given pin numbers.
+        /// </summary>
+        /// <param name="pinValuePairs">The pin/value pairs to read.</param>
+        void Read(Span<PinValuePair> pinValuePairs);
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Gpio/IGpioControllerExtensions.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/IGpioControllerExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Disposables;
+
+namespace System.Device.Gpio
+{
+    /// <summary>
+    /// Extensions for <see cref="IGpioController"/> interface.
+    /// </summary>
+    public static class IGpioControllerExtensions
+    {
+        /// <summary>
+        /// Opens a pin in order for it to be ready to use.
+        /// </summary>
+        /// <param name="controller">The GPioController.</param>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <returns>A disposable that will close the pin if disposed.</returns>
+        public static IDisposable OpenPinAsDisposable(this IGpioController controller, int pinNumber)
+        {
+            controller.OpenPin(pinNumber);
+            return Disposable.Create(() => controller.ClosePin(pinNumber));
+        }
+
+        /// <summary>
+        /// Opens a pin and sets it to a specific mode.
+        /// </summary>
+        /// <param name="controller">The GPioController.</param>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="mode">The mode to be set.</param>
+        /// <returns>A disposable that will close the pin if disposed.</returns>
+        public static IDisposable OpenPinAsDisposable(this IGpioController controller, int pinNumber, PinMode mode)
+        {
+            controller.OpenPin(pinNumber, mode);
+            return Disposable.Create(() => controller.ClosePin(pinNumber));
+        }
+
+        /// <summary>
+        /// Adds a callback that will be invoked when pinNumber has an event of type eventType.
+        /// </summary>
+        /// <param name="controller">The GPioController.</param>
+        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="callback">The callback method that will be invoked.</param>
+        /// <returns>A disposable object that will remove the added callback </returns>
+        public static IDisposable RegisterCallbackForPinValueChangedEventAsDisposable(this IGpioController controller, int pinNumber,
+            PinEventTypes eventTypes, PinChangeEventHandler callback)
+        {
+            controller.RegisterCallbackForPinValueChangedEvent(pinNumber, eventTypes, callback);
+            return Disposable.Create(() => controller.UnregisterCallbackForPinValueChangedEvent(pinNumber, callback));
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Gpio/SharedGpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/SharedGpioController.cs
@@ -43,19 +43,17 @@ namespace System.Device.Gpio
         public int PinCount => _controller.PinCount;
 
         /// <inheritdoc/>
-        public IDisposable OpenPin(int pinNumber)
+        public void OpenPin(int pinNumber)
         {
             _controller.OpenPin(pinNumber);
             _openPins.Add(pinNumber);
-            return Disposable.Create(() => ClosePin(pinNumber));
         }
 
         /// <inheritdoc/>
-        public IDisposable OpenPin(int pinNumber, PinMode mode)
+        public void OpenPin(int pinNumber, PinMode mode)
         {
             _controller.OpenPin(pinNumber, mode);
             _openPins.Add(pinNumber);
-            return Disposable.Create(() => ClosePin(pinNumber));
         }
 
         /// <inheritdoc/>
@@ -128,11 +126,9 @@ namespace System.Device.Gpio
         }
 
         /// <inheritdoc/>
-        public IDisposable RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+        public void RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
             _controller.RegisterCallbackForPinValueChangedEvent(pinNumber, eventTypes, callback);
-
-            return Disposable.Create(() => UnregisterCallbackForPinValueChangedEvent(pinNumber, callback));
         }
 
         /// <inheritdoc/>

--- a/src/System.Device.Gpio/System/Device/Gpio/SharedGpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/SharedGpioController.cs
@@ -1,0 +1,156 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Disposables;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Device.Gpio
+{
+    /// <summary>
+    /// Represents a shared view of general-purpose I/O (GPIO) controller.
+    /// </summary>
+    public sealed class SharedGpioController : IGpioController
+    {
+        private readonly List<int> _openPins = new List<int>();
+        private readonly IGpioController _controller;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GpioController"/> class that will use the logical pin numbering scheme as default.
+        /// </summary>
+        public SharedGpioController(IGpioController controller)
+        {
+            _controller = controller;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            foreach (var openPin in _openPins)
+            {
+                _controller.ClosePin(openPin);
+            }
+
+            _openPins.Clear();
+        }
+
+        /// <inheritdoc/>
+        public PinNumberingScheme NumberingScheme => _controller.NumberingScheme;
+
+        /// <inheritdoc/>
+        public int PinCount => _controller.PinCount;
+
+        /// <inheritdoc/>
+        public IDisposable OpenPin(int pinNumber)
+        {
+            _controller.OpenPin(pinNumber);
+            _openPins.Add(pinNumber);
+            return Disposable.Create(() => ClosePin(pinNumber));
+        }
+
+        /// <inheritdoc/>
+        public IDisposable OpenPin(int pinNumber, PinMode mode)
+        {
+            _controller.OpenPin(pinNumber, mode);
+            _openPins.Add(pinNumber);
+            return Disposable.Create(() => ClosePin(pinNumber));
+        }
+
+        /// <inheritdoc/>
+        public void ClosePin(int pinNumber)
+        {
+            if (_openPins.Remove(pinNumber))
+            {
+                _controller.ClosePin(pinNumber);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void SetPinMode(int pinNumber, PinMode mode)
+        {
+            _controller.SetPinMode(pinNumber, mode);
+        }
+
+        /// <inheritdoc/>
+        public PinMode GetPinMode(int pinNumber)
+        {
+            return _controller.GetPinMode(pinNumber);
+        }
+
+        /// <inheritdoc/>
+        public bool IsPinOpen(int pinNumber)
+        {
+            return _openPins.Contains(pinNumber);
+        }
+
+        /// <inheritdoc/>
+        public bool IsPinModeSupported(int pinNumber, PinMode mode)
+        {
+            return _controller.IsPinModeSupported(pinNumber, mode);
+        }
+
+        /// <inheritdoc/>
+        public PinValue Read(int pinNumber)
+        {
+            return _controller.Read(pinNumber);
+        }
+
+        /// <inheritdoc/>
+        public void Write(int pinNumber, PinValue value)
+        {
+            _controller.Write(pinNumber, value);
+        }
+
+        /// <inheritdoc/>
+        public WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, TimeSpan timeout)
+        {
+            return _controller.WaitForEvent(pinNumber, eventTypes, timeout);
+        }
+
+        /// <inheritdoc/>
+        public WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
+        {
+            return _controller.WaitForEvent(pinNumber, eventTypes, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, TimeSpan timeout)
+        {
+            return _controller.WaitForEventAsync(pinNumber, eventTypes, timeout);
+        }
+
+        /// <inheritdoc/>
+        public ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, CancellationToken token)
+        {
+            return _controller.WaitForEventAsync(pinNumber, eventTypes, token);
+        }
+
+        /// <inheritdoc/>
+        public IDisposable RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+        {
+            _controller.RegisterCallbackForPinValueChangedEvent(pinNumber, eventTypes, callback);
+
+            return Disposable.Create(() => UnregisterCallbackForPinValueChangedEvent(pinNumber, callback));
+        }
+
+        /// <inheritdoc/>
+        public void UnregisterCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
+        {
+            _controller.UnregisterCallbackForPinValueChangedEvent(pinNumber, callback);
+        }
+
+        /// <inheritdoc/>
+        public void Write(ReadOnlySpan<PinValuePair> pinValuePairs)
+        {
+            _controller.Write(pinValuePairs);
+        }
+
+        /// <inheritdoc/>
+        public void Read(Span<PinValuePair> pinValuePairs)
+        {
+            _controller.Read(pinValuePairs);
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Disposables/Disposable.cs
+++ b/src/System.Device.Gpio/System/Disposables/Disposable.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Disposables
+{
+    /// <summary>
+    /// Utility to create disposable objects
+    /// </summary>
+    public static class Disposable
+    {
+        private class AnonymousDisposable : IDisposable
+        {
+            private readonly Action _onDispose;
+
+            public AnonymousDisposable(Action onDispose)
+            {
+                _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));
+            }
+
+            public void Dispose()
+            {
+                _onDispose();
+            }
+        }
+
+        /// <summary>
+        /// Creates a disposable object.
+        /// </summary>
+        /// <param name="onDispose">The action to perform on disposal</param>
+        /// <returns>The disposable object</returns>
+        public static IDisposable Create(Action onDispose)
+        {
+            return new AnonymousDisposable(onDispose);
+        }
+    }
+}


### PR DESCRIPTION
With this PR I am trying to propose a discussion around some interfaces used during the development of the piTop bindings

- introduction of a IGpioController interface to make it possible to have mocks and implement shared proxy
- share controller class to create a view over a controller so that devices and other part of applications can manage pins and callbacks with the ability to clean up just the portion of state interested
- disposable factory to create disposable object to simplify the closing of pins and the unregistration of callbacks 