### PR TITLE
Adding crosstargeting in order to be able to call WinRT APIs in net5.0

### DIFF
--- a/eng/Compilers.props
+++ b/eng/Compilers.props
@@ -3,7 +3,7 @@
     <!-- This is set to false by default when using the compilers' NuGet package. -->
     <UseSharedCompilation>true</UseSharedCompilation>
 
-    <CompilerVersion>3.6.0-2.20166.2</CompilerVersion>
+    <CompilerVersion>3.8.0-4.final</CompilerVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-rc.1.20452.10",
+    "dotnet": "5.0.100-rc.2.20479.15",
     "runtimes": {
       "dotnet/x64": [
         "2.1.11"
@@ -8,7 +8,7 @@
     }
   },
   "sdk": {
-    "version": "5.0.100-rc.1.20452.10"
+    "version": "5.0.100-rc.2.20479.15"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20506.7",

--- a/src/System.Device.Gpio/Interop/Unix/Interop.Libraries.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Interop.Libraries.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-internal partial class Interop
+internal static partial class Interop
 {
     private const string LibcLibrary = "libc";
 }

--- a/src/System.Device.Gpio/System.Device.Gpio.csproj
+++ b/src/System.Device.Gpio/System.Device.Gpio.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <!--<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('win'))">$(TargetFrameworks);net5.0-windows10.0.17763.0</TargetFrameworks>-->
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('win'))">$(TargetFrameworks);net5.0-windows10.0.17763.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
     <IsPackable>true</IsPackable>

--- a/src/System.Device.Gpio/System.Device.Gpio.csproj
+++ b/src/System.Device.Gpio/System.Device.Gpio.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net5.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('win'))">$(TargetFrameworks);net5.0-windows10.0.17763.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
     <IsPackable>true</IsPackable>

--- a/src/System.Device.Gpio/System.Device.Gpio.csproj
+++ b/src/System.Device.Gpio/System.Device.Gpio.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0;net5.0-windows10.0.17763.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
     <IsPackable>true</IsPackable>
@@ -10,17 +10,19 @@
     <Compile Remove="winmd\**" />
     <EmbeddedResource Remove="winmd\**" />
     <None Remove="winmd\**" />
+    <None Include="build\net5.0\System.Device.Gpio.targets" Pack="true" PackagePath="\build\net5.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" /> <!-- This is Windows specific -->
-    <PackageReference Include="System.Runtime.WindowsRuntime" Version="$(SystemRuntimeWindowsRuntimePackageVersion)" /> <!-- This is Windows specific -->
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
-    <PackageReference Include="System.Runtime.InteropServices.WindowsRuntime" Version="4.3.0" /> <!-- This is Windows specific -->
     <PackageReference Include="Microsoft.DotNet.GenAPI" Version="$(MicrosoftDotNetGenApiPackageVersion)">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Runtime.WindowsRuntime" Version="$(SystemRuntimeWindowsRuntimePackageVersion)" />
+    <PackageReference Include="System.Runtime.InteropServices.WindowsRuntime" Version="4.3.0" />
+
     <Reference Include="Windows.Devices.DevicesLowLevelContract">
       <HintPath>winmd\Windows.Devices.DevicesLowLevelContract.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
@@ -33,6 +35,28 @@
       <HintPath>winmd\Windows.Foundation.UniversalApiContract.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
+    <!--Remove the Linux-specific code-->
+    <Compile Remove="System\Device\Gpio\Drivers\Windows10Driver.notSupported.cs" />
+    <Compile Remove="System\Device\I2c\I2cDevice.nonWindows.cs" />
+    <Compile Remove="System\Device\Pwm\PwmChannel.nonWindows.cs" />
+    <Compile Remove="System\Device\Spi\SpiDevice.nonWindows.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <!--Remove Windows Code-->
+    <Compile Remove="Interop\Windows\WinRT\*.cs" />
+    <Compile Remove="System\Device\Gpio\Drivers\Windows10DriverPin.cs" />
+    <Compile Remove="System\Device\Gpio\Drivers\Windows10Driver.cs" />
+    <Compile Remove="System\Device\I2c\Devices\Windows10I2cDevice.cs" />
+    <Compile Remove="System\Device\Pwm\Channels\Windows10PwmChannel.cs" />
+    <Compile Remove="System\Device\Spi\Devices\Windows10SpiDevice.cs" />
+    <Compile Remove="System\Device\I2c\I2cDevice.Windows.cs" />
+    <Compile Remove="System\Device\Pwm\PwmChannel.Windows.cs" />
+    <Compile Remove="System\Device\Spi\SpiDevice.Windows.cs" />
+
   </ItemGroup>
 
 </Project>

