### PR TITLE
Adjusting naming for segments and characters Tm1637

### DIFF
--- a/src/devices/Tm1637/README.md
+++ b/src/devices/Tm1637/README.md
@@ -2,7 +2,7 @@
 
 # Summary
 
-TM1637 is a 6 segments Led controler. It used a 2 wire implementation, one for the clock (CLK), one for the data (DIO). This chip can act as well as a key reader. This part has not been implemented. Only the Led display has been implemented. Most of its modern usages are for 4 to 6 segment displays. 
+TM1637 is a segments display with 6 characters Led controler. It used a 2 wire implementation, one for the clock (CLK), one for the data (DIO). This chip can act as well as a key reader. This part has not been implemented. Only the Led display has been implemented. Most of its modern usages are for 4 to 6 segment displays. 
 
 ## Device family
 
@@ -92,10 +92,10 @@ The maximum size of the buffer is 6.
 
 ## Segment order
 
-You can change the order of the segments. In some cases, especially when you have displays with 6 segments split with 2 displays of 3, the order may not be the one you expect.
+You can change the order of the characters. In some cases, especially when you have displays with 6 segments split with 2 displays of 3, the order may not be the one you expect.
 
 ```csharp
-tm1637.SegmentOrder = new byte[] { 2, 1, 0, 5, 4, 3 };
+tm1637.CharacterOrder = new byte[] { 2, 1, 0, 5, 4, 3 };
 ```
 
 Make sure you have a length of 6 and all numbers from 0 to 5.

--- a/src/devices/Tm1637/Tm1637.cs
+++ b/src/devices/Tm1637/Tm1637.cs
@@ -18,9 +18,9 @@ namespace Iot.Device.Tm1637
     public sealed class Tm1637 : IDisposable
     {
         /// <summary>
-        /// The number of segments that the TM1637 can handle
+        /// The number of characters that the TM1637 can handle
         /// </summary>
-        public static byte MaxSegments => 6;
+        public static byte MaxCharacters => 6;
 
         // According to the doc, the clock pulse width minimum is 400 ns
         // And waiting time between clk up and down is 1 µs
@@ -33,8 +33,8 @@ namespace Iot.Device.Tm1637
 
         private byte _brightness;
 
-        // Default segment order is from 0 to 5
-        private byte[] _segmentOrder = new byte[6] { 0, 1, 2, 3, 4, 5 };
+        // Default character order is from 0 to 5
+        private byte[] _charactersOrder = new byte[6] { 0, 1, 2, 3, 4, 5 };
 
         // To store what has been displayed last. Used when change on brightness or
         // screen on/off is used
@@ -64,27 +64,27 @@ namespace Iot.Device.Tm1637
         }
 
         /// <summary>
-        /// Order of segments, expect a 6 length byte array
+        /// Order of characters, expect a 6 length byte array
         /// 0 to 5, any order. Most of the time 4 segments do
         /// not need to be changed but the 6 ones may be in different order
         /// like 0 1 2 5 4 3. In this case, this byte array has be be in this order
         /// </summary>
-        public byte[] SegmentOrder
+        public byte[] CharacterOrder
         {
             get
             {
-                return _segmentOrder;
+                return _charactersOrder;
             }
             set
             {
-                if (value.Length != MaxSegments)
+                if (value.Length != MaxCharacters)
                 {
-                    throw new ArgumentException($"Size of {nameof(SegmentOrder)} can only be 6 length");
+                    throw new ArgumentException($"Size of {nameof(CharacterOrder)} can only be 6 length");
                 }
 
                 // Check if we have all values from 0 to 5
                 bool allExist = true;
-                for (int i = 0; i < MaxSegments; i++)
+                for (int i = 0; i < MaxCharacters; i++)
                 {
                     allExist &= Array.Exists(value, e => e == i);
                 }
@@ -92,10 +92,10 @@ namespace Iot.Device.Tm1637
                 if (!allExist)
                 {
                     throw new ArgumentException(
-                        $"{nameof(SegmentOrder)} needs to have all existing segments from 0 to 5");
+                        $"{nameof(CharacterOrder)} needs to have all existing characters from 0 to 5");
                 }
 
-                value.CopyTo(_segmentOrder, 0);
+                value.CopyTo(_charactersOrder, 0);
             }
         }
 
@@ -160,7 +160,7 @@ namespace Iot.Device.Tm1637
                 DelayHelper.DelayMicroseconds(ClockWidthMicroseconds, true);
             }
 
-            // Wait for the acknoledge
+            // Wait for the acknowledge
             _controller.Write(_pinClk, PinValue.Low);
             _controller.Write(_pinDio, PinValue.High);
             _controller.Write(_pinClk, PinValue.High);
@@ -225,22 +225,22 @@ namespace Iot.Device.Tm1637
         /// <param name="rawData">The raw data array to display, size of the array has to be 6 maximum</param>
         private void Display(ReadOnlySpan<byte> rawData)
         {
-            if (rawData.Length > MaxSegments)
+            if (rawData.Length > MaxCharacters)
             {
-                throw new ArgumentException($"Maximum number of segments for TM1637 is {MaxSegments}");
+                throw new ArgumentException($"Maximum number of segments for TM1637 is {MaxCharacters}");
             }
 
             // Prepare the buffer with the right order to transfer
-            byte[] toTransfer = new byte[MaxSegments];
+            byte[] toTransfer = new byte[MaxCharacters];
 
             for (int i = 0; i < rawData.Length; i++)
             {
-                toTransfer[_segmentOrder[i]] = rawData[i];
+                toTransfer[_charactersOrder[i]] = rawData[i];
             }
 
-            for (int j = rawData.Length; j < MaxSegments; j++)
+            for (int j = rawData.Length; j < MaxCharacters; j++)
             {
-                toTransfer[_segmentOrder[j]] = (byte)Character.Nothing;
+                toTransfer[_charactersOrder[j]] = (byte)Character.Nothing;
             }
 
             _lastDisplay = toTransfer;
@@ -253,7 +253,7 @@ namespace Iot.Device.Tm1637
             // Second command is set address to automatic
             WriteByte((byte)DataCommand.DataCommandSetting);
             // Transfer the data
-            for (int i = 0; i < MaxSegments; i++)
+            for (int i = 0; i < MaxCharacters; i++)
             {
                 WriteByte(toTransfer[i]);
             }
@@ -292,21 +292,21 @@ namespace Iot.Device.Tm1637
         ///
         /// Representation of the number 0 so lighting segments a, b, c, d, e and F is then 0x3f
         /// </remarks>
-        /// <param name="segmentPosition">The segment position from 0 to 5</param>
-        /// <param name="rawData">The segemnet characters to display</param>
-        public void Display(byte segmentPosition, Character rawData)
+        /// <param name="characterPosition">The character position from 0 to 5</param>
+        /// <param name="rawData">The segment characters to display</param>
+        public void Display(byte characterPosition, Character rawData)
         {
-            if (segmentPosition > MaxSegments)
+            if (characterPosition > MaxCharacters)
             {
-                throw new ArgumentException($"Maximum number of segments for TM1637 is {MaxSegments}");
+                throw new ArgumentException($"Maximum number of characters for TM1637 is {MaxCharacters}");
             }
 
             // Recreate the buffer in correct order
-            _lastDisplay[_segmentOrder[segmentPosition]] = (byte)rawData;
-            DisplayRaw(_segmentOrder[segmentPosition], (byte)rawData);
+            _lastDisplay[_charactersOrder[characterPosition]] = (byte)rawData;
+            DisplayRaw(_charactersOrder[characterPosition], (byte)rawData);
         }
 
-        private void DisplayRaw(byte segmentAddress, byte rawData)
+        private void DisplayRaw(byte characterAddress, byte rawData)
         {
             StartTransmission();
             // First command for fix address
@@ -314,7 +314,7 @@ namespace Iot.Device.Tm1637
             StopTransmission();
             StartTransmission();
             // Set the address to transfer
-            WriteByte((byte)(DataCommand.AddressCommandSetting + segmentAddress));
+            WriteByte((byte)(DataCommand.AddressCommandSetting + characterAddress));
             // Transfer the byte
             WriteByte(rawData);
             StopTransmission();

--- a/src/devices/Tm1637/samples/Tm1637.sample.cs
+++ b/src/devices/Tm1637/samples/Tm1637.sample.cs
@@ -18,7 +18,7 @@ namespace Tm1637Sample
             tm1637.ScreenOn = true;
             tm1637.ClearDisplay();
             // Displays 4 Characters
-            // If you have a 4 display, all 4 will be displayed as well as on a 6
+            // If you have a 4 character display, all 4 will be displayed as well as on a 6
             Character[] toDisplay = new Character[4]
             {
                 Character.Digit4, Character.Digit2 | Character.Dot, Character.Digit3, Character.Digit8
@@ -38,7 +38,7 @@ namespace Tm1637Sample
             Thread.Sleep(3000);
 
             // Changing order of the segments
-            tm1637.SegmentOrder = new byte[] { 2, 1, 0, 5, 4, 3 };
+            tm1637.CharacterOrder = new byte[] { 2, 1, 0, 5, 4, 3 };
 
             // Displays couple of raw data
             Character[] rawData = new Character[6]
@@ -79,7 +79,7 @@ namespace Tm1637Sample
             Thread.Sleep(3000);
 
             // Revert order of the segments
-            tm1637.SegmentOrder = new byte[] { 0, 1, 2, 3, 4, 5 };
+            tm1637.CharacterOrder = new byte[] { 0, 1, 2, 3, 4, 5 };
 
             // Blink the screen by switching on and off
             for (int i = 0; i < 10; i++)


### PR DESCRIPTION
Fixing issue #1188 
- Replaced "segment" by "character" where needed to bring more clarity
