### PR TITLE
Simplify license header

### DIFF
--- a/samples/force-sensitive-resistor/FsrWithAdcSample.cs
+++ b/samples/force-sensitive-resistor/FsrWithAdcSample.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Adc;

--- a/samples/force-sensitive-resistor/FsrWithCapacitorSample.cs
+++ b/samples/force-sensitive-resistor/FsrWithCapacitorSample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 

--- a/samples/force-sensitive-resistor/Program.cs
+++ b/samples/force-sensitive-resistor/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/samples/led-blink/Program.cs
+++ b/samples/led-blink/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/samples/led-matrix-weather/MathUtils.cs
+++ b/samples/led-matrix-weather/MathUtils.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/samples/led-matrix-weather/Program.Drawings.cs
+++ b/samples/led-matrix-weather/Program.Drawings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/samples/led-matrix-weather/Program.cs
+++ b/samples/led-matrix-weather/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/samples/led-matrix-weather/Weather.OpenWeather.cs
+++ b/samples/led-matrix-weather/Weather.OpenWeather.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/samples/led-matrix-weather/Weather.cs
+++ b/samples/led-matrix-weather/Weather.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/samples/led-more-blinking-lights/Program.cs
+++ b/samples/led-more-blinking-lights/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/samples/led-more-blinking-lights/TimeEnvelope.cs
+++ b/samples/led-more-blinking-lights/TimeEnvelope.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/samples/led-more-blinking-lights/Volume.cs
+++ b/samples/led-more-blinking-lights/Volume.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio.Drivers;
 using System.Diagnostics;

--- a/src/System.Device.Gpio.Tests/LibGpiodDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/LibGpiodDriverTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio.Drivers;
 using Xunit;

--- a/src/System.Device.Gpio.Tests/Mcp3008Tests.cs
+++ b/src/System.Device.Gpio.Tests/Mcp3008Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/System.Device.Gpio.Tests/ProtocolTests.cs
+++ b/src/System.Device.Gpio.Tests/ProtocolTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/System.Device.Gpio.Tests/PwmTests.cs
+++ b/src/System.Device.Gpio.Tests/PwmTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio.Drivers;
 using System.Diagnostics;

--- a/src/System.Device.Gpio.Tests/SetupHelpers.cs
+++ b/src/System.Device.Gpio.Tests/SetupHelpers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/System.Device.Gpio.Tests/SysFsDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/SysFsDriverTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio.Drivers;
 using Xunit;

--- a/src/System.Device.Gpio.Tests/WindowsDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/WindowsDriverTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio.Drivers;
 using Xunit;