--- a/src/System.Device.Gpio/System.Device.Gpio.csproj
+++ b/src/System.Device.Gpio/System.Device.Gpio.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('win'))">$(TargetFrameworks);net5.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
+    <!--<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('win'))">$(TargetFrameworks);net5.0-windows10.0.17763.0</TargetFrameworks>-->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
     <IsPackable>true</IsPackable>
@@ -11,7 +12,7 @@
     <Compile Remove="winmd\**" />
     <EmbeddedResource Remove="winmd\**" />
     <None Remove="winmd\**" />
-    <None Include="build\net5.0\System.Device.Gpio.targets" Pack="true" PackagePath="\build\net5.0" />
+    <None Include="buildTransitive\net5.0\System.Device.Gpio.targets" Pack="true" PackagePath="\buildTransitive\net5.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" /> <!-- This is Windows specific -->
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
@@ -44,6 +45,7 @@
     <Compile Remove="System\Device\I2c\I2cDevice.nonWindows.cs" />
     <Compile Remove="System\Device\Pwm\PwmChannel.nonWindows.cs" />
     <Compile Remove="System\Device\Spi\SpiDevice.nonWindows.cs" />
+    <Compile Remove="System\Device\CommonHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/System.Device.Gpio/System/Device/CommonHelpers.cs
+++ b/src/System.Device.Gpio/System/Device/CommonHelpers.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Device
+{
+    internal static class CommonHelpers
+    {
+        private const string WindowsPlatformTargetingFormat = "In order to use {0} on Windows with .NET 5.0 it is required for your application to target net5.0-windows10.0.17763.0 or higher. Please add that to your target frameworks in your project file.";
+
+        public static string GetFormattedWindowsPlatformTargetingErrorMessage(string className)
+         => string.Format(WindowsPlatformTargetingFormat, className);
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.notSupported.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.notSupported.cs
@@ -19,7 +19,7 @@ namespace System.Device.Gpio.Drivers
             // If we land in this method it means the console application is running on Windows and targetting net5.0 (without specifying Windows platform)
             // In order to call WinRT code in net5.0 it is required for the application to target the specific platform
             // so we throw the bellow exception with a detailed message in order to instruct the consumer on how to move forward.
-            throw new PlatformNotSupportedException("In order to use Windows10Driver on Windows with .NET 5.0 it is required for your application to target net5.0-windows10.0.17763.0. Please add that to your target frameworks in your project file.");
+            throw new PlatformNotSupportedException(CommonHelpers.GetFormattedWindowsPlatformTargetingErrorMessage(nameof(Windows10Driver)));
         }
 
         /// <inheritdoc />

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.notSupported.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.notSupported.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+
+namespace System.Device.Gpio.Drivers
+{
+    /// <summary>
+    /// A GPIO driver for Windows 10 IoT.
+    /// </summary>
+    public class Windows10Driver : GpioDriver
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Windows10Driver"/> class.
+        /// </summary>
+        public Windows10Driver()
+        {
+            // If we land in this method it means the console application is running on Windows and targetting net5.0 (without specifying Windows platform)
+            // In order to call WinRT code in net5.0 it is required for the application to target the specific platform
+            // so we throw the bellow exception with a detailed message in order to instruct the consumer on how to move forward.
+            throw new PlatformNotSupportedException("In order to use Windows10Driver on Windows with .NET 5.0 it is required for your application to target net5.0-windows10.0.17763.0. Please add that to your target frameworks in your project file.");
+        }
+
+        /// <inheritdoc />
+        protected internal override int PinCount => throw new PlatformNotSupportedException();
+
+        /// <inheritdoc />
+        protected internal override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected internal override void ClosePin(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected internal override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected internal override PinMode GetPinMode(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected internal override void OpenPin(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected internal override PinValue Read(int pinNumber)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected internal override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected internal override void SetPinMode(int pinNumber, PinMode mode)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <inheritdoc />
+        protected internal override void Write(int pinNumber, PinValue value)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.Windows.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Device.I2c
+{
+    /// <summary>
+    /// The communications channel to a device on an I2C bus.
+    /// </summary>
+    public abstract partial class I2cDevice
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static I2cDevice CreateWindows10I2cDevice(I2cConnectionSettings settings)
+        {
+            // This wrapper is needed to prevent Mono from loading Windows10I2cDevice
+            // which causes all fields to be loaded - one of such fields is WinRT type which does not
+            // exist on Linux which causes TypeLoadException.
+            // Using NoInlining and no explicit type prevents this from happening.
+            return new Windows10I2cDevice(settings);
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-
 namespace System.Device.I2c
 {
     /// <summary>
     /// The communications channel to a device on an I2C bus.
     /// </summary>
-    public abstract class I2cDevice : IDisposable
+    public abstract partial class I2cDevice : IDisposable
     {
         /// <summary>
         /// The connection settings of a device on an I2C bus. The connection settings are immutable after the device is created
@@ -75,16 +73,6 @@ namespace System.Device.I2c
             {
                 return new UnixI2cDevice(settings);
             }
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static I2cDevice CreateWindows10I2cDevice(I2cConnectionSettings settings)
-        {
-            // This wrapper is needed to prevent Mono from loading Windows10I2cDevice
-            // which causes all fields to be loaded - one of such fields is WinRT type which does not
-            // exist on Linux which causes TypeLoadException.
-            // Using NoInlining and no explicit type prevents this from happening.
-            return new Windows10I2cDevice(settings);
         }
 
         /// <inheritdoc cref="IDisposable.Dispose"/>

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.nonWindows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.nonWindows.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Device.I2c
+{
+    /// <summary>
+    /// The communications channel to a device on an I2C bus.
+    /// </summary>
+    public abstract partial class I2cDevice
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static I2cDevice CreateWindows10I2cDevice(I2cConnectionSettings settings)
+        {
+            // If we land in this method it means the console application is running on Windows and targetting net5.0 (without specifying Windows platform)
+            // In order to call WinRT code in net5.0 it is required for the application to target the specific platform
+            // so we throw the bellow exception with a detailed message in order to instruct the consumer on how to move forward.
+            throw new PlatformNotSupportedException("In order to use I2CDevice on Windows with .NET 5.0 it is required for your application to target net5.0-windows10.0.17763.0. Please add that to your target frameworks in your project file.");
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.nonWindows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.nonWindows.cs
@@ -17,7 +17,7 @@ namespace System.Device.I2c
             // If we land in this method it means the console application is running on Windows and targetting net5.0 (without specifying Windows platform)
             // In order to call WinRT code in net5.0 it is required for the application to target the specific platform
             // so we throw the bellow exception with a detailed message in order to instruct the consumer on how to move forward.
-            throw new PlatformNotSupportedException("In order to use I2CDevice on Windows with .NET 5.0 it is required for your application to target net5.0-windows10.0.17763.0. Please add that to your target frameworks in your project file.");
+            throw new PlatformNotSupportedException(CommonHelpers.GetFormattedWindowsPlatformTargetingErrorMessage(nameof(I2cDevice)));
         }
     }
 }

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.Windows.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Device.Pwm
+{
+    /// <summary>
+    /// Represents a single PWM channel.
+    /// </summary>
+    public abstract partial class PwmChannel
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static PwmChannel CreateWindows10PwmChannel(int chip, int channel, int frequency, double dutyCyclePercentage)
+        {
+            // This wrapper is needed to prevent Mono from loading Windows10PwmChannel
+            // which causes all fields to be loaded - one of such fields is WinRT type which does not
+            // exist on Linux which causes TypeLoadException.
+            // Using NoInlining and no explicit type prevents this from happening.
+            return new Channels.Windows10PwmChannel(
+                    chip,
+                    channel,
+                    frequency,
+                    dutyCyclePercentage);
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-
 namespace System.Device.Pwm
 {
     /// <summary>
@@ -102,20 +100,6 @@ namespace System.Device.Pwm
                 // at the cost of some potentially weird errors if it is actually a beagle bone kernel.
                 return false;
             }
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static PwmChannel CreateWindows10PwmChannel(int chip, int channel, int frequency, double dutyCyclePercentage)
-        {
-            // This wrapper is needed to prevent Mono from loading Windows10PwmChannel
-            // which causes all fields to be loaded - one of such fields is WinRT type which does not
-            // exist on Linux which causes TypeLoadException.
-            // Using NoInlining and no explicit type prevents this from happening.
-            return new Channels.Windows10PwmChannel(
-                    chip,
-                    channel,
-                    frequency,
-                    dutyCyclePercentage);
         }
     }
 }

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.nonWindows.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.nonWindows.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Device.Pwm
+{
+    /// <summary>
+    /// Represents a single PWM channel.
+    /// </summary>
+    public abstract partial class PwmChannel
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static PwmChannel CreateWindows10PwmChannel(int chip, int channel, int frequency, double dutyCyclePercentage)
+        {
+            // If we land in this method it means the console application is running on Windows and targetting net5.0 (without specifying Windows platform)
+            // In order to call WinRT code in net5.0 it is required for the application to target the specific platform
+            // so we throw the bellow exception with a detailed message in order to instruct the consumer on how to move forward.
+            throw new PlatformNotSupportedException("In order to use PwmChannel on Windows with .NET 5.0 it is required for your application to target net5.0-windows10.0.17763.0. Please add that to your target frameworks in your project file.");
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.nonWindows.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.nonWindows.cs
@@ -17,7 +17,7 @@ namespace System.Device.Pwm
             // If we land in this method it means the console application is running on Windows and targetting net5.0 (without specifying Windows platform)
             // In order to call WinRT code in net5.0 it is required for the application to target the specific platform
             // so we throw the bellow exception with a detailed message in order to instruct the consumer on how to move forward.
-            throw new PlatformNotSupportedException("In order to use PwmChannel on Windows with .NET 5.0 it is required for your application to target net5.0-windows10.0.17763.0. Please add that to your target frameworks in your project file.");
+            throw new PlatformNotSupportedException(CommonHelpers.GetFormattedWindowsPlatformTargetingErrorMessage(nameof(PwmChannel)));
         }
     }
 }

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.Windows.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Device.Spi
+{
+    /// <summary>
+    /// The communications channel to a device on a SPI bus.
+    /// </summary>
+    public abstract partial class SpiDevice
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static SpiDevice CreateWindows10SpiDevice(SpiConnectionSettings settings)
+        {
+            // This wrapper is needed to prevent Mono from loading Windows10SpiDevice
+            // which causes all fields to be loaded - one of such fields is WinRT type which does not
+            // exist on Linux which causes TypeLoadException.
+            // Using NoInlining and no explicit type prevents this from happening.
+            return new Windows10SpiDevice(settings);
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-
 namespace System.Device.Spi
 {
     /// <summary>
@@ -68,16 +66,6 @@ namespace System.Device.Spi
             {
                 return new UnixSpiDevice(settings);
             }
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static SpiDevice CreateWindows10SpiDevice(SpiConnectionSettings settings)
-        {
-            // This wrapper is needed to prevent Mono from loading Windows10SpiDevice
-            // which causes all fields to be loaded - one of such fields is WinRT type which does not
-            // exist on Linux which causes TypeLoadException.
-            // Using NoInlining and no explicit type prevents this from happening.
-            return new Windows10SpiDevice(settings);
         }
 
         /// <inheritdoc cref="IDisposable.Dispose"/>

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.nonWindows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.nonWindows.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Device.Spi
+{
+    /// <summary>
+    /// The communications channel to a device on a SPI bus.
+    /// </summary>
+    public abstract partial class SpiDevice : IDisposable
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static SpiDevice CreateWindows10SpiDevice(SpiConnectionSettings settings)
+        {
+            // If we land in this method it means the console application is running on Windows and targetting net5.0 (without specifying Windows platform)
+            // In order to call WinRT code in net5.0 it is required for the application to target the specific platform
+            // so we throw the bellow exception with a detailed message in order to instruct the consumer on how to move forward.
+            throw new PlatformNotSupportedException("In order to use SpiDevice on Windows with .NET 5.0 it is required for your application to target net5.0-windows10.0.17763.0. Please add that to your target frameworks in your project file.");
+        }
+    }
+}

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.nonWindows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.nonWindows.cs
@@ -9,7 +9,7 @@ namespace System.Device.Spi
     /// <summary>
     /// The communications channel to a device on a SPI bus.
     /// </summary>
-    public abstract partial class SpiDevice : IDisposable
+    public abstract partial class SpiDevice
     {
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static SpiDevice CreateWindows10SpiDevice(SpiConnectionSettings settings)
@@ -17,7 +17,7 @@ namespace System.Device.Spi
             // If we land in this method it means the console application is running on Windows and targetting net5.0 (without specifying Windows platform)
             // In order to call WinRT code in net5.0 it is required for the application to target the specific platform
             // so we throw the bellow exception with a detailed message in order to instruct the consumer on how to move forward.
-            throw new PlatformNotSupportedException("In order to use SpiDevice on Windows with .NET 5.0 it is required for your application to target net5.0-windows10.0.17763.0. Please add that to your target frameworks in your project file.");
+            throw new PlatformNotSupportedException(CommonHelpers.GetFormattedWindowsPlatformTargetingErrorMessage(nameof(SpiDevice)));
         }
     }
 }

--- a/src/System.Device.Gpio/build/net5.0/System.Device.Gpio.targets
+++ b/src/System.Device.Gpio/build/net5.0/System.Device.Gpio.targets
@@ -1,7 +1,0 @@
-<Project>
-  <Target Name="EnsureProjectIsTargetingWindowsPlatformIfRequired"
-          BeforeTargets="Build"
-          Condition="'$(TargetFramework)' == 'net5.0' And $(RuntimeIdentifier.StartsWith('win'))">
-    <Error Text="In order to use System.Device.Gpio package when running on Windows and targeting net5.0, it is required to add 'net5.0-windows10.0.17763.0' to your project's target frameworks." />
-  </Target>
-</Project>

--- a/src/System.Device.Gpio/build/net5.0/System.Device.Gpio.targets
+++ b/src/System.Device.Gpio/build/net5.0/System.Device.Gpio.targets
@@ -1,0 +1,7 @@
+<Project>
+  <Target Name="EnsureProjectIsTargetingWindowsPlatformIfRequired"
+          BeforeTargets="Build"
+          Condition="'$(TargetFramework)' == 'net5.0' And $(RuntimeIdentifier.StartsWith('win'))">
+    <Error Text="In order to use System.Device.Gpio package when running on Windows and targeting net5.0, it is required to add 'net5.0-windows10.0.17763.0' to your project's target frameworks." />
+  </Target>
+</Project>

--- a/src/System.Device.Gpio/buildTransitive/net5.0/System.Device.Gpio.targets
+++ b/src/System.Device.Gpio/buildTransitive/net5.0/System.Device.Gpio.targets
@@ -1,0 +1,11 @@
+<Project>
+  <Target Name="EnsureProjectIsTargetingWindowsPlatformIfRequired"
+          BeforeTargets="Build"
+          Condition="'$(TargetFramework)' == 'net5.0' And
+                     '$(SuppressWindowsPlatformTargetingRequiredError)' == '' And
+                     ('$(OutputType)' == 'Exe' Or '$(OutputType)'=='WinExe') And
+                     $(RuntimeIdentifier.StartsWith('win'))">
+    <Error Text="In order to use System.Device.Gpio package when running on Windows and targeting net5.0, it is required to add 'net5.0-windows10.0.xxxxx.0' (where xxxxx needs to be a number 17763 or above) to your project's target frameworks.
+                 To suppress this error, set the property %3CSuppressWindowsPlatformTargetingRequiredError%3Etrue%3C/SuppressWindowsPlatformTargetingRequiredError%3E in your project." />
+  </Target>
+</Project>

--- a/src/System.Device.Gpio/buildTransitive/net5.0/System.Device.Gpio.targets
+++ b/src/System.Device.Gpio/buildTransitive/net5.0/System.Device.Gpio.targets
@@ -5,7 +5,6 @@
                      '$(SuppressWindowsPlatformTargetingRequiredError)' == '' And
                      ('$(OutputType)' == 'Exe' Or '$(OutputType)'=='WinExe') And
                      $(RuntimeIdentifier.StartsWith('win'))">
-    <Error Text="In order to use System.Device.Gpio package when running on Windows and targeting net5.0, it is required to add 'net5.0-windows10.0.xxxxx.0' (where xxxxx needs to be a number 17763 or above) to your project's target frameworks.
-                 To suppress this error, set the property %3CSuppressWindowsPlatformTargetingRequiredError%3Etrue%3C/SuppressWindowsPlatformTargetingRequiredError%3E in your project." />
+    <Error Text="In order to use System.Device.Gpio package when running on Windows and targeting net5.0, it is required to add 'net5.0-windows10.0.xxxxx.0' (where xxxxx needs to be a number 17763 or above) to your project's target frameworks. To suppress this error, set the property %3CSuppressWindowsPlatformTargetingRequiredError%3Etrue%3C/SuppressWindowsPlatformTargetingRequiredError%3E in your project." />
   </Target>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/iot/issues/1091
Fixes https://github.com/dotnet/iot/issues/1103
Fixes https://github.com/dotnet/iot/issues/1193

cc: @richlander @pgrawehr @Ellerbach @krwq @ericstj @terrajobst @jkoritzinsky @dsplaisted 

This PR will add cross-targeting to System.Device.Gpio package so that it will now have 3 different assets in the package:
- One netstandard2.0 asset: This will be used by consuming apps that are targeting netstandard2.0 compatible frameworks **that are not net5.0**. Nothing has changed from this asset from what we shipped before.
- One net5.0 asset: This asset will be for people targeting net5.0 that **don't intend to target Windows**. This implementation is very similar to the netstandard2.0 one, except that it will now throw platform not supported exceptions when running on Windows and trying to use types that depend on WinRT APIs.
- One net5.0-windows10.0.17763.0 asset: This asset will be for people targeting net5.0 that **want to run in Windows**. It will be using the new CSWinRT project to call into WinRT APIs and don't depend on System.Runtime.* package any longer. In order for folks to get this asset, they will need to change the target frameworks section in their projects and add `net5.0-windows10.0.17763.0` so that the package will work at runtime. **This is a breaking change**

As explained above, when running on net5.0 and targeting Windows it will be required to edit the target frameworks section of the project. This is the only way to get this working for now, and we are looking into some embedding scenarios (once CSWinRT supports them) so that we can change the way we distribute our package so that consuming projects won't require to cross-target. As part of this change, we are also adding a targets file with the package that will try to detect cases where cross-targeting is required, in order to catch those cases early and give helpful messages to consumers so that they can change their project accordingly. Here is how the package will look now:
![image](https://user-images.githubusercontent.com/13854455/96494306-08617400-11fb-11eb-86dc-b779df2a089c.png)

And here are the package dependencies after this change:
![image](https://user-images.githubusercontent.com/13854455/96494357-1a431700-11fb-11eb-9180-98eece9cec0e.png)

Any feedback is appreciated 😄 