--- a/src/System.Device.Gpio.Tests/XunitOptions.cs
+++ b/src/System.Device.Gpio.Tests/XunitOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/System.Device.Gpio/Interop/Unix/Interop.Libraries.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Interop.Libraries.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 internal static partial class Interop
 {

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.access.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.access.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.close.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.close.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_create.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_create.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_ctl.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_ctl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_wait.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_wait.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.ioctl.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.ioctl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.lseek.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.lseek.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.mmap.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.mmap.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.munmap.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.munmap.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.open.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.open.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.read.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.read.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.write.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.write.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/SafeChipHandle.cs
+++ b/src/System.Device.Gpio/Interop/Unix/SafeChipHandle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 

--- a/src/System.Device.Gpio/Interop/Unix/SafeChipIteratorHandle.cs
+++ b/src/System.Device.Gpio/Interop/Unix/SafeChipIteratorHandle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 

--- a/src/System.Device.Gpio/Interop/Unix/SafeLineHandle.cs
+++ b/src/System.Device.Gpio/Interop/Unix/SafeLineHandle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 

--- a/src/System.Device.Gpio/Interop/Windows/WinRT/Interop.WaitForCompletion.cs
+++ b/src/System.Device.Gpio/Interop/Windows/WinRT/Interop.WaitForCompletion.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/System.Device.Gpio/System/Device/CommonHelpers.cs
+++ b/src/System.Device.Gpio/System/Device/CommonHelpers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/InterruptSysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/InterruptSysFsDriver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Buffers.Binary;
 using System.Diagnostics;

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPiCM3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPiCM3Driver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio.Drivers
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio.Drivers
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriverDevicePin.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/UnixDriverDevicePin.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio.Drivers
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.notSupported.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10Driver.notSupported.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10DriverPin.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Windows10DriverPin.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/src/System.Device.Gpio/System/Device/Gpio/ExceptionHelper.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/ExceptionHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 using System.IO;

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Device.Gpio.Drivers;

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/System.Device.Gpio/System/Device/Gpio/PinChangeEventHandler.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinChangeEventHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/PinEventTypes.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinEventTypes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/PinMode.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/PinNumberingScheme.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinNumberingScheme.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/PinValue.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinValue.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/PinValueChangedEventArgs.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinValueChangedEventArgs.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/PinValuePair.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinValuePair.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio
 {

--- a/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/System.Device.Gpio/System/Device/Gpio/WaitForEventResult.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/WaitForEventResult.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio
 {

--- a/src/System.Device.Gpio/System/Device/I2c/Devices/UnixI2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Devices/UnixI2cDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/System.Device.Gpio/System/Device/I2c/Devices/Windows10I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Devices/Windows10I2cDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Windows.Devices.Enumeration;
 using WinI2c = Windows.Devices.I2c;

--- a/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.I2c
 {

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.Windows.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
 

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.I2c
 {

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.nonWindows.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.nonWindows.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
 

--- a/src/System.Device.Gpio/System/Device/Pwm/Channels/BeagleBonePwmChannel.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Channels/BeagleBonePwmChannel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Pwm.Channels
 {

--- a/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Channels/UnixPwmChannel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Text;

--- a/src/System.Device.Gpio/System/Device/Pwm/Channels/Windows10PwmChannel.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/Channels/Windows10PwmChannel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Windows.Devices.Enumeration;
 using Windows.Security.ExchangeActiveSyncProvisioning;

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.Windows.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
 

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Pwm
 {

--- a/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.nonWindows.cs
+++ b/src/System.Device.Gpio/System/Device/Pwm/PwmChannel.nonWindows.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
 

--- a/src/System.Device.Gpio/System/Device/Spi/DataFlow.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/DataFlow.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Spi
 {

--- a/src/System.Device.Gpio/System/Device/Spi/Devices/UnixSpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Devices/UnixSpiDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.IO;

--- a/src/System.Device.Gpio/System/Device/Spi/Devices/Windows10SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Devices/Windows10SpiDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using Windows.Devices.Enumeration;

--- a/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiConnectionSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.Windows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.Windows.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
 

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Spi
 {

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.nonWindows.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.nonWindows.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
 

--- a/src/System.Device.Gpio/System/Device/Spi/SpiMode.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Spi
 {

--- a/src/System.Device.Gpio/System/Device/SysFsHelpers.cs
+++ b/src/System.Device.Gpio/System/Device/SysFsHelpers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 using System.IO;

--- a/src/devices/Ads1115/Ads1115.cs
+++ b/src/devices/Ads1115/Ads1115.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Ads1115/ComparatorLatching.cs
+++ b/src/devices/Ads1115/ComparatorLatching.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ads1115
 {

--- a/src/devices/Ads1115/ComparatorMode.cs
+++ b/src/devices/Ads1115/ComparatorMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ads1115
 {

--- a/src/devices/Ads1115/ComparatorPolarity.cs
+++ b/src/devices/Ads1115/ComparatorPolarity.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ads1115
 {

--- a/src/devices/Ads1115/ComparatorQueue.cs
+++ b/src/devices/Ads1115/ComparatorQueue.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ads1115
 {

--- a/src/devices/Ads1115/DataRate.cs
+++ b/src/devices/Ads1115/DataRate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ads1115
 {

--- a/src/devices/Ads1115/DeviceMode.cs
+++ b/src/devices/Ads1115/DeviceMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ads1115
 {

--- a/src/devices/Ads1115/I2cAddress.cs
+++ b/src/devices/Ads1115/I2cAddress.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ads1115
 {

--- a/src/devices/Ads1115/InputMultiplexer.cs
+++ b/src/devices/Ads1115/InputMultiplexer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ads1115
 {

--- a/src/devices/Ads1115/MeasuringRange.cs
+++ b/src/devices/Ads1115/MeasuringRange.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ads1115
 {

--- a/src/devices/Ads1115/Register.cs
+++ b/src/devices/Ads1115/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ads1115
 {

--- a/src/devices/Ads1115/samples/Program.cs
+++ b/src/devices/Ads1115/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Adxl345/Adxl345.cs
+++ b/src/devices/Adxl345/Adxl345.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Adxl345/GravityRange.cs
+++ b/src/devices/Adxl345/GravityRange.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Adxl345
 {

--- a/src/devices/Adxl345/Register.cs
+++ b/src/devices/Adxl345/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Adxl345
 {

--- a/src/devices/Adxl345/samples/Program.cs
+++ b/src/devices/Adxl345/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Numerics;

--- a/src/devices/Ags01db/Ags01db.cs
+++ b/src/devices/Ags01db/Ags01db.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Ags01db/Register.cs
+++ b/src/devices/Ags01db/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ags01db
 {

--- a/src/devices/Ahtxx/Aht10.cs
+++ b/src/devices/Ahtxx/Aht10.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 

--- a/src/devices/Ahtxx/Aht20.cs
+++ b/src/devices/Ahtxx/Aht20.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 

--- a/src/devices/Ahtxx/AhtBase.cs
+++ b/src/devices/Ahtxx/AhtBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Ahtxx/samples/Ahtxx.Sample.cs
+++ b/src/devices/Ahtxx/samples/Ahtxx.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Ak8963/Ak8963.cs
+++ b/src/devices/Ak8963/Ak8963.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Ak8963/Ak8963I2c.cs
+++ b/src/devices/Ak8963/Ak8963I2c.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Ak8963/Ak8963I2cBase.cs
+++ b/src/devices/Ak8963/Ak8963I2cBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Ak8963/MeasurementMode.cs
+++ b/src/devices/Ak8963/MeasurementMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Magnetometer
 {

--- a/src/devices/Ak8963/OutputBitMode.cs
+++ b/src/devices/Ak8963/OutputBitMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Magnetometer
 {

--- a/src/devices/Ak8963/Register.cs
+++ b/src/devices/Ak8963/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Magnetometer
 {

--- a/src/devices/Ak8963/samples/Ak8963.sample.cs
+++ b/src/devices/Ak8963/samples/Ak8963.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Apa102/Apa102.cs
+++ b/src/devices/Apa102/Apa102.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Apa102/samples/Apa102.Samples.cs
+++ b/src/devices/Apa102/samples/Apa102.Samples.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Bh1745/AdcGain.cs
+++ b/src/devices/Bh1745/AdcGain.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bh1745
 {

--- a/src/devices/Bh1745/Bh1745.cs
+++ b/src/devices/Bh1745/Bh1745.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Bh1745/Bh1745Extensions.cs
+++ b/src/devices/Bh1745/Bh1745Extensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Bh1745/ChannelCompensationMultipliers.cs
+++ b/src/devices/Bh1745/ChannelCompensationMultipliers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bh1745
 {

--- a/src/devices/Bh1745/InterruptConfiguration.cs
+++ b/src/devices/Bh1745/InterruptConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bh1745
 {

--- a/src/devices/Bh1745/Mask.cs
+++ b/src/devices/Bh1745/Mask.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bh1745
 {

--- a/src/devices/Bh1745/MeasurementTime.cs
+++ b/src/devices/Bh1745/MeasurementTime.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bh1745
 {

--- a/src/devices/Bh1745/Register.cs
+++ b/src/devices/Bh1745/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bh1745
 {

--- a/src/devices/Bh1745/samples/Bh1745.Sample.cs
+++ b/src/devices/Bh1745/samples/Bh1745.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Bh1745/samples/Bh1745CustomConfiguration.Sample.cs
+++ b/src/devices/Bh1745/samples/Bh1745CustomConfiguration.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Bh1750fvi/Bh1750fvi.cs
+++ b/src/devices/Bh1750fvi/Bh1750fvi.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Bh1750fvi/Command.cs
+++ b/src/devices/Bh1750fvi/Command.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bh1750fvi
 {

--- a/src/devices/Bh1750fvi/I2cAddress.cs
+++ b/src/devices/Bh1750fvi/I2cAddress.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bh1750fvi
 {

--- a/src/devices/Bh1750fvi/MeasuringMode.cs
+++ b/src/devices/Bh1750fvi/MeasuringMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bh1750fvi
 {

--- a/src/devices/Bh1750fvi/samples/Program.cs
+++ b/src/devices/Bh1750fvi/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Bmp180/Bmp180.cs
+++ b/src/devices/Bmp180/Bmp180.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Ported from https://github.com/adafruit/Adafruit_Python_BMP/blob/master/Adafruit_BMP/BMP085.py
 // Formulas and code examples can also be found in the datasheet https://cdn-shop.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf

--- a/src/devices/Bmp180/CalibrationData.cs
+++ b/src/devices/Bmp180/CalibrationData.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmp180
 {

--- a/src/devices/Bmp180/Register.cs
+++ b/src/devices/Bmp180/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmp180
 {

--- a/src/devices/Bmp180/Sampling.cs
+++ b/src/devices/Bmp180/Sampling.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmp180
 {

--- a/src/devices/Bmp180/samples/Bmp180.Sample.cs
+++ b/src/devices/Bmp180/samples/Bmp180.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Bmxx80/Bme280.cs
+++ b/src/devices/Bmxx80/Bme280.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Bmxx80/Bme680.cs
+++ b/src/devices/Bmxx80/Bme680.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Bmxx80/Bme680HeaterProfile.cs
+++ b/src/devices/Bmxx80/Bme680HeaterProfile.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80
 {

--- a/src/devices/Bmxx80/Bme680HeaterProfileConfig.cs
+++ b/src/devices/Bmxx80/Bme680HeaterProfileConfig.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using UnitsNet;

--- a/src/devices/Bmxx80/Bme680Mask.cs
+++ b/src/devices/Bmxx80/Bme680Mask.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80
 {

--- a/src/devices/Bmxx80/Bmp280.cs
+++ b/src/devices/Bmxx80/Bmp280.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Ported from https://github.com/adafruit/Adafruit_BMP280_Library/blob/master/Adafruit_BMP280.cpp
 // Formulas and code examples can also be found in the datasheet http://www.adafruit.com/datasheets/BST-BMP280-DS001-11.pdf

--- a/src/devices/Bmxx80/Bmxx80Base.cs
+++ b/src/devices/Bmxx80/Bmxx80Base.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Bmxx80/CalibrationData/Bme280CalibrationData.cs
+++ b/src/devices/Bmxx80/CalibrationData/Bme280CalibrationData.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Bmxx80.Register;
 

--- a/src/devices/Bmxx80/CalibrationData/Bme680CalibrationData.cs
+++ b/src/devices/Bmxx80/CalibrationData/Bme680CalibrationData.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Bmxx80.Register;
 

--- a/src/devices/Bmxx80/CalibrationData/Bmp280CalibrationData.cs
+++ b/src/devices/Bmxx80/CalibrationData/Bmp280CalibrationData.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Bmxx80.Register;
 

--- a/src/devices/Bmxx80/CalibrationData/Bmxx80CalibrationData.cs
+++ b/src/devices/Bmxx80/CalibrationData/Bmxx80CalibrationData.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80.CalibrationData
 {

--- a/src/devices/Bmxx80/DeviceStatus.cs
+++ b/src/devices/Bmxx80/DeviceStatus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80
 {

--- a/src/devices/Bmxx80/FilteringMode/Bme680FilteringMode.cs
+++ b/src/devices/Bmxx80/FilteringMode/Bme680FilteringMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80.FilteringMode
 {

--- a/src/devices/Bmxx80/FilteringMode/Bmx280FilteringMode.cs
+++ b/src/devices/Bmxx80/FilteringMode/Bmx280FilteringMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80.FilteringMode
 {

--- a/src/devices/Bmxx80/PowerMode/Bme680PowerMode.cs
+++ b/src/devices/Bmxx80/PowerMode/Bme680PowerMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80.PowerMode
 {

--- a/src/devices/Bmxx80/PowerMode/Bmx280PowerMode.cs
+++ b/src/devices/Bmxx80/PowerMode/Bmx280PowerMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80.PowerMode
 {

--- a/src/devices/Bmxx80/Register/Bme280Register.cs
+++ b/src/devices/Bmxx80/Register/Bme280Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80.Register
 {

--- a/src/devices/Bmxx80/Register/Bme680Register.cs
+++ b/src/devices/Bmxx80/Register/Bme680Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80.Register
 {

--- a/src/devices/Bmxx80/Register/Bmx280Register.cs
+++ b/src/devices/Bmxx80/Register/Bmx280Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80.Register
 {

--- a/src/devices/Bmxx80/Register/Bmxx80Register.cs
+++ b/src/devices/Bmxx80/Register/Bmxx80Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80.Register
 {

--- a/src/devices/Bmxx80/Sampling.cs
+++ b/src/devices/Bmxx80/Sampling.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80
 {

--- a/src/devices/Bmxx80/StandbyTime.cs
+++ b/src/devices/Bmxx80/StandbyTime.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bmxx80
 {

--- a/src/devices/Bmxx80/samples/Bme280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme280.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Bmxx80/samples/Bme680.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme680.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Bmxx80/samples/Bmp280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bmp280.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Bmxx80/tests/Bmp280Tests.cs
+++ b/src/devices/Bmxx80/tests/Bmp280Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Bno055/Bno055Sensor.cs
+++ b/src/devices/Bno055/Bno055Sensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Bno055/Models/AxisRemap.cs
+++ b/src/devices/Bno055/Models/AxisRemap.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bno055
 {

--- a/src/devices/Bno055/Models/CalibrationStatus.cs
+++ b/src/devices/Bno055/Models/CalibrationStatus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Bno055/Models/Error.cs
+++ b/src/devices/Bno055/Models/Error.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bno055
 {

--- a/src/devices/Bno055/Models/Info.cs
+++ b/src/devices/Bno055/Models/Info.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Bno055/Models/InteruptStatus.cs
+++ b/src/devices/Bno055/Models/InteruptStatus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Bno055/Models/OperationMode.cs
+++ b/src/devices/Bno055/Models/OperationMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bno055
 {

--- a/src/devices/Bno055/Models/PowerMode.cs
+++ b/src/devices/Bno055/Models/PowerMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bno055
 {

--- a/src/devices/Bno055/Models/Registers.cs
+++ b/src/devices/Bno055/Models/Registers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bno055
 {

--- a/src/devices/Bno055/Models/Status.cs
+++ b/src/devices/Bno055/Models/Status.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bno055
 {

--- a/src/devices/Bno055/Models/TemperatureSource.cs
+++ b/src/devices/Bno055/Models/TemperatureSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Bno055
 {

--- a/src/devices/Bno055/Models/TestResult.cs
+++ b/src/devices/Bno055/Models/TestResult.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Bno055/Models/Units.cs
+++ b/src/devices/Bno055/Models/Units.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Bno055/samples/Bno055.sample.cs
+++ b/src/devices/Bno055/samples/Bno055.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/BoardLed/BoardLed.cs
+++ b/src/devices/BoardLed/BoardLed.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/BoardLed/samples/Program.cs
+++ b/src/devices/BoardLed/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using Iot.Device.BoardLed;

--- a/src/devices/BrickPi3/BrickPi3.cs
+++ b/src/devices/BrickPi3/BrickPi3.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/BrickPi3/Extensions/EnumExtension.cs
+++ b/src/devices/BrickPi3/Extensions/EnumExtension.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/BrickPi3/Models/BrickPiInfo.cs
+++ b/src/devices/BrickPi3/Models/BrickPiInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/devices/BrickPi3/Models/BrickPiVoltage.cs
+++ b/src/devices/BrickPi3/Models/BrickPiVoltage.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.BrickPi3.Models
 {

--- a/src/devices/BrickPi3/Models/Motors.cs
+++ b/src/devices/BrickPi3/Models/Motors.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.BrickPi3.Models
 {

--- a/src/devices/BrickPi3/Models/Sensors.cs
+++ b/src/devices/BrickPi3/Models/Sensors.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.BrickPi3.Models
 {

--- a/src/devices/BrickPi3/Models/SpiMessages.cs
+++ b/src/devices/BrickPi3/Models/SpiMessages.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.BrickPi3.Models
 {

--- a/src/devices/BrickPi3/Movement/Motor.cs
+++ b/src/devices/BrickPi3/Movement/Motor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/Movement/Vehicle.cs
+++ b/src/devices/BrickPi3/Movement/Vehicle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/BrickPi3/Sensors/EV3ColorSensor.cs
+++ b/src/devices/BrickPi3/Sensors/EV3ColorSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/Sensors/EV3GyroSensor.cs
+++ b/src/devices/BrickPi3/Sensors/EV3GyroSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/Sensors/EV3IRSensor.cs
+++ b/src/devices/BrickPi3/Sensors/EV3IRSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/Sensors/EV3TouchSensor.cs
+++ b/src/devices/BrickPi3/Sensors/EV3TouchSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/Sensors/EV3UltraSonicSensor.cs
+++ b/src/devices/BrickPi3/Sensors/EV3UltraSonicSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/Sensors/ISensor.cs
+++ b/src/devices/BrickPi3/Sensors/ISensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.BrickPi3.Models;
 

--- a/src/devices/BrickPi3/Sensors/NXTColorSensor.cs
+++ b/src/devices/BrickPi3/Sensors/NXTColorSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/Sensors/NXTLightSensor.cs
+++ b/src/devices/BrickPi3/Sensors/NXTLightSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/Sensors/NXTSoundSensor.cs
+++ b/src/devices/BrickPi3/Sensors/NXTSoundSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/Sensors/NXTTouchSensor.cs
+++ b/src/devices/BrickPi3/Sensors/NXTTouchSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/Sensors/NXTUltraSonicSensor.cs
+++ b/src/devices/BrickPi3/Sensors/NXTUltraSonicSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/devices/BrickPi3/samples/BrickPi3.samples.cs
+++ b/src/devices/BrickPi3/samples/BrickPi3.samples.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/devices/BrickPi3/samples/MotorTests.cs
+++ b/src/devices/BrickPi3/samples/MotorTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/BrickPi3/samples/SensorTests.cs
+++ b/src/devices/BrickPi3/samples/SensorTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 using System;
 using System.Diagnostics;
 using System.Threading;

--- a/src/devices/Buzzer/Buzzer.cs
+++ b/src/devices/Buzzer/Buzzer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Pwm;

--- a/src/devices/Buzzer/samples/Buzzer.Sample.cs
+++ b/src/devices/Buzzer/samples/Buzzer.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Buzzer/samples/Enums.cs
+++ b/src/devices/Buzzer/samples/Enums.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Buzzer.Samples
 {

--- a/src/devices/Buzzer/samples/MelodyElement.cs
+++ b/src/devices/Buzzer/samples/MelodyElement.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Buzzer.Samples
 {

--- a/src/devices/Buzzer/samples/MelodyPlayer.cs
+++ b/src/devices/Buzzer/samples/MelodyPlayer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Buzzer/samples/NoteElement.cs
+++ b/src/devices/Buzzer/samples/NoteElement.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Buzzer.Samples
 {

--- a/src/devices/Buzzer/samples/PauseElement.cs
+++ b/src/devices/Buzzer/samples/PauseElement.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Buzzer.Samples
 {

--- a/src/devices/Card/CreditCard/ApduCommands.cs
+++ b/src/devices/Card/CreditCard/ApduCommands.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Card.CreditCardProcessing
 {

--- a/src/devices/Card/CreditCard/ApplicationDataDetail.cs
+++ b/src/devices/Card/CreditCard/ApplicationDataDetail.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Card.CreditCardProcessing
 {

--- a/src/devices/Card/CreditCard/BerSplitter.cs
+++ b/src/devices/Card/CreditCard/BerSplitter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Card/CreditCard/ConversionType.cs
+++ b/src/devices/Card/CreditCard/ConversionType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Card.CreditCardProcessing
 {

--- a/src/devices/Card/CreditCard/CreditCard.cs
+++ b/src/devices/Card/CreditCard/CreditCard.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Card/CreditCard/DataType.cs
+++ b/src/devices/Card/CreditCard/DataType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Card.CreditCardProcessing
 {

--- a/src/devices/Card/CreditCard/Source.cs
+++ b/src/devices/Card/CreditCard/Source.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Card/CreditCard/Tag.cs
+++ b/src/devices/Card/CreditCard/Tag.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Card/CreditCard/TagDetails.cs
+++ b/src/devices/Card/CreditCard/TagDetails.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Card/CreditCard/TagList.cs
+++ b/src/devices/Card/CreditCard/TagList.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/devices/Card/CreditCard/TerminalTransactionQualifier.cs
+++ b/src/devices/Card/CreditCard/TerminalTransactionQualifier.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Card/ErrorType.cs
+++ b/src/devices/Card/ErrorType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Card
 {

--- a/src/devices/Card/LogInfo.cs
+++ b/src/devices/Card/LogInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/Card/Mifare/AccessSector.cs
+++ b/src/devices/Card/Mifare/AccessSector.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Card/Mifare/AccessType.cs
+++ b/src/devices/Card/Mifare/AccessType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Card/Mifare/MifareCard.cs
+++ b/src/devices/Card/Mifare/MifareCard.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Card/Mifare/MifareCardCapacity.cs
+++ b/src/devices/Card/Mifare/MifareCardCapacity.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Card.Mifare
 {

--- a/src/devices/Card/Mifare/MifareCardCommand.cs
+++ b/src/devices/Card/Mifare/MifareCardCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Card.Mifare
 {

--- a/src/devices/Card/ProcessError.cs
+++ b/src/devices/Card/ProcessError.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Card/Rfid/ApplicationType.cs
+++ b/src/devices/Card/Rfid/ApplicationType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Rfid
 {

--- a/src/devices/Card/Rfid/Data106kbpsInnovisionJewel.cs
+++ b/src/devices/Card/Rfid/Data106kbpsInnovisionJewel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Rfid
 {

--- a/src/devices/Card/Rfid/Data106kbpsTypeA.cs
+++ b/src/devices/Card/Rfid/Data106kbpsTypeA.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Rfid
 {

--- a/src/devices/Card/Rfid/Data106kbpsTypeB.cs
+++ b/src/devices/Card/Rfid/Data106kbpsTypeB.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Card/Rfid/Data212_424kbps.cs
+++ b/src/devices/Card/Rfid/Data212_424kbps.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Rfid
 {

--- a/src/devices/Card/Rfid/MaxFrameSize.cs
+++ b/src/devices/Card/Rfid/MaxFrameSize.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Rfid
 {

--- a/src/devices/Card/VersionSupported.cs
+++ b/src/devices/Card/VersionSupported.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ccs811/Ccs811Sensor.cs
+++ b/src/devices/Ccs811/Ccs811Sensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Ccs811/Error.cs
+++ b/src/devices/Ccs811/Error.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ccs811/MeasurementArgs.cs
+++ b/src/devices/Ccs811/MeasurementArgs.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using UnitsNet;
 

--- a/src/devices/Ccs811/OperationMode.cs
+++ b/src/devices/Ccs811/OperationMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ccs811
 {

--- a/src/devices/Ccs811/Register.cs
+++ b/src/devices/Ccs811/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ccs811
 {

--- a/src/devices/Ccs811/Status.cs
+++ b/src/devices/Ccs811/Status.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ccs811/samples/Css811SensorSample.cs
+++ b/src/devices/Ccs811/samples/Css811SensorSample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/CharacterLcd/Flags.cs
+++ b/src/devices/CharacterLcd/Flags.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/CharacterLcd/Hd44780.cs
+++ b/src/devices/CharacterLcd/Hd44780.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers;

--- a/src/devices/CharacterLcd/ICharacterLcd.cs
+++ b/src/devices/CharacterLcd/ICharacterLcd.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/CharacterLcd/Lcd1602.cs
+++ b/src/devices/CharacterLcd/Lcd1602.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.I2c;

--- a/src/devices/CharacterLcd/Lcd2004.cs
+++ b/src/devices/CharacterLcd/Lcd2004.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.I2c;

--- a/src/devices/CharacterLcd/LcdCharacterEncoding.cs
+++ b/src/devices/CharacterLcd/LcdCharacterEncoding.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/CharacterLcd/LcdCharacterEncodingFactory.cs
+++ b/src/devices/CharacterLcd/LcdCharacterEncodingFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/CharacterLcd/LcdConsole.cs
+++ b/src/devices/CharacterLcd/LcdConsole.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Drawing;

--- a/src/devices/CharacterLcd/LcdInterface.Gpio.cs
+++ b/src/devices/CharacterLcd/LcdInterface.Gpio.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device;

--- a/src/devices/CharacterLcd/LcdInterface.I2c.cs
+++ b/src/devices/CharacterLcd/LcdInterface.I2c.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/CharacterLcd/LcdInterface.I2c4Bit.cs
+++ b/src/devices/CharacterLcd/LcdInterface.I2c4Bit.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/CharacterLcd/LcdInterface.cs
+++ b/src/devices/CharacterLcd/LcdInterface.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device;

--- a/src/devices/CharacterLcd/LcdRgb.cs
+++ b/src/devices/CharacterLcd/LcdRgb.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/CharacterLcd/LineWrapMode.cs
+++ b/src/devices/CharacterLcd/LineWrapMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.CharacterLcd
 {

--- a/src/devices/CharacterLcd/Registers.cs
+++ b/src/devices/CharacterLcd/Registers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.CharacterLcd
 {

--- a/src/devices/CharacterLcd/samples/CharacterLcd.Sample.cs
+++ b/src/devices/CharacterLcd/samples/CharacterLcd.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/CharacterLcd/samples/Hd44780.ExtendedSample.cs
+++ b/src/devices/CharacterLcd/samples/Hd44780.ExtendedSample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/CharacterLcd/samples/LcdConsole.Samples.cs
+++ b/src/devices/CharacterLcd/samples/LcdConsole.Samples.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/CharacterLcd/samples/Pcf8574tSample.cs
+++ b/src/devices/CharacterLcd/samples/Pcf8574tSample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Common/Iot/Device/Common/NumberHelper.cs
+++ b/src/devices/Common/Iot/Device/Common/NumberHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
+++ b/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using UnitsNet;

--- a/src/devices/Common/Iot/Device/Graphics/BdfFont.cs
+++ b/src/devices/Common/Iot/Device/Graphics/BdfFont.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/Common/Iot/Device/Graphics/BitmapImage.cs
+++ b/src/devices/Common/Iot/Device/Graphics/BitmapImage.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Drawing;

--- a/src/devices/Common/System/Device/DelayHelper.cs
+++ b/src/devices/Common/System/Device/DelayHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 using System.Threading;

--- a/src/devices/Common/System/Device/Gpio/PinVector32.cs
+++ b/src/devices/Common/System/Device/Gpio/PinVector32.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio
 {

--- a/src/devices/Common/System/Device/Gpio/PinVector64.cs
+++ b/src/devices/Common/System/Device/Gpio/PinVector64.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Device.Gpio
 {

--- a/src/devices/Common/tests/WeatherTests.cs
+++ b/src/devices/Common/tests/WeatherTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/CpuTemperature/CpuTemperature.cs
+++ b/src/devices/CpuTemperature/CpuTemperature.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/CpuTemperature/samples/CpuTemperature.Sample.cs
+++ b/src/devices/CpuTemperature/samples/CpuTemperature.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/DCMotor/DCMotor.cs
+++ b/src/devices/DCMotor/DCMotor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/DCMotor/DCMotor2PinNoEnable.cs
+++ b/src/devices/DCMotor/DCMotor2PinNoEnable.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/DCMotor/DCMotor2PinWithBiDirectionalPin.cs
+++ b/src/devices/DCMotor/DCMotor2PinWithBiDirectionalPin.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/DCMotor/DCMotor3Pin.cs
+++ b/src/devices/DCMotor/DCMotor3Pin.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/DCMotor/samples/Program.cs
+++ b/src/devices/DCMotor/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Dhtxx/CommunicationProtocol.cs
+++ b/src/devices/Dhtxx/CommunicationProtocol.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.DHTxx
 {

--- a/src/devices/Dhtxx/Devices/Dht10.cs
+++ b/src/devices/Dhtxx/Devices/Dht10.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device;

--- a/src/devices/Dhtxx/Devices/Dht11.cs
+++ b/src/devices/Dhtxx/Devices/Dht11.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using UnitsNet;

--- a/src/devices/Dhtxx/Devices/Dht12.cs
+++ b/src/devices/Dhtxx/Devices/Dht12.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.I2c;

--- a/src/devices/Dhtxx/Devices/Dht21.cs
+++ b/src/devices/Dhtxx/Devices/Dht21.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using UnitsNet;

--- a/src/devices/Dhtxx/Devices/Dht22.cs
+++ b/src/devices/Dhtxx/Devices/Dht22.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using UnitsNet;

--- a/src/devices/Dhtxx/DhtBase.cs
+++ b/src/devices/Dhtxx/DhtBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device;

--- a/src/devices/Dhtxx/samples/DhtSensor.sample.cs
+++ b/src/devices/Dhtxx/samples/DhtSensor.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Display/Alignment.cs
+++ b/src/devices/Display/Alignment.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Display
 {

--- a/src/devices/Display/BlinkRate.cs
+++ b/src/devices/Display/BlinkRate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Display
 {

--- a/src/devices/Display/Dot.cs
+++ b/src/devices/Display/Dot.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Display/Font.cs
+++ b/src/devices/Display/Font.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Display
 {

--- a/src/devices/Display/FontHelper.cs
+++ b/src/devices/Display/FontHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Display/Ht16k33.cs
+++ b/src/devices/Display/Ht16k33.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Display/ISevenSegmentDisplay.cs
+++ b/src/devices/Display/ISevenSegmentDisplay.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Display/Large4Digit7SegmentDisplay.cs
+++ b/src/devices/Display/Large4Digit7SegmentDisplay.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Display/Segment.cs
+++ b/src/devices/Display/Segment.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Display/samples/Large4Digit7SegmentDisplay.sample.cs
+++ b/src/devices/Display/samples/Large4Digit7SegmentDisplay.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/ExplorerHat/DCMotorExtensions.cs
+++ b/src/devices/ExplorerHat/DCMotorExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/ExplorerHat/ExplorerHat.cs
+++ b/src/devices/ExplorerHat/ExplorerHat.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/ExplorerHat/Led.cs
+++ b/src/devices/ExplorerHat/Led.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/ExplorerHat/Lights.cs
+++ b/src/devices/ExplorerHat/Lights.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/devices/ExplorerHat/Motors.cs
+++ b/src/devices/ExplorerHat/Motors.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/ExplorerHat/samples/Program.cs
+++ b/src/devices/ExplorerHat/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/Ft4222/DeviceInformation.cs
+++ b/src/devices/Ft4222/DeviceInformation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ft4222/Ft4222Gpio.cs
+++ b/src/devices/Ft4222/Ft4222Gpio.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Ft4222/Ft4222I2c.cs
+++ b/src/devices/Ft4222/Ft4222I2c.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Ft4222/Ft4222Spi.cs
+++ b/src/devices/Ft4222/Ft4222Spi.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Ft4222/FtClockRate.cs
+++ b/src/devices/Ft4222/FtClockRate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/FtCommon.cs
+++ b/src/devices/Ft4222/FtCommon.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Ft4222/FtDevice.cs
+++ b/src/devices/Ft4222/FtDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/FtFlag.cs
+++ b/src/devices/Ft4222/FtFlag.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ft4222/FtFunction.cs
+++ b/src/devices/Ft4222/FtFunction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/devices/Ft4222/FtOpenType.cs
+++ b/src/devices/Ft4222/FtOpenType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/FtStatus.cs
+++ b/src/devices/Ft4222/FtStatus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/FtVersion.cs
+++ b/src/devices/Ft4222/FtVersion.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/GpioPinMode.cs
+++ b/src/devices/Ft4222/GpioPinMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/GpioPinValue.cs
+++ b/src/devices/Ft4222/GpioPinValue.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/GpioPort.cs
+++ b/src/devices/Ft4222/GpioPort.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/GpioTrigger.cs
+++ b/src/devices/Ft4222/GpioTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ft4222/I2cMasterFlag.cs
+++ b/src/devices/Ft4222/I2cMasterFlag.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/PinDrivingStrength.cs
+++ b/src/devices/Ft4222/PinDrivingStrength.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/SafeFtHandle.cs
+++ b/src/devices/Ft4222/SafeFtHandle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/devices/Ft4222/SpiClock.cs
+++ b/src/devices/Ft4222/SpiClock.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/SpiClockPhase.cs
+++ b/src/devices/Ft4222/SpiClockPhase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/SpiClockPolarity.cs
+++ b/src/devices/Ft4222/SpiClockPolarity.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/SpiDrivingStrength.cs
+++ b/src/devices/Ft4222/SpiDrivingStrength.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/SpiOperatingMode.cs
+++ b/src/devices/Ft4222/SpiOperatingMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/SpiSlaveProtocol.cs
+++ b/src/devices/Ft4222/SpiSlaveProtocol.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ft4222
 {

--- a/src/devices/Ft4222/samples/Ft4222.sample.cs
+++ b/src/devices/Ft4222/samples/Ft4222.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/GoPiGo3/GoPiGo3.cs
+++ b/src/devices/GoPiGo3/GoPiGo3.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/GoPiGo3/Models/GoPiGoInfo.cs
+++ b/src/devices/GoPiGo3/Models/GoPiGoInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GoPiGo3/Models/GoPiGoLed.cs
+++ b/src/devices/GoPiGo3/Models/GoPiGoLed.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.GoPiGo3.Models
 {

--- a/src/devices/GoPiGo3/Models/GoPiGoVoltage.cs
+++ b/src/devices/GoPiGo3/Models/GoPiGoVoltage.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.GoPiGo3.Models
 {

--- a/src/devices/GoPiGo3/Models/GroveInputOutput.cs
+++ b/src/devices/GoPiGo3/Models/GroveInputOutput.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.GoPiGo3.Models
 {

--- a/src/devices/GoPiGo3/Models/GroveSensors.cs
+++ b/src/devices/GoPiGo3/Models/GroveSensors.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/GoPiGo3/Models/MotorPort.cs
+++ b/src/devices/GoPiGo3/Models/MotorPort.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.GoPiGo3.Models
 {

--- a/src/devices/GoPiGo3/Models/MotorStatus.cs
+++ b/src/devices/GoPiGo3/Models/MotorStatus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.GoPiGo3.Models
 {

--- a/src/devices/GoPiGo3/Models/Motors.cs
+++ b/src/devices/GoPiGo3/Models/Motors.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/GoPiGo3/Models/ServoPort.cs
+++ b/src/devices/GoPiGo3/Models/ServoPort.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.GoPiGo3.Models
 {

--- a/src/devices/GoPiGo3/Models/SpiMessages.cs
+++ b/src/devices/GoPiGo3/Models/SpiMessages.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.GoPiGo3.Models
 {

--- a/src/devices/GoPiGo3/Movements/Motor.cs
+++ b/src/devices/GoPiGo3/Movements/Motor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/GoPiGo3/Movements/Vehicle.cs
+++ b/src/devices/GoPiGo3/Movements/Vehicle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/GoPiGo3/Sensors/AnalogSensor.cs
+++ b/src/devices/GoPiGo3/Sensors/AnalogSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GoPiGo3/Sensors/Button.cs
+++ b/src/devices/GoPiGo3/Sensors/Button.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GoPiGo3.Models;
 

--- a/src/devices/GoPiGo3/Sensors/Buzzer.cs
+++ b/src/devices/GoPiGo3/Sensors/Buzzer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GoPiGo3/Sensors/DigitalInput.cs
+++ b/src/devices/GoPiGo3/Sensors/DigitalInput.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GoPiGo3/Sensors/DigitalOutput.cs
+++ b/src/devices/GoPiGo3/Sensors/DigitalOutput.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GoPiGo3/Sensors/ISensor.cs
+++ b/src/devices/GoPiGo3/Sensors/ISensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Iot.Device.GoPiGo3.Models;

--- a/src/devices/GoPiGo3/Sensors/Led.cs
+++ b/src/devices/GoPiGo3/Sensors/Led.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GoPiGo3.Models;
 

--- a/src/devices/GoPiGo3/Sensors/LedPwm.cs
+++ b/src/devices/GoPiGo3/Sensors/LedPwm.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GoPiGo3.Models;
 

--- a/src/devices/GoPiGo3/Sensors/LightSensor.cs
+++ b/src/devices/GoPiGo3/Sensors/LightSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GoPiGo3.Models;
 

--- a/src/devices/GoPiGo3/Sensors/PotentiometerSensor.cs
+++ b/src/devices/GoPiGo3/Sensors/PotentiometerSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GoPiGo3.Models;
 

--- a/src/devices/GoPiGo3/Sensors/Relay.cs
+++ b/src/devices/GoPiGo3/Sensors/Relay.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GoPiGo3.Models;
 

--- a/src/devices/GoPiGo3/Sensors/SoundSensor.cs
+++ b/src/devices/GoPiGo3/Sensors/SoundSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GoPiGo3.Models;
 

--- a/src/devices/GoPiGo3/Sensors/UltraSonicSensor.cs
+++ b/src/devices/GoPiGo3/Sensors/UltraSonicSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GoPiGo3/samples/MovementTests.cs
+++ b/src/devices/GoPiGo3/samples/MovementTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/GoPiGo3/samples/Program.cs
+++ b/src/devices/GoPiGo3/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/GoPiGo3/samples/SensorTests.cs
+++ b/src/devices/GoPiGo3/samples/SensorTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/GrovePi/GrovePi.cs
+++ b/src/devices/GrovePi/GrovePi.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/GrovePi/Models/DhtType.cs
+++ b/src/devices/GrovePi/Models/DhtType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.GrovePiDevice.Models
 {

--- a/src/devices/GrovePi/Models/GrovePiCommand.cs
+++ b/src/devices/GrovePi/Models/GrovePiCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.GrovePiDevice.Models
 {

--- a/src/devices/GrovePi/Models/GrovePiInfo.cs
+++ b/src/devices/GrovePi/Models/GrovePiInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/GrovePi/Models/GrovePort.cs
+++ b/src/devices/GrovePi/Models/GrovePort.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.GrovePiDevice.Models
 {

--- a/src/devices/GrovePi/Sensors/AnalogSensor.cs
+++ b/src/devices/GrovePi/Sensors/AnalogSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GrovePi/Sensors/Button.cs
+++ b/src/devices/GrovePi/Sensors/Button.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using Iot.Device.GrovePiDevice.Models;

--- a/src/devices/GrovePi/Sensors/Buzzer.cs
+++ b/src/devices/GrovePi/Sensors/Buzzer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GrovePiDevice.Models;
 

--- a/src/devices/GrovePi/Sensors/DhtSensor.cs
+++ b/src/devices/GrovePi/Sensors/DhtSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GrovePi/Sensors/DigitalInput.cs
+++ b/src/devices/GrovePi/Sensors/DigitalInput.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GrovePi/Sensors/DigitalOutput.cs
+++ b/src/devices/GrovePi/Sensors/DigitalOutput.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GrovePi/Sensors/GrooveTemperatureSensor.cs
+++ b/src/devices/GrovePi/Sensors/GrooveTemperatureSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.GrovePiDevice.Models;

--- a/src/devices/GrovePi/Sensors/ISensor.cs
+++ b/src/devices/GrovePi/Sensors/ISensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GrovePiDevice.Models;
 

--- a/src/devices/GrovePi/Sensors/Led.cs
+++ b/src/devices/GrovePi/Sensors/Led.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using Iot.Device.GrovePiDevice.Models;

--- a/src/devices/GrovePi/Sensors/LedBar.cs
+++ b/src/devices/GrovePi/Sensors/LedBar.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GrovePi/Sensors/LedPwm.cs
+++ b/src/devices/GrovePi/Sensors/LedPwm.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GrovePiDevice.Models;
 

--- a/src/devices/GrovePi/Sensors/LightSensor.cs
+++ b/src/devices/GrovePi/Sensors/LightSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GrovePiDevice.Models;
 

--- a/src/devices/GrovePi/Sensors/PotentiometerSensor.cs
+++ b/src/devices/GrovePi/Sensors/PotentiometerSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GrovePiDevice.Models;
 

--- a/src/devices/GrovePi/Sensors/PwmOutput.cs
+++ b/src/devices/GrovePi/Sensors/PwmOutput.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/GrovePi/Sensors/Relay.cs
+++ b/src/devices/GrovePi/Sensors/Relay.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using Iot.Device.GrovePiDevice.Models;

--- a/src/devices/GrovePi/Sensors/SoundSensor.cs
+++ b/src/devices/GrovePi/Sensors/SoundSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.GrovePiDevice.Models;
 

--- a/src/devices/GrovePi/Sensors/UltrasonicSensor.cs
+++ b/src/devices/GrovePi/Sensors/UltrasonicSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/GrovePi/samples/Program.cs
+++ b/src/devices/GrovePi/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/Hcsr04/Hcsr04.cs
+++ b/src/devices/Hcsr04/Hcsr04.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/Hcsr04/samples/Hcsr04.Sample.cs
+++ b/src/devices/Hcsr04/samples/Hcsr04.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/Hcsr501/Hcsr501.cs
+++ b/src/devices/Hcsr501/Hcsr501.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Hcsr501/Hcsr501ValueChangedEventArgs.cs
+++ b/src/devices/Hcsr501/Hcsr501ValueChangedEventArgs.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Hcsr501/samples/Program.cs
+++ b/src/devices/Hcsr501/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/Hmc5883l/Gain.cs
+++ b/src/devices/Hmc5883l/Gain.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Hmc5883l
 {

--- a/src/devices/Hmc5883l/Hmc5883l.cs
+++ b/src/devices/Hmc5883l/Hmc5883l.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Hmc5883l/MeasurementConfiguration.cs
+++ b/src/devices/Hmc5883l/MeasurementConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Hmc5883l
 {

--- a/src/devices/Hmc5883l/MeasuringMode.cs
+++ b/src/devices/Hmc5883l/MeasuringMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Hmc5883l
 {

--- a/src/devices/Hmc5883l/OutputRate.cs
+++ b/src/devices/Hmc5883l/OutputRate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Hmc5883l
 {

--- a/src/devices/Hmc5883l/Register.cs
+++ b/src/devices/Hmc5883l/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Hmc5883l
 {

--- a/src/devices/Hmc5883l/SamplesAmount.cs
+++ b/src/devices/Hmc5883l/SamplesAmount.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Hmc5883l
 {

--- a/src/devices/Hmc5883l/Status.cs
+++ b/src/devices/Hmc5883l/Status.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 using System;
 
 namespace Iot.Device.Hmc5883l

--- a/src/devices/Hmc5883l/samples/Program.cs
+++ b/src/devices/Hmc5883l/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Hts221/Hts221.cs
+++ b/src/devices/Hts221/Hts221.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Hts221/Register.cs
+++ b/src/devices/Hts221/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Hts221
 {

--- a/src/devices/Hts221/samples/Hts221.Sample.cs
+++ b/src/devices/Hts221/samples/Hts221.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/Ina219/Ina219.cs
+++ b/src/devices/Ina219/Ina219.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Ina219/Ina219Enum.cs
+++ b/src/devices/Ina219/Ina219Enum.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ina219/samples/Ina219.Sample.cs
+++ b/src/devices/Ina219/samples/Ina219.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 using Iot.Device;

--- a/src/devices/Interop/Unix/Interop.Libraries.cs
+++ b/src/devices/Interop/Unix/Interop.Libraries.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 internal partial class Interop
 {

--- a/src/devices/Interop/Unix/Libasound/Interop.libasound.cs
+++ b/src/devices/Interop/Unix/Libasound/Interop.libasound.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/devices/Interop/Unix/Libasound/Interop.libasound.struct.cs
+++ b/src/devices/Interop/Unix/Libasound/Interop.libasound.struct.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/devices/Interop/Unix/Libc/Interop.ioctl.macros.cs
+++ b/src/devices/Interop/Unix/Libc/Interop.ioctl.macros.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/devices/Interop/Unix/Libc/Interop.libc.cs
+++ b/src/devices/Interop/Unix/Libc/Interop.libc.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/devices/Interop/Unix/Libc/Interop.videodev2.cs
+++ b/src/devices/Interop/Unix/Libc/Interop.videodev2.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/devices/Interop/Unix/Libc/Interop.videodev2.struct.cs
+++ b/src/devices/Interop/Unix/Libc/Interop.videodev2.struct.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/devices/Interop/Unix/ThreadHelper.cs
+++ b/src/devices/Interop/Unix/ThreadHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/devices/LiquidLevel/LiquidLevelSwitch.cs
+++ b/src/devices/LiquidLevel/LiquidLevelSwitch.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/LiquidLevel/Llc200d3sh.cs
+++ b/src/devices/LiquidLevel/Llc200d3sh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 

--- a/src/devices/LiquidLevel/samples/LiquidLevelSwitch.sample.cs
+++ b/src/devices/LiquidLevel/samples/LiquidLevelSwitch.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/LiquidLevel/samples/Llc200d3sh.sample.cs
+++ b/src/devices/LiquidLevel/samples/Llc200d3sh.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/Lm75/Lm75.cs
+++ b/src/devices/Lm75/Lm75.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Lm75/Register.cs
+++ b/src/devices/Lm75/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Lm75
 {

--- a/src/devices/Lm75/samples/Program.cs
+++ b/src/devices/Lm75/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Lps25h/Lps25h.cs
+++ b/src/devices/Lps25h/Lps25h.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Lps25h/Register.cs
+++ b/src/devices/Lps25h/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Lps25h
 {

--- a/src/devices/Lps25h/samples/Lps25h.Sample.cs
+++ b/src/devices/Lps25h/samples/Lps25h.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/Lsm9Ds1/AccelerationScale.cs
+++ b/src/devices/Lsm9Ds1/AccelerationScale.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Lsm9Ds1
 {

--- a/src/devices/Lsm9Ds1/AngularRateScale.cs
+++ b/src/devices/Lsm9Ds1/AngularRateScale.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Lsm9Ds1
 {

--- a/src/devices/Lsm9Ds1/Lsm9Ds1.AccelerometerAndGyroscope.cs
+++ b/src/devices/Lsm9Ds1/Lsm9Ds1.AccelerometerAndGyroscope.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Lsm9Ds1/Lsm9Ds1.Magnetometer.cs
+++ b/src/devices/Lsm9Ds1/Lsm9Ds1.Magnetometer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Lsm9Ds1/MagneticInductionScale.cs
+++ b/src/devices/Lsm9Ds1/MagneticInductionScale.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Lsm9Ds1
 {

--- a/src/devices/Lsm9Ds1/RegisterAg.cs
+++ b/src/devices/Lsm9Ds1/RegisterAg.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Lsm9Ds1
 {

--- a/src/devices/Lsm9Ds1/RegisterM.cs
+++ b/src/devices/Lsm9Ds1/RegisterM.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Lsm9Ds1
 {

--- a/src/devices/Lsm9Ds1/samples/Lsm9Ds1.AccelerometerAndGyroscope.Sample.cs
+++ b/src/devices/Lsm9Ds1/samples/Lsm9Ds1.AccelerometerAndGyroscope.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Magnetometer.Sample.cs
+++ b/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Magnetometer.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Numerics;

--- a/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Sample.cs
+++ b/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/Max44009/IntegrationTime.cs
+++ b/src/devices/Max44009/IntegrationTime.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Max44009
 {

--- a/src/devices/Max44009/Max44009.cs
+++ b/src/devices/Max44009/Max44009.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Max44009/Register.cs
+++ b/src/devices/Max44009/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Max44009
 {

--- a/src/devices/Max44009/WorkingMode.cs
+++ b/src/devices/Max44009/WorkingMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Max44009
 {

--- a/src/devices/Max44009/samples/Program.cs
+++ b/src/devices/Max44009/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Max7219/FixedSizeFont.cs
+++ b/src/devices/Max7219/FixedSizeFont.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Max7219/Fonts.cs
+++ b/src/devices/Max7219/Fonts.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Max7219/IFont.cs
+++ b/src/devices/Max7219/IFont.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/devices/Max7219/MatrixGraphics.cs
+++ b/src/devices/Max7219/MatrixGraphics.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Max7219/Max7219.cs
+++ b/src/devices/Max7219/Max7219.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Max7219/Register.cs
+++ b/src/devices/Max7219/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Max7219
 {

--- a/src/devices/Max7219/RotationType.cs
+++ b/src/devices/Max7219/RotationType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Max7219
 {

--- a/src/devices/Max7219/samples/Max7219.sample.cs
+++ b/src/devices/Max7219/samples/Max7219.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp23xxx/BankStyle.cs
+++ b/src/devices/Mcp23xxx/BankStyle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp23xxx
 {

--- a/src/devices/Mcp23xxx/BusAdapter.cs
+++ b/src/devices/Mcp23xxx/BusAdapter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/I2cAdapter.cs
+++ b/src/devices/Mcp23xxx/I2cAdapter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/Mcp23008.cs
+++ b/src/devices/Mcp23xxx/Mcp23008.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/Mcp23009.cs
+++ b/src/devices/Mcp23xxx/Mcp23009.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/Mcp23017.cs
+++ b/src/devices/Mcp23xxx/Mcp23017.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/Mcp23018.cs
+++ b/src/devices/Mcp23xxx/Mcp23018.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/Mcp23S08.cs
+++ b/src/devices/Mcp23xxx/Mcp23S08.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/Mcp23S09.cs
+++ b/src/devices/Mcp23xxx/Mcp23S09.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.Spi;

--- a/src/devices/Mcp23xxx/Mcp23S17.cs
+++ b/src/devices/Mcp23xxx/Mcp23S17.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/Mcp23S18.cs
+++ b/src/devices/Mcp23xxx/Mcp23S18.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.Spi;

--- a/src/devices/Mcp23xxx/Mcp23x0x.cs
+++ b/src/devices/Mcp23xxx/Mcp23x0x.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 

--- a/src/devices/Mcp23xxx/Mcp23x1x.cs
+++ b/src/devices/Mcp23xxx/Mcp23x1x.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 

--- a/src/devices/Mcp23xxx/Mcp23xxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23xxx.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/Port.cs
+++ b/src/devices/Mcp23xxx/Port.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp23xxx
 {

--- a/src/devices/Mcp23xxx/Register.cs
+++ b/src/devices/Mcp23xxx/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp23xxx
 {

--- a/src/devices/Mcp23xxx/SpiAdapter.cs
+++ b/src/devices/Mcp23xxx/SpiAdapter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
+++ b/src/devices/Mcp23xxx/samples/Mcp23xxx.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/tests/ConstructionTests.cs
+++ b/src/devices/Mcp23xxx/tests/ConstructionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Mcp23xxx/tests/EnableDisableTests.cs
+++ b/src/devices/Mcp23xxx/tests/EnableDisableTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/tests/GpioReadTests.cs
+++ b/src/devices/Mcp23xxx/tests/GpioReadTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/tests/GpioWriteTests.cs
+++ b/src/devices/Mcp23xxx/tests/GpioWriteTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp23xxx/tests/Mcp23xxxTest.cs
+++ b/src/devices/Mcp23xxx/tests/Mcp23xxxTest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/devices/Mcp23xxx/tests/OpCodeTests.cs
+++ b/src/devices/Mcp23xxx/tests/OpCodeTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp23xxx/tests/RegisterTests.cs
+++ b/src/devices/Mcp23xxx/tests/RegisterTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp25xxx/InstructionFormat.cs
+++ b/src/devices/Mcp25xxx/InstructionFormat.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx
 {

--- a/src/devices/Mcp25xxx/Mcp2515.cs
+++ b/src/devices/Mcp25xxx/Mcp2515.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.Spi;

--- a/src/devices/Mcp25xxx/Mcp25625.cs
+++ b/src/devices/Mcp25xxx/Mcp25625.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp25xxx/Mcp25xxx.cs
+++ b/src/devices/Mcp25xxx/Mcp25xxx.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Mcp25xxx/ReadStatusResponse.cs
+++ b/src/devices/Mcp25xxx/ReadStatusResponse.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxFxEid0.cs
+++ b/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxFxEid0.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxFxEid8.cs
+++ b/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxFxEid8.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxFxSidh.cs
+++ b/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxFxSidh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxFxSidl.cs
+++ b/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxFxSidl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxMxEid0.cs
+++ b/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxMxEid0.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxMxEid8.cs
+++ b/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxMxEid8.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxMxSidh.cs
+++ b/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxMxSidh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxMxSidl.cs
+++ b/src/devices/Mcp25xxx/Register/AcceptanceFilter/RxMxSidl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/Address.cs
+++ b/src/devices/Mcp25xxx/Register/Address.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register
 {

--- a/src/devices/Mcp25xxx/Register/BitTimeConfiguration/Cnf1.cs
+++ b/src/devices/Mcp25xxx/Register/BitTimeConfiguration/Cnf1.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/BitTimeConfiguration/Cnf2.cs
+++ b/src/devices/Mcp25xxx/Register/BitTimeConfiguration/Cnf2.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/BitTimeConfiguration/Cnf3.cs
+++ b/src/devices/Mcp25xxx/Register/BitTimeConfiguration/Cnf3.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/CanControl/CanCtrl.cs
+++ b/src/devices/Mcp25xxx/Register/CanControl/CanCtrl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Tests.Register.CanControl;
 

--- a/src/devices/Mcp25xxx/Register/CanControl/CanStat.cs
+++ b/src/devices/Mcp25xxx/Register/CanControl/CanStat.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Tests.Register.CanControl;
 

--- a/src/devices/Mcp25xxx/Register/CanControl/OperationMode.cs
+++ b/src/devices/Mcp25xxx/Register/CanControl/OperationMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Tests.Register.CanControl
 {

--- a/src/devices/Mcp25xxx/Register/ErrorDetection/Eflg.cs
+++ b/src/devices/Mcp25xxx/Register/ErrorDetection/Eflg.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register.ErrorDetection
 {

--- a/src/devices/Mcp25xxx/Register/ErrorDetection/Rec.cs
+++ b/src/devices/Mcp25xxx/Register/ErrorDetection/Rec.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register.ErrorDetection
 {

--- a/src/devices/Mcp25xxx/Register/ErrorDetection/Tec.cs
+++ b/src/devices/Mcp25xxx/Register/ErrorDetection/Tec.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register.ErrorDetection
 {

--- a/src/devices/Mcp25xxx/Register/IRegister.cs
+++ b/src/devices/Mcp25xxx/Register/IRegister.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register
 {

--- a/src/devices/Mcp25xxx/Register/Interrupt/CanIntE.cs
+++ b/src/devices/Mcp25xxx/Register/Interrupt/CanIntE.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register.Interrupt
 {

--- a/src/devices/Mcp25xxx/Register/Interrupt/CanIntF.cs
+++ b/src/devices/Mcp25xxx/Register/Interrupt/CanIntF.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register.Interrupt
 {

--- a/src/devices/Mcp25xxx/Register/MessageReceive/BfpCtrl.cs
+++ b/src/devices/Mcp25xxx/Register/MessageReceive/BfpCtrl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register.MessageReceive
 {

--- a/src/devices/Mcp25xxx/Register/MessageReceive/OperatingMode.cs
+++ b/src/devices/Mcp25xxx/Register/MessageReceive/OperatingMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register.MessageReceive
 {

--- a/src/devices/Mcp25xxx/Register/MessageReceive/RxB0Ctrl.cs
+++ b/src/devices/Mcp25xxx/Register/MessageReceive/RxB0Ctrl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using static Iot.Device.Mcp25xxx.Register.MessageReceive.RxB1Ctrl;
 

--- a/src/devices/Mcp25xxx/Register/MessageReceive/RxB1Ctrl.cs
+++ b/src/devices/Mcp25xxx/Register/MessageReceive/RxB1Ctrl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register.MessageReceive
 {

--- a/src/devices/Mcp25xxx/Register/MessageReceive/RxBxDlc.cs
+++ b/src/devices/Mcp25xxx/Register/MessageReceive/RxBxDlc.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageReceive/RxBxDn.cs
+++ b/src/devices/Mcp25xxx/Register/MessageReceive/RxBxDn.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageReceive/RxBxEid0.cs
+++ b/src/devices/Mcp25xxx/Register/MessageReceive/RxBxEid0.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageReceive/RxBxEid8.cs
+++ b/src/devices/Mcp25xxx/Register/MessageReceive/RxBxEid8.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageReceive/RxBxSidh.cs
+++ b/src/devices/Mcp25xxx/Register/MessageReceive/RxBxSidh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageReceive/RxBxSidl.cs
+++ b/src/devices/Mcp25xxx/Register/MessageReceive/RxBxSidl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxCtrl.cs
+++ b/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxCtrl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxDlc.cs
+++ b/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxDlc.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxDn.cs
+++ b/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxDn.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxEid0.cs
+++ b/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxEid0.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxEid8.cs
+++ b/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxEid8.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxSidh.cs
+++ b/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxSidh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxSidl.cs
+++ b/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxSidl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp25xxx/Register/MessageTransmit/TxRtsCtrl.cs
+++ b/src/devices/Mcp25xxx/Register/MessageTransmit/TxRtsCtrl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx.Register.MessageTransmit
 {

--- a/src/devices/Mcp25xxx/RxBufferAddressPointer.cs
+++ b/src/devices/Mcp25xxx/RxBufferAddressPointer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx
 {

--- a/src/devices/Mcp25xxx/RxStatusResponse.cs
+++ b/src/devices/Mcp25xxx/RxStatusResponse.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx
 {

--- a/src/devices/Mcp25xxx/TxBufferAddressPointer.cs
+++ b/src/devices/Mcp25xxx/TxBufferAddressPointer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp25xxx
 {

--- a/src/devices/Mcp25xxx/samples/Mcp25xxx.Sample.cs
+++ b/src/devices/Mcp25xxx/samples/Mcp25xxx.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp25xxx/tests/Mcp25xxxSpiDevice.cs
+++ b/src/devices/Mcp25xxx/tests/Mcp25xxxSpiDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp25xxx/tests/Mcp25xxxTests.cs
+++ b/src/devices/Mcp25xxx/tests/Mcp25xxxTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Xunit;

--- a/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxFxEid0Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxFxEid0Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.AcceptanceFilter;

--- a/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxFxEid8Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxFxEid8Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.AcceptanceFilter;

--- a/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxFxSidhTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxFxSidhTests.cs
@@ -1,5 +1,4 @@
 ﻿// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.AcceptanceFilter;

--- a/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxFxSidlTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxFxSidlTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Mcp25xxx.Register;

--- a/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxMxEid0Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxMxEid0Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.AcceptanceFilter;

--- a/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxMxEid8Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxMxEid8Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.AcceptanceFilter;

--- a/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxMxSidhTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxMxSidhTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.AcceptanceFilter;

--- a/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxMxSidlTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxMxSidlTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Mcp25xxx.Register;

--- a/src/devices/Mcp25xxx/tests/Register/BitTimeConfiguration/Cnf1Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/BitTimeConfiguration/Cnf1Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Mcp25xxx.Register;

--- a/src/devices/Mcp25xxx/tests/Register/BitTimeConfiguration/Cnf2Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/BitTimeConfiguration/Cnf2Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Mcp25xxx.Register;

--- a/src/devices/Mcp25xxx/tests/Register/BitTimeConfiguration/Cnf3Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/BitTimeConfiguration/Cnf3Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Mcp25xxx.Register;

--- a/src/devices/Mcp25xxx/tests/Register/CanControl/CanCtrlTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/CanControl/CanCtrlTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.CanControl;

--- a/src/devices/Mcp25xxx/tests/Register/CanControl/CanStatTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/CanControl/CanStatTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.CanControl;

--- a/src/devices/Mcp25xxx/tests/Register/ErrorDetection/EflgTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/ErrorDetection/EflgTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.ErrorDetection;

--- a/src/devices/Mcp25xxx/tests/Register/ErrorDetection/RecTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/ErrorDetection/RecTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.ErrorDetection;

--- a/src/devices/Mcp25xxx/tests/Register/ErrorDetection/TecTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/ErrorDetection/TecTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.ErrorDetection;

--- a/src/devices/Mcp25xxx/tests/Register/Interrupt/CanIntETests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/Interrupt/CanIntETests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.Interrupt;

--- a/src/devices/Mcp25xxx/tests/Register/Interrupt/CanIntFTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/Interrupt/CanIntFTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.Interrupt;

--- a/src/devices/Mcp25xxx/tests/Register/MessageReceive/BfpCtrlTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageReceive/BfpCtrlTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageReceive;

--- a/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxB0CtrlTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxB0CtrlTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageReceive;

--- a/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxB1CtrlTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxB1CtrlTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageReceive;

--- a/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxDlcTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxDlcTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageReceive;

--- a/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxDnTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxDnTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageReceive;

--- a/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxEid0Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxEid0Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageReceive;

--- a/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxEid8Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxEid8Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageReceive;

--- a/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxSidhTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxSidhTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageReceive;

--- a/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxSidlTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageReceive/RxBxSidlTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Mcp25xxx.Register;

--- a/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxCtrlTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxCtrlTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageTransmit;

--- a/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxDlcTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxDlcTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageTransmit;

--- a/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxDnTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxDnTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageTransmit;

--- a/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxEid0Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxEid0Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageTransmit;

--- a/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxEid8Tests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxEid8Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageTransmit;

--- a/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxSidhTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxSidhTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageTransmit;

--- a/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxSidlTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxBxSidlTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Mcp25xxx.Register;

--- a/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxRtsCtrlTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/MessageTransmit/TxRtsCtrlTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.MessageTransmit;

--- a/src/devices/Mcp25xxx/tests/RxStatusResponseTests.cs
+++ b/src/devices/Mcp25xxx/tests/RxStatusResponseTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 using static Iot.Device.Mcp25xxx.RxStatusResponse;

--- a/src/devices/Mcp3428/Config.cs
+++ b/src/devices/Mcp3428/Config.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp3428/ConversionResult.cs
+++ b/src/devices/Mcp3428/ConversionResult.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp3428
 {

--- a/src/devices/Mcp3428/Helpers.cs
+++ b/src/devices/Mcp3428/Helpers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mcp3428/Mcp3426.cs
+++ b/src/devices/Mcp3428/Mcp3426.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 

--- a/src/devices/Mcp3428/Mcp3427.cs
+++ b/src/devices/Mcp3428/Mcp3427.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 

--- a/src/devices/Mcp3428/Mcp3428.cs
+++ b/src/devices/Mcp3428/Mcp3428.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 

--- a/src/devices/Mcp3428/Mcp342x.cs
+++ b/src/devices/Mcp3428/Mcp342x.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Mcp3428/samples/Mcp3428.Sample.cs
+++ b/src/devices/Mcp3428/samples/Mcp3428.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Mcp3xxx/Mcp3001.cs
+++ b/src/devices/Mcp3xxx/Mcp3001.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 

--- a/src/devices/Mcp3xxx/Mcp3002.cs
+++ b/src/devices/Mcp3xxx/Mcp3002.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 

--- a/src/devices/Mcp3xxx/Mcp3004.cs
+++ b/src/devices/Mcp3xxx/Mcp3004.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 

--- a/src/devices/Mcp3xxx/Mcp3008.cs
+++ b/src/devices/Mcp3xxx/Mcp3008.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 

--- a/src/devices/Mcp3xxx/Mcp3201.cs
+++ b/src/devices/Mcp3xxx/Mcp3201.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 

--- a/src/devices/Mcp3xxx/Mcp3202.cs
+++ b/src/devices/Mcp3xxx/Mcp3202.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 

--- a/src/devices/Mcp3xxx/Mcp3204.cs
+++ b/src/devices/Mcp3xxx/Mcp3204.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 

--- a/src/devices/Mcp3xxx/Mcp3208.cs
+++ b/src/devices/Mcp3xxx/Mcp3208.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp3xxx/Mcp3301.cs
+++ b/src/devices/Mcp3xxx/Mcp3301.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 

--- a/src/devices/Mcp3xxx/Mcp3302.cs
+++ b/src/devices/Mcp3xxx/Mcp3302.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp3xxx/Mcp3304.cs
+++ b/src/devices/Mcp3xxx/Mcp3304.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp3xxx/Mcp33xx.cs
+++ b/src/devices/Mcp3xxx/Mcp33xx.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp3xxx/Mcp3Base.cs
+++ b/src/devices/Mcp3xxx/Mcp3Base.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Mcp3xxx/Mcp3xxx.cs
+++ b/src/devices/Mcp3xxx/Mcp3xxx.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp3xxx/samples/Mcp3008.Sample.cs
+++ b/src/devices/Mcp3xxx/samples/Mcp3008.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/Mcp9808/Mcp9808.cs
+++ b/src/devices/Mcp9808/Mcp9808.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Mcp9808/Register.cs
+++ b/src/devices/Mcp9808/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mcp9808
 {

--- a/src/devices/Mcp9808/samples/Program.cs
+++ b/src/devices/Mcp9808/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Media/SoundDevice/Devices/UnixSoundDevice.cs
+++ b/src/devices/Media/SoundDevice/Devices/UnixSoundDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Media/SoundDevice/SoundConnectionSettings.cs
+++ b/src/devices/Media/SoundDevice/SoundConnectionSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/SoundDevice/SoundDevice.cs
+++ b/src/devices/Media/SoundDevice/SoundDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/Media/SoundDevice/WavHeader.cs
+++ b/src/devices/Media/SoundDevice/WavHeader.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/SoundDevice/WavHeaderChunk.cs
+++ b/src/devices/Media/SoundDevice/WavHeaderChunk.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/SoundDevice/samples/Program.cs
+++ b/src/devices/Media/SoundDevice/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/Media/VideoDevice/ColorEffect.cs
+++ b/src/devices/Media/VideoDevice/ColorEffect.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/VideoDevice/Devices/UnixVideoDevice.cs
+++ b/src/devices/Media/VideoDevice/Devices/UnixVideoDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Media/VideoDevice/ExposureType.cs
+++ b/src/devices/Media/VideoDevice/ExposureType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/VideoDevice/PixelFormat.cs
+++ b/src/devices/Media/VideoDevice/PixelFormat.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/devices/Media/VideoDevice/PowerLineFrequency.cs
+++ b/src/devices/Media/VideoDevice/PowerLineFrequency.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/VideoDevice/SceneMode.cs
+++ b/src/devices/Media/VideoDevice/SceneMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/VideoDevice/VideoConnectionSettings.cs
+++ b/src/devices/Media/VideoDevice/VideoConnectionSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/VideoDevice/VideoDevice.Converter.cs
+++ b/src/devices/Media/VideoDevice/VideoDevice.Converter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Drawing;

--- a/src/devices/Media/VideoDevice/VideoDevice.cs
+++ b/src/devices/Media/VideoDevice/VideoDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Media/VideoDevice/VideoDeviceValue.cs
+++ b/src/devices/Media/VideoDevice/VideoDeviceValue.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/VideoDevice/VideoDeviceValueType.cs
+++ b/src/devices/Media/VideoDevice/VideoDeviceValueType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/VideoDevice/WhiteBalanceEffect.cs
+++ b/src/devices/Media/VideoDevice/WhiteBalanceEffect.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Media
 {

--- a/src/devices/Media/VideoDevice/samples/Program.cs
+++ b/src/devices/Media/VideoDevice/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Drawing;

--- a/src/devices/Mhz19b/AbmState.cs
+++ b/src/devices/Mhz19b/AbmState.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mhz19b
 {

--- a/src/devices/Mhz19b/DetectionRange.cs
+++ b/src/devices/Mhz19b/DetectionRange.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mhz19b
 {

--- a/src/devices/Mhz19b/Mhz19b.cs
+++ b/src/devices/Mhz19b/Mhz19b.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/Mhz19b/samples/Mhz19b.Sample.cs
+++ b/src/devices/Mhz19b/samples/Mhz19b.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/Mlx90614/Mlx90614.cs
+++ b/src/devices/Mlx90614/Mlx90614.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Mlx90614/Register.cs
+++ b/src/devices/Mlx90614/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mlx90614
 {

--- a/src/devices/Mlx90614/samples/Program.cs
+++ b/src/devices/Mlx90614/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/MotorHat/DCMotor3Pwm.cs
+++ b/src/devices/MotorHat/DCMotor3Pwm.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Pwm;

--- a/src/devices/MotorHat/MotorHat.cs
+++ b/src/devices/MotorHat/MotorHat.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/MotorHat/samples/MotorHat.Sample.cs
+++ b/src/devices/MotorHat/samples/MotorHat.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/Mpr121/ChannelStatusesChangedEventArgs.cs
+++ b/src/devices/Mpr121/ChannelStatusesChangedEventArgs.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/devices/Mpr121/Channels.cs
+++ b/src/devices/Mpr121/Channels.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mpr121
 {

--- a/src/devices/Mpr121/Mpr121.cs
+++ b/src/devices/Mpr121/Mpr121.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Mpr121/Mpr121Configuration.cs
+++ b/src/devices/Mpr121/Mpr121Configuration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mpr121
 {

--- a/src/devices/Mpr121/Registers.cs
+++ b/src/devices/Mpr121/Registers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Mpr121
 {

--- a/src/devices/Mpr121/samples/Mpr121.Sample.cs
+++ b/src/devices/Mpr121/samples/Mpr121.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Mpu9250/AccelerometerBandwidth.cs
+++ b/src/devices/Mpu9250/AccelerometerBandwidth.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Imu
 {

--- a/src/devices/Mpu9250/AccelerometerLowPowerFrequency.cs
+++ b/src/devices/Mpu9250/AccelerometerLowPowerFrequency.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Imu
 {

--- a/src/devices/Mpu9250/AccelerometerRange.cs
+++ b/src/devices/Mpu9250/AccelerometerRange.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Imu
 {

--- a/src/devices/Mpu9250/Ak8963Attached.cs
+++ b/src/devices/Mpu9250/Ak8963Attached.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device;

--- a/src/devices/Mpu9250/ClockSource.cs
+++ b/src/devices/Mpu9250/ClockSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Imu
 {

--- a/src/devices/Mpu9250/DisableModes.cs
+++ b/src/devices/Mpu9250/DisableModes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mpu9250/FifoModes.cs
+++ b/src/devices/Mpu9250/FifoModes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mpu9250/GyroscopeBandwidth.cs
+++ b/src/devices/Mpu9250/GyroscopeBandwidth.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Imu
 {

--- a/src/devices/Mpu9250/GyroscopeRange.cs
+++ b/src/devices/Mpu9250/GyroscopeRange.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Imu
 {

--- a/src/devices/Mpu9250/I2cBusFrequency.cs
+++ b/src/devices/Mpu9250/I2cBusFrequency.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Imu
 {

--- a/src/devices/Mpu9250/I2cChannel.cs
+++ b/src/devices/Mpu9250/I2cChannel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Imu
 {

--- a/src/devices/Mpu9250/Mpu6500.cs
+++ b/src/devices/Mpu9250/Mpu6500.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Mpu9250/Mpu9250.cs
+++ b/src/devices/Mpu9250/Mpu9250.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Mpu9250/Register.cs
+++ b/src/devices/Mpu9250/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Imu
 {

--- a/src/devices/Mpu9250/SelfTestScale.cs
+++ b/src/devices/Mpu9250/SelfTestScale.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Imu
 {

--- a/src/devices/Mpu9250/UserControls.cs
+++ b/src/devices/Mpu9250/UserControls.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Mpu9250/samples/Mpu9250.sample.cs
+++ b/src/devices/Mpu9250/samples/Mpu9250.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Nrf24l01/Command.cs
+++ b/src/devices/Nrf24l01/Command.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Nrf24l01
 {

--- a/src/devices/Nrf24l01/DataRate.cs
+++ b/src/devices/Nrf24l01/DataRate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Nrf24l01
 {

--- a/src/devices/Nrf24l01/DataReceivedEventArgs.cs
+++ b/src/devices/Nrf24l01/DataReceivedEventArgs.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Nrf24l01/Nrf24l01.cs
+++ b/src/devices/Nrf24l01/Nrf24l01.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Nrf24l01/Nrf24l01Pipe.cs
+++ b/src/devices/Nrf24l01/Nrf24l01Pipe.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Nrf24l01/OutputPower.cs
+++ b/src/devices/Nrf24l01/OutputPower.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Nrf24l01
 {

--- a/src/devices/Nrf24l01/PowerMode.cs
+++ b/src/devices/Nrf24l01/PowerMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Nrf24l01
 {

--- a/src/devices/Nrf24l01/Register.cs
+++ b/src/devices/Nrf24l01/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Nrf24l01
 {

--- a/src/devices/Nrf24l01/WorkingMode.cs
+++ b/src/devices/Nrf24l01/WorkingMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Nrf24l01
 {

--- a/src/devices/Nrf24l01/samples/Program.cs
+++ b/src/devices/Nrf24l01/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/src/devices/OneWire/DeviceFamily.cs
+++ b/src/devices/OneWire/DeviceFamily.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.OneWire
 {

--- a/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.Linux.cs
+++ b/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.Linux.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.cs
+++ b/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/devices/OneWire/OneWireBus.Linux.cs
+++ b/src/devices/OneWire/OneWireBus.Linux.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/OneWire/OneWireBus.cs
+++ b/src/devices/OneWire/OneWireBus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/devices/OneWire/OneWireDevice.cs
+++ b/src/devices/OneWire/OneWireDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/devices/OneWire/samples/OneWire.Sample.cs
+++ b/src/devices/OneWire/samples/OneWire.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/devices/Pca95x4/Pca95x4.cs
+++ b/src/devices/Pca95x4/Pca95x4.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Pca95x4/Register.cs
+++ b/src/devices/Pca95x4/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pca95x4
 {

--- a/src/devices/Pca95x4/samples/Pca95x4.Sample.cs
+++ b/src/devices/Pca95x4/samples/Pca95x4.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Pca9685/Mode1.cs
+++ b/src/devices/Pca9685/Mode1.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pwm
 {

--- a/src/devices/Pca9685/Mode2.cs
+++ b/src/devices/Pca9685/Mode2.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pwm
 {

--- a/src/devices/Pca9685/Pca9685.cs
+++ b/src/devices/Pca9685/Pca9685.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Pca9685/Pca9685PwmChannel.cs
+++ b/src/devices/Pca9685/Pca9685PwmChannel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Pwm;

--- a/src/devices/Pca9685/Register.cs
+++ b/src/devices/Pca9685/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pwm
 {

--- a/src/devices/Pca9685/samples/Pca9685.Sample.cs
+++ b/src/devices/Pca9685/samples/Pca9685.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pcx857x/Pca8574.cs
+++ b/src/devices/Pcx857x/Pca8574.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.I2c;

--- a/src/devices/Pcx857x/Pca8575.cs
+++ b/src/devices/Pcx857x/Pca8575.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.I2c;

--- a/src/devices/Pcx857x/Pcf8574.cs
+++ b/src/devices/Pcx857x/Pcf8574.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.I2c;

--- a/src/devices/Pcx857x/Pcf8575.cs
+++ b/src/devices/Pcx857x/Pcf8575.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.I2c;

--- a/src/devices/Pcx857x/Pcx8574.cs
+++ b/src/devices/Pcx857x/Pcx8574.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.I2c;

--- a/src/devices/Pcx857x/Pcx8575.cs
+++ b/src/devices/Pcx857x/Pcx8575.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using System.Device.I2c;

--- a/src/devices/Pcx857x/Pcx857x.cs
+++ b/src/devices/Pcx857x/Pcx857x.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/devices/Pcx857x/tests/ConstructionTests.cs
+++ b/src/devices/Pcx857x/tests/ConstructionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/devices/Pcx857x/tests/GpioReadTests.cs
+++ b/src/devices/Pcx857x/tests/GpioReadTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Pcx857x/tests/GpioWriteTests.cs
+++ b/src/devices/Pcx857x/tests/GpioWriteTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Pcx857x/tests/Pcx857xTest.cs
+++ b/src/devices/Pcx857x/tests/Pcx857xTest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/devices/Pn5180/Command.cs
+++ b/src/devices/Pn5180/Command.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pn5180/EepromAddress.cs
+++ b/src/devices/Pn5180/EepromAddress.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pn5180/Pn5180.cs
+++ b/src/devices/Pn5180/Pn5180.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Pn5180/RBlock.cs
+++ b/src/devices/Pn5180/RBlock.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pn5180/RadioFrequencyCollision.cs
+++ b/src/devices/Pn5180/RadioFrequencyCollision.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pn5180/RadioFrequencyStatus.cs
+++ b/src/devices/Pn5180/RadioFrequencyStatus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pn5180/ReceiverRadioFrequencyConfiguration.cs
+++ b/src/devices/Pn5180/ReceiverRadioFrequencyConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pn5180/Register.cs
+++ b/src/devices/Pn5180/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pn5180/SelectedPiccInformation.cs
+++ b/src/devices/Pn5180/SelectedPiccInformation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Rfid;
 

--- a/src/devices/Pn5180/TransmitterRadioFrequencyConfiguration.cs
+++ b/src/devices/Pn5180/TransmitterRadioFrequencyConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pn5180/samples/Pn5180sample.cs
+++ b/src/devices/Pn5180/samples/Pn5180sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pn532/AsTarget/TargetBaudRateInialized.cs
+++ b/src/devices/Pn532/AsTarget/TargetBaudRateInialized.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.AsTarget
 {

--- a/src/devices/Pn532/AsTarget/TargetFeliCaParameters.cs
+++ b/src/devices/Pn532/AsTarget/TargetFeliCaParameters.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Pn532/AsTarget/TargetFramingType.cs
+++ b/src/devices/Pn532/AsTarget/TargetFramingType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.AsTarget
 {

--- a/src/devices/Pn532/AsTarget/TargetMifareParameters.cs
+++ b/src/devices/Pn532/AsTarget/TargetMifareParameters.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Pn532/AsTarget/TargetModeInitialization.cs
+++ b/src/devices/Pn532/AsTarget/TargetModeInitialization.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Pn532/AsTarget/TargetModeInitialized.cs
+++ b/src/devices/Pn532/AsTarget/TargetModeInitialized.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.AsTarget
 {

--- a/src/devices/Pn532/AsTarget/TargetPiccParameters.cs
+++ b/src/devices/Pn532/AsTarget/TargetPiccParameters.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Pn532/BaudRate.cs
+++ b/src/devices/Pn532/BaudRate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532
 {

--- a/src/devices/Pn532/CommandSet.cs
+++ b/src/devices/Pn532/CommandSet.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532
 {

--- a/src/devices/Pn532/DiagnoseMode.cs
+++ b/src/devices/Pn532/DiagnoseMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532
 {

--- a/src/devices/Pn532/ErrorCode.cs
+++ b/src/devices/Pn532/ErrorCode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace IoT.Device.Pn532
 {

--- a/src/devices/Pn532/FirmwareVersion.cs
+++ b/src/devices/Pn532/FirmwareVersion.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Pn532/ListPassive/MaxTarget.cs
+++ b/src/devices/Pn532/ListPassive/MaxTarget.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.ListPassive
 {

--- a/src/devices/Pn532/ListPassive/PollingType.cs
+++ b/src/devices/Pn532/ListPassive/PollingType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.ListPassive
 {

--- a/src/devices/Pn532/ListPassive/TargetBaudRate.cs
+++ b/src/devices/Pn532/ListPassive/TargetBaudRate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.ListPassive
 {

--- a/src/devices/Pn532/OperatingMode.cs
+++ b/src/devices/Pn532/OperatingMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532
 {

--- a/src/devices/Pn532/P3.cs
+++ b/src/devices/Pn532/P3.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Pn532/P7.cs
+++ b/src/devices/Pn532/P7.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Pn532/ParametersFlags.cs
+++ b/src/devices/Pn532/ParametersFlags.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Pn532/RFConfigurationTimeout.cs
+++ b/src/devices/Pn532/RFConfigurationTimeout.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532
 {

--- a/src/devices/Pn532/RfConfiguration/Analog106kbpsTypeAMode.cs
+++ b/src/devices/Pn532/RfConfiguration/Analog106kbpsTypeAMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.RfConfiguration
 {

--- a/src/devices/Pn532/RfConfiguration/Analog212-424_848kbpsMode.cs
+++ b/src/devices/Pn532/RfConfiguration/Analog212-424_848kbpsMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.RfConfiguration
 {

--- a/src/devices/Pn532/RfConfiguration/Analog212_424kbpsMode.cs
+++ b/src/devices/Pn532/RfConfiguration/Analog212_424kbpsMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.RfConfiguration
 {

--- a/src/devices/Pn532/RfConfiguration/AnalogSettingsTypeBMode.cs
+++ b/src/devices/Pn532/RfConfiguration/AnalogSettingsTypeBMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.RfConfiguration
 {

--- a/src/devices/Pn532/RfConfiguration/MaxRetriesMode.cs
+++ b/src/devices/Pn532/RfConfiguration/MaxRetriesMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.RfConfiguration
 {

--- a/src/devices/Pn532/RfConfiguration/RfFieldMode.cs
+++ b/src/devices/Pn532/RfConfiguration/RfFieldMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Pn532/RfConfiguration/RfTimeout.cs
+++ b/src/devices/Pn532/RfConfiguration/RfTimeout.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532.RfConfiguration
 {

--- a/src/devices/Pn532/RfConfiguration/VariousTimingsMode.cs
+++ b/src/devices/Pn532/RfConfiguration/VariousTimingsMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Pn532/RfConfigurationMode.cs
+++ b/src/devices/Pn532/RfConfigurationMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532
 {

--- a/src/devices/Pn532/SecurityAccessModuleMode.cs
+++ b/src/devices/Pn532/SecurityAccessModuleMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532
 {

--- a/src/devices/Pn532/SfrRegister.cs
+++ b/src/devices/Pn532/SfrRegister.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532
 {

--- a/src/devices/Pn532/VersionSupported.cs
+++ b/src/devices/Pn532/VersionSupported.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Pn532/WakeUpEnable.cs
+++ b/src/devices/Pn532/WakeUpEnable.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Pn532
 {

--- a/src/devices/Pn532/samples/Program.cs
+++ b/src/devices/Pn532/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/RGBLedMatrix/Gpio.cs
+++ b/src/devices/RGBLedMatrix/Gpio.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio.Drivers;

--- a/src/devices/RGBLedMatrix/PinMapping.cs
+++ b/src/devices/RGBLedMatrix/PinMapping.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.LEDMatrix
 {

--- a/src/devices/RGBLedMatrix/RgbLedMatrix.cs
+++ b/src/devices/RGBLedMatrix/RgbLedMatrix.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Interop;

--- a/src/devices/RGBLedMatrix/samples/RGBLedMatrix.sample.cs
+++ b/src/devices/RGBLedMatrix/samples/RGBLedMatrix.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/devices/RadioReceiver/Devices/Tea5767/FrequencyRange.cs
+++ b/src/devices/RadioReceiver/Devices/Tea5767/FrequencyRange.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.RadioReceiver
 {

--- a/src/devices/RadioReceiver/Devices/Tea5767/SearchDirection.cs
+++ b/src/devices/RadioReceiver/Devices/Tea5767/SearchDirection.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.RadioReceiver
 {

--- a/src/devices/RadioReceiver/Devices/Tea5767/Tea5767.cs
+++ b/src/devices/RadioReceiver/Devices/Tea5767/Tea5767.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/RadioReceiver/RadioReceiverBase.cs
+++ b/src/devices/RadioReceiver/RadioReceiverBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using UnitsNet;

--- a/src/devices/RadioReceiver/samples/Program.cs
+++ b/src/devices/RadioReceiver/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/RadioTransmitter/Devices/Kt0803/BassBoost.cs
+++ b/src/devices/RadioTransmitter/Devices/Kt0803/BassBoost.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.RadioTransmitter
 {

--- a/src/devices/RadioTransmitter/Devices/Kt0803/Kt0803.cs
+++ b/src/devices/RadioTransmitter/Devices/Kt0803/Kt0803.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/RadioTransmitter/Devices/Kt0803/PgaGain.cs
+++ b/src/devices/RadioTransmitter/Devices/Kt0803/PgaGain.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.RadioTransmitter
 {

--- a/src/devices/RadioTransmitter/Devices/Kt0803/Region.cs
+++ b/src/devices/RadioTransmitter/Devices/Kt0803/Region.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.RadioTransmitter
 {

--- a/src/devices/RadioTransmitter/Devices/Kt0803/Register.cs
+++ b/src/devices/RadioTransmitter/Devices/Kt0803/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.RadioTransmitter
 {

--- a/src/devices/RadioTransmitter/Devices/Kt0803/TransmissionPower.cs
+++ b/src/devices/RadioTransmitter/Devices/Kt0803/TransmissionPower.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.RadioTransmitter
 {

--- a/src/devices/RadioTransmitter/RadioTransmitterBase.cs
+++ b/src/devices/RadioTransmitter/RadioTransmitterBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/RadioTransmitter/samples/Program.cs
+++ b/src/devices/RadioTransmitter/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Rtc/Devices/Ds1307/Ds1307.cs
+++ b/src/devices/Rtc/Devices/Ds1307/Ds1307.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Rtc/Devices/Ds1307/Ds1307Register.cs
+++ b/src/devices/Rtc/Devices/Ds1307/Ds1307Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Rtc
 {

--- a/src/devices/Rtc/Devices/Ds3231/Ds3231.cs
+++ b/src/devices/Rtc/Devices/Ds3231/Ds3231.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Rtc/Devices/Ds3231/Ds3231Register.cs
+++ b/src/devices/Rtc/Devices/Ds3231/Ds3231Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Rtc
 {

--- a/src/devices/Rtc/Devices/Pcf8563/Pcf8563.cs
+++ b/src/devices/Rtc/Devices/Pcf8563/Pcf8563.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Rtc/Devices/Pcf8563/Pcf8563Register.cs
+++ b/src/devices/Rtc/Devices/Pcf8563/Pcf8563Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Rtc
 {

--- a/src/devices/Rtc/RtcBase.cs
+++ b/src/devices/Rtc/RtcBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Seesaw/SeesawAdc.cs
+++ b/src/devices/Seesaw/SeesawAdc.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Seesaw/SeesawBase.cs
+++ b/src/devices/Seesaw/SeesawBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Seesaw/SeesawEeprom.cs
+++ b/src/devices/Seesaw/SeesawEeprom.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Seesaw/SeesawGpio.cs
+++ b/src/devices/Seesaw/SeesawGpio.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Seesaw/SeesawGpioDriver.cs
+++ b/src/devices/Seesaw/SeesawGpioDriver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Seesaw/SeesawModules.cs
+++ b/src/devices/Seesaw/SeesawModules.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Seesaw/SeesawTouch.cs
+++ b/src/devices/Seesaw/SeesawTouch.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Seesaw/samples/Seesaw.Sample.BlinkingLights.cs
+++ b/src/devices/Seesaw/samples/Seesaw.Sample.BlinkingLights.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Seesaw/samples/Seesaw.Sample.Capabilities.cs
+++ b/src/devices/Seesaw/samples/Seesaw.Sample.Capabilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Seesaw/samples/Seesaw.Sample.SoilSensor.cs
+++ b/src/devices/Seesaw/samples/Seesaw.Sample.SoilSensor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Seesaw/samples/Volume.cs
+++ b/src/devices/Seesaw/samples/Volume.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Seesaw;

--- a/src/devices/SenseHat/SenseHat.cs
+++ b/src/devices/SenseHat/SenseHat.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Drawing;

--- a/src/devices/SenseHat/SenseHatAccelerometerAndGyroscope.cs
+++ b/src/devices/SenseHat/SenseHatAccelerometerAndGyroscope.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 using Iot.Device.Lsm9Ds1;

--- a/src/devices/SenseHat/SenseHatJoystick.cs
+++ b/src/devices/SenseHat/SenseHatJoystick.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/SenseHat/SenseHatLedMatrix.cs
+++ b/src/devices/SenseHat/SenseHatLedMatrix.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/SenseHat/SenseHatLedMatrixI2c.cs
+++ b/src/devices/SenseHat/SenseHatLedMatrixI2c.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/SenseHat/SenseHatLedMatrixSysFs.cs
+++ b/src/devices/SenseHat/SenseHatLedMatrixSysFs.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/SenseHat/SenseHatMagnetometer.cs
+++ b/src/devices/SenseHat/SenseHatMagnetometer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 using Iot.Device.Lsm9Ds1;

--- a/src/devices/SenseHat/SenseHatPressureAndTemperature.cs
+++ b/src/devices/SenseHat/SenseHatPressureAndTemperature.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 

--- a/src/devices/SenseHat/SenseHatTemperatureAndHumidity.cs
+++ b/src/devices/SenseHat/SenseHatTemperatureAndHumidity.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 

--- a/src/devices/SenseHat/samples/AccelerometerAndGyroscope.Sample.cs
+++ b/src/devices/SenseHat/samples/AccelerometerAndGyroscope.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/SenseHat/samples/Joystick.Sample.cs
+++ b/src/devices/SenseHat/samples/Joystick.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/SenseHat/samples/LedMatrix.Sample.cs
+++ b/src/devices/SenseHat/samples/LedMatrix.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/SenseHat/samples/Magnetometer.Sample.cs
+++ b/src/devices/SenseHat/samples/Magnetometer.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Numerics;

--- a/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
+++ b/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/SenseHat/samples/SenseHat.Sample.cs
+++ b/src/devices/SenseHat/samples/SenseHat.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Drawing;

--- a/src/devices/SenseHat/samples/TemperatureAndHumidity.Sample.cs
+++ b/src/devices/SenseHat/samples/TemperatureAndHumidity.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/ServoMotor/ServoMotor.cs
+++ b/src/devices/ServoMotor/ServoMotor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Pwm;

--- a/src/devices/ServoMotor/samples/ServoMotor.Sample.cs
+++ b/src/devices/ServoMotor/samples/ServoMotor.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Pwm;

--- a/src/devices/ServoMotor/tests/ServoMotorTests.cs
+++ b/src/devices/ServoMotor/tests/ServoMotorTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Pwm;

--- a/src/devices/Sht3x/I2cAddress.cs
+++ b/src/devices/Sht3x/I2cAddress.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Sht3x
 {

--- a/src/devices/Sht3x/Register.cs
+++ b/src/devices/Sht3x/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Sht3x
 {

--- a/src/devices/Sht3x/Resolution.cs
+++ b/src/devices/Sht3x/Resolution.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Sht3x
 {

--- a/src/devices/Sht3x/Sht3x.cs
+++ b/src/devices/Sht3x/Sht3x.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Sht3x/samples/Program.cs
+++ b/src/devices/Sht3x/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Shtc3/Register.cs
+++ b/src/devices/Shtc3/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Shtc3
 {

--- a/src/devices/Shtc3/Shtc3.cs
+++ b/src/devices/Shtc3/Shtc3.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Shtc3/Status.cs
+++ b/src/devices/Shtc3/Status.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Shtc3
 {

--- a/src/devices/Shtc3/samples/Program.cs
+++ b/src/devices/Shtc3/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Si7021/Register.cs
+++ b/src/devices/Si7021/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Si7021
 {

--- a/src/devices/Si7021/Resolution.cs
+++ b/src/devices/Si7021/Resolution.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Si7021
 {

--- a/src/devices/Si7021/Si7021.cs
+++ b/src/devices/Si7021/Si7021.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Si7021/samples/Program.cs
+++ b/src/devices/Si7021/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/SocketCan/CanFlags.cs
+++ b/src/devices/SocketCan/CanFlags.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/SocketCan/CanFrame.cs
+++ b/src/devices/SocketCan/CanFrame.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/SocketCan/CanId.cs
+++ b/src/devices/SocketCan/CanId.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/SocketCan/CanRaw.cs
+++ b/src/devices/SocketCan/CanRaw.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/devices/SocketCan/Interop.cs
+++ b/src/devices/SocketCan/Interop.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/devices/SocketCan/SafeCanRawSocketHandle.cs
+++ b/src/devices/SocketCan/SafeCanRawSocketHandle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/SocketCan/samples/SocketCan.Sample.cs
+++ b/src/devices/SocketCan/samples/SocketCan.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/SoftPwm/SoftwarePwmChannel.cs
+++ b/src/devices/SoftPwm/SoftwarePwmChannel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/SoftPwm/samples/SoftPwm.sample.cs
+++ b/src/devices/SoftPwm/samples/SoftPwm.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Pwm.Drivers;

--- a/src/devices/SoftwareSpi/SoftwareSpi.cs
+++ b/src/devices/SoftwareSpi/SoftwareSpi.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/Ssd1351/Ssd1351.cs
+++ b/src/devices/Ssd1351/Ssd1351.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Ssd1351/Ssd1351Commands.cs
+++ b/src/devices/Ssd1351/Ssd1351Commands.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Drawing;

--- a/src/devices/Ssd1351/Ssd1351Imaging.cs
+++ b/src/devices/Ssd1351/Ssd1351Imaging.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Drawing;

--- a/src/devices/Ssd1351/samples/Ssd1351.Sample.cs
+++ b/src/devices/Ssd1351/samples/Ssd1351.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 using System.Drawing;

--- a/src/devices/Ssd13xx/Commands/ActivateScroll.cs
+++ b/src/devices/Ssd13xx/Commands/ActivateScroll.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands
 {

--- a/src/devices/Ssd13xx/Commands/DeactivateScroll.cs
+++ b/src/devices/Ssd13xx/Commands/DeactivateScroll.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands
 {

--- a/src/devices/Ssd13xx/Commands/ICommand.cs
+++ b/src/devices/Ssd13xx/Commands/ICommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands
 {

--- a/src/devices/Ssd13xx/Commands/ISharedCommand.cs
+++ b/src/devices/Ssd13xx/Commands/ISharedCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands
 {

--- a/src/devices/Ssd13xx/Commands/ISsd1306Command.cs
+++ b/src/devices/Ssd13xx/Commands/ISsd1306Command.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands
 {

--- a/src/devices/Ssd13xx/Commands/ISsd1327Command.cs
+++ b/src/devices/Ssd13xx/Commands/ISsd1327Command.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands
 {

--- a/src/devices/Ssd13xx/Commands/SetContrastControlForBank0.cs
+++ b/src/devices/Ssd13xx/Commands/SetContrastControlForBank0.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands
 {

--- a/src/devices/Ssd13xx/Commands/SetDisplayOff.cs
+++ b/src/devices/Ssd13xx/Commands/SetDisplayOff.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands
 {

--- a/src/devices/Ssd13xx/Commands/SetDisplayOn.cs
+++ b/src/devices/Ssd13xx/Commands/SetDisplayOn.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands
 {

--- a/src/devices/Ssd13xx/Commands/SetInverseDisplay.cs
+++ b/src/devices/Ssd13xx/Commands/SetInverseDisplay.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands
 {

--- a/src/devices/Ssd13xx/Commands/SetMultiplexRatio.cs
+++ b/src/devices/Ssd13xx/Commands/SetMultiplexRatio.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/ContinuousVerticalAndHorizontalScrollSetup.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/ContinuousVerticalAndHorizontalScrollSetup.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/EntireDisplayOn.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/EntireDisplayOn.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/HorizontalScrollSetup.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/HorizontalScrollSetup.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/NoOperation.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/NoOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetChargePump.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetChargePump.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetColumnAddress.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetColumnAddress.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetComOutputScanDirection.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetComOutputScanDirection.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetComPinsHardwareConfiguration.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetComPinsHardwareConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetDisplayClockDivideRatioOscillatorFrequency.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetDisplayClockDivideRatioOscillatorFrequency.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetDisplayOffset.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetDisplayOffset.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetDisplayStartLine.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetDisplayStartLine.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetHigherColumnStartAddressForPageAddressingMode.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetHigherColumnStartAddressForPageAddressingMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetLowerColumnStartAddressForPageAddressingMode.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetLowerColumnStartAddressForPageAddressingMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetMemoryAddressingMode.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetMemoryAddressingMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetNormalDisplay.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetNormalDisplay.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetPageAddress.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetPageAddress.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetPageStartAddressForPageAddressingMode.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetPageStartAddressForPageAddressingMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetPreChargePeriod.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetPreChargePeriod.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetSegmentReMap.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetSegmentReMap.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetVcomhDeselectLevel.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetVcomhDeselectLevel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1306Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetVerticalScrollArea.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1306Commands/SetVerticalScrollArea.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SelectDefaultLinearGrayScaleTable.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SelectDefaultLinearGrayScaleTable.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetColumnAddress.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetColumnAddress.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetComDeselectVoltageLevel.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetComDeselectVoltageLevel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetDisplayClockDivideRatioOscillatorFrequency.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetDisplayClockDivideRatioOscillatorFrequency.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetDisplayOffset.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetDisplayOffset.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetDisplayStartLine.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetDisplayStartLine.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetInternalVddRegulator.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetInternalVddRegulator.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetNormalDisplay.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetNormalDisplay.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1327Commands
 {

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetPhaseLength.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetPhaseLength.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetPreChargeVoltage.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetPreChargeVoltage.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetReMap.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetReMap.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetRowAddress.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetRowAddress.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetSecondPreChargePeriod.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetSecondPreChargePeriod.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetSecondPreChargeVsl.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetSecondPreChargeVsl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetUnlockDriver.cs
+++ b/src/devices/Ssd13xx/Commands/Ssd1327Commands/SetUnlockDriver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Ssd13xx.Commands.Ssd1327Commands
 {

--- a/src/devices/Ssd13xx/Ssd1306.cs
+++ b/src/devices/Ssd13xx/Ssd1306.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Ssd13xx/Ssd1327.cs
+++ b/src/devices/Ssd13xx/Ssd1327.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Ssd13xx/Ssd13xx.cs
+++ b/src/devices/Ssd13xx/Ssd13xx.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Ssd13xx/samples/BasicFont.cs
+++ b/src/devices/Ssd13xx/samples/BasicFont.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/devices/Ssd13xx/samples/Ssd13xx.Sample.cs
+++ b/src/devices/Ssd13xx/samples/Ssd13xx.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Ssd13xx/tests/Commands/ActivateScrollTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/ActivateScrollTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Xunit;

--- a/src/devices/Ssd13xx/tests/Commands/ContinuousVerticalAndHorizontalScrollSetupTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/ContinuousVerticalAndHorizontalScrollSetupTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Commands.Ssd1306Commands;

--- a/src/devices/Ssd13xx/tests/Commands/DeactivateScrollTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/DeactivateScrollTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Xunit;

--- a/src/devices/Ssd13xx/tests/Commands/EntireDisplayOnTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/EntireDisplayOnTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Commands.Ssd1306Commands;

--- a/src/devices/Ssd13xx/tests/Commands/HorizontalScrollSetupTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/HorizontalScrollSetupTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Commands.Ssd1306Commands;

--- a/src/devices/Ssd13xx/tests/Commands/NoOperationTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/NoOperationTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Commands.Ssd1306Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetChargePumpTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetChargePumpTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Commands.Ssd1306Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetColumnAddressTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetColumnAddressTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/devices/Ssd13xx/tests/Commands/SetComOutputScanDirectionTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetComOutputScanDirectionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Commands.Ssd1306Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetComPinsHardwareConfigurationTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetComPinsHardwareConfigurationTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Commands.Ssd1306Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetContrastControlForBank0Tests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetContrastControlForBank0Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Xunit;

--- a/src/devices/Ssd13xx/tests/Commands/SetDisplayClockDivideRatioOscillatorFrequencyTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetDisplayClockDivideRatioOscillatorFrequencyTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/devices/Ssd13xx/tests/Commands/SetDisplayOffTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetDisplayOffTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Xunit;

--- a/src/devices/Ssd13xx/tests/Commands/SetDisplayOffsetTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetDisplayOffsetTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Ssd13xx.Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetDisplayOnTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetDisplayOnTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Xunit;

--- a/src/devices/Ssd13xx/tests/Commands/SetDisplayStartLineTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetDisplayStartLineTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Ssd13xx.Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetHigherColumnStartAddressForPageAddressingModeTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetHigherColumnStartAddressForPageAddressingModeTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Ssd13xx.Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetInverseDisplayTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetInverseDisplayTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Xunit;

--- a/src/devices/Ssd13xx/tests/Commands/SetLowerColumnStartAddressForPageAddressingModeTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetLowerColumnStartAddressForPageAddressingModeTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Ssd13xx.Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetMemoryAddressingModeTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetMemoryAddressingModeTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Ssd13xx.Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetMultiplexRatioTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetMultiplexRatioTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Ssd13xx.Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetNormalDisplayTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetNormalDisplayTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Commands.Ssd1306Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetPageAddressTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetPageAddressTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Ssd13xx.Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetPageStartAddressForPageAddressingModeTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetPageStartAddressForPageAddressingModeTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Ssd13xx.Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetPreChargePeriodTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetPreChargePeriodTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Ssd13xx.Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetSegmentReMapTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetSegmentReMapTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Commands.Ssd1306Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetVcomhDeselectLevelTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetVcomhDeselectLevelTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Commands.Ssd1306Commands;

--- a/src/devices/Ssd13xx/tests/Commands/SetVerticalScrollAreaTests.cs
+++ b/src/devices/Ssd13xx/tests/Commands/SetVerticalScrollAreaTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Ssd13xx.Commands;

--- a/src/devices/Tcs3472x/Gain.cs
+++ b/src/devices/Tcs3472x/Gain.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Tcs3472x
 {

--- a/src/devices/Tcs3472x/InterruptState.cs
+++ b/src/devices/Tcs3472x/InterruptState.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Tcs3472x
 {

--- a/src/devices/Tcs3472x/Registers.cs
+++ b/src/devices/Tcs3472x/Registers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Tcs3472x/TCS3472Type.cs
+++ b/src/devices/Tcs3472x/TCS3472Type.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Tcs3472x
 {

--- a/src/devices/Tcs3472x/Tcs3472x.cs
+++ b/src/devices/Tcs3472x/Tcs3472x.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/Tcs3472x/samples/Tcs3472x.sample.cs
+++ b/src/devices/Tcs3472x/samples/Tcs3472x.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Tm1637/Character.cs
+++ b/src/devices/Tm1637/Character.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Tm1637/DataCommand.cs
+++ b/src/devices/Tm1637/DataCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Tm1637/DisplayCommand.cs
+++ b/src/devices/Tm1637/DisplayCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Tm1637/Tm1637.cs
+++ b/src/devices/Tm1637/Tm1637.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device;

--- a/src/devices/Tm1637/samples/Tm1637.sample.cs
+++ b/src/devices/Tm1637/samples/Tm1637.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/devices/UFireIse/Command.cs
+++ b/src/devices/UFireIse/Command.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.UFire
 {

--- a/src/devices/UFireIse/Register.cs
+++ b/src/devices/UFireIse/Register.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.UFire
 {

--- a/src/devices/UFireIse/UFireIse.cs
+++ b/src/devices/UFireIse/UFireIse.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the.NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device;

--- a/src/devices/UFireIse/UFireOrp.cs
+++ b/src/devices/UFireIse/UFireOrp.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the.NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.I2c;
 using UnitsNet;

--- a/src/devices/UFireIse/UFirePh.cs
+++ b/src/devices/UFireIse/UFirePh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/UFireIse/samples/UFireIse.Sample.cs
+++ b/src/devices/UFireIse/samples/UFireIse.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Uln2003/samples/Uln2003.Sample.cs
+++ b/src/devices/Uln2003/samples/Uln2003.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Iot.Device.Uln2003;

--- a/src/devices/Vl53L0X/InfoDevice.cs
+++ b/src/devices/Vl53L0X/InfoDevice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Vl53L0X
 {

--- a/src/devices/Vl53L0X/Information.cs
+++ b/src/devices/Vl53L0X/Information.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Vl53L0X/MeasurementMode.cs
+++ b/src/devices/Vl53L0X/MeasurementMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Vl53L0X
 {

--- a/src/devices/Vl53L0X/OperationRange.cs
+++ b/src/devices/Vl53L0X/OperationRange.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Vl53L0X
 {

--- a/src/devices/Vl53L0X/PeriodPulse.cs
+++ b/src/devices/Vl53L0X/PeriodPulse.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Vl53L0X
 {

--- a/src/devices/Vl53L0X/Precision.cs
+++ b/src/devices/Vl53L0X/Precision.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Vl53L0X
 {

--- a/src/devices/Vl53L0X/Registers.cs
+++ b/src/devices/Vl53L0X/Registers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Vl53L0X
 {

--- a/src/devices/Vl53L0X/SquadInfo.cs
+++ b/src/devices/Vl53L0X/SquadInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Vl53L0X
 {

--- a/src/devices/Vl53L0X/StepEnables.cs
+++ b/src/devices/Vl53L0X/StepEnables.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Vl53L0X
 {

--- a/src/devices/Vl53L0X/StepTimeouts.cs
+++ b/src/devices/Vl53L0X/StepTimeouts.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/Vl53L0X/VcselType.cs
+++ b/src/devices/Vl53L0X/VcselType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.Vl53L0X
 {

--- a/src/devices/Vl53L0X/Vl53L0X.cs
+++ b/src/devices/Vl53L0X/Vl53L0X.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // This code has been ported from the Dexter Industries Python code
 // https://github.com/DexterInd/DI_Sensors/blob/master/Python/di_sensors/VL53L0X.py

--- a/src/devices/Vl53L0X/samples/Vl53L0X.sample.cs
+++ b/src/devices/Vl53L0X/samples/Vl53L0X.sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/src/devices/Ws28xx/BitmapImageNeo3.cs
+++ b/src/devices/Ws28xx/BitmapImageNeo3.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Drawing;
 using Iot.Device.Graphics;

--- a/src/devices/Ws28xx/BitmapImageWs2808.cs
+++ b/src/devices/Ws28xx/BitmapImageWs2808.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Drawing;
 using Iot.Device.Graphics;

--- a/src/devices/Ws28xx/Ws2808.cs
+++ b/src/devices/Ws28xx/Ws2808.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 

--- a/src/devices/Ws28xx/Ws2812B.cs
+++ b/src/devices/Ws28xx/Ws2812B.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 

--- a/src/devices/Ws28xx/Ws28xx.cs
+++ b/src/devices/Ws28xx/Ws28xx.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 using Iot.Device.Graphics;

--- a/src/devices/Ws28xx/samples/Ws28xx.Sample.cs
+++ b/src/devices/Ws28xx/samples/Ws28xx.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/tools/DevicesApiTester/Commands/Gpio/GpioBlinkLed.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioBlinkLed.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/tools/DevicesApiTester/Commands/Gpio/GpioButtonEvent.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioButtonEvent.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/tools/DevicesApiTester/Commands/Gpio/GpioButtonWait.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioButtonWait.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/tools/DevicesApiTester/Commands/Gpio/GpioCommand.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 using CommandLine;

--- a/tools/DevicesApiTester/Commands/Gpio/GpioDriverType.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioDriverType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio.Drivers;
 using DeviceApiTester.Infrastructure;

--- a/tools/DevicesApiTester/Commands/Gpio/GpioReadPin.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioReadPin.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/tools/DevicesApiTester/Commands/Gpio/GpioWritePin.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioWritePin.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/tools/DevicesApiTester/Commands/I2c/I2cCommand.cs
+++ b/tools/DevicesApiTester/Commands/I2c/I2cCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using CommandLine;
 using DeviceApiTester.Infrastructure;

--- a/tools/DevicesApiTester/Commands/I2c/I2cDetect.cs
+++ b/tools/DevicesApiTester/Commands/I2c/I2cDetect.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/tools/DevicesApiTester/Commands/I2c/I2cDump.cs
+++ b/tools/DevicesApiTester/Commands/I2c/I2cDump.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/tools/DevicesApiTester/Commands/I2c/I2cReadBytes.cs
+++ b/tools/DevicesApiTester/Commands/I2c/I2cReadBytes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/tools/DevicesApiTester/Commands/I2c/I2cWriteBytes.cs
+++ b/tools/DevicesApiTester/Commands/I2c/I2cWriteBytes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/tools/DevicesApiTester/Commands/I2c/I2cWriteRandomBytes.cs
+++ b/tools/DevicesApiTester/Commands/I2c/I2cWriteRandomBytes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.I2c;

--- a/tools/DevicesApiTester/Commands/Pwm/PwmCommand.cs
+++ b/tools/DevicesApiTester/Commands/Pwm/PwmCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Pwm;
 using CommandLine;

--- a/tools/DevicesApiTester/Commands/Pwm/PwmPinOutput.cs
+++ b/tools/DevicesApiTester/Commands/Pwm/PwmPinOutput.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/tools/DevicesApiTester/Commands/Script/ScriptRun.cs
+++ b/tools/DevicesApiTester/Commands/Script/ScriptRun.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/tools/DevicesApiTester/Commands/Spi/ReadBytes.cs
+++ b/tools/DevicesApiTester/Commands/Spi/ReadBytes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/tools/DevicesApiTester/Commands/Spi/SpiCommand.cs
+++ b/tools/DevicesApiTester/Commands/Spi/SpiCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Spi;
 using CommandLine;

--- a/tools/DevicesApiTester/Commands/Spi/SpiWriteBytes.cs
+++ b/tools/DevicesApiTester/Commands/Spi/SpiWriteBytes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/tools/DevicesApiTester/Commands/Spi/WriteRandomBytes.cs
+++ b/tools/DevicesApiTester/Commands/Spi/WriteRandomBytes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Spi;

--- a/tools/DevicesApiTester/Infrastructure/CommandLineProgram.cs
+++ b/tools/DevicesApiTester/Infrastructure/CommandLineProgram.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/tools/DevicesApiTester/Infrastructure/DebuggableCommand.cs
+++ b/tools/DevicesApiTester/Infrastructure/DebuggableCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using CommandLine;
 

--- a/tools/DevicesApiTester/Infrastructure/DriverFactory.cs
+++ b/tools/DevicesApiTester/Infrastructure/DriverFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/tools/DevicesApiTester/Infrastructure/HexStringUtilities.cs
+++ b/tools/DevicesApiTester/Infrastructure/HexStringUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/tools/DevicesApiTester/Infrastructure/ICommandVerb.cs
+++ b/tools/DevicesApiTester/Infrastructure/ICommandVerb.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace DeviceApiTester.Infrastructure
 {

--- a/tools/DevicesApiTester/Infrastructure/ICommandVerbAsync.cs
+++ b/tools/DevicesApiTester/Infrastructure/ICommandVerbAsync.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 

--- a/tools/DevicesApiTester/Infrastructure/ImplementationTypeAttribute.cs
+++ b/tools/DevicesApiTester/Infrastructure/ImplementationTypeAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/tools/device-listing/DeviceInfo.cs
+++ b/tools/device-listing/DeviceInfo.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/tools/device-listing/device-listing.cs
+++ b/tools/device-listing/device-listing.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.cs
+++ b/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/samples/_DeviceBinding.Sample.cs
+++ b/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/samples/_DeviceBinding.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/tests/_DeviceBindingTests.cs
+++ b/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/tests/_DeviceBindingTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 


### PR DESCRIPTION
- We decided that a two line scheme is better.
- It is simply a simplification. It has no actual or intended legal meaning/change.
- Same as https://github.com/dotnet/runtime/pull/38793