### PR TITLE
Sense HAT sample: Fixed bad format exceptions, net5.0

### DIFF
--- a/src/devices/SenseHat/samples/SenseHat.Sample.cs
+++ b/src/devices/SenseHat/samples/SenseHat.Sample.cs
@@ -57,12 +57,12 @@ namespace Iot.Device.SenseHat.Samples
 
                     Console.WriteLine($"Temperature Sensor 1: {tempValue.DegreesCelsius:0.#}\u00B0C");
                     Console.WriteLine($"Temperature Sensor 2: {temp2Value.DegreesCelsius:0.#}\u00B0C");
-                    Console.WriteLine($"Pressure: {preValue:0.##}hPa");
-                    Console.WriteLine($"Altitude: {altValue:0.##}m");
-                    Console.WriteLine($"Acceleration: {sh.Acceleration}g");
-                    Console.WriteLine($"Angular rate: {sh.AngularRate}DPS");
-                    Console.WriteLine($"Magnetic induction: {sh.MagneticInduction}gauss");
-                    Console.WriteLine($"Relative humidity: {humValue:0.#}%");
+                    Console.WriteLine($"Pressure: {preValue}");
+                    Console.WriteLine($"Altitude: {altValue}");
+                    Console.WriteLine($"Acceleration: {sh.Acceleration}");
+                    Console.WriteLine($"Angular rate: {sh.AngularRate}");
+                    Console.WriteLine($"Magnetic induction: {sh.MagneticInduction}");
+                    Console.WriteLine($"Relative humidity: {humValue}");
 
                     // WeatherHelper supports more calculations, such as saturated vapor pressure, actual vapor pressure and absolute humidity.
                     Console.WriteLine($"Heat index: {WeatherHelper.CalculateHeatIndex(tempValue, humValue).DegreesCelsius:0.#}\u00B0C");

--- a/src/devices/SenseHat/samples/SenseHat.Samples.csproj
+++ b/src/devices/SenseHat/samples/SenseHat.Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I'm finally putting together an IoT docset that can go out with the rest of the .NET 5 docs. As part of that, I'm going write do a quickstart that gives the user a one-line script that installs .NET on the Pi, clones this repo, and then builds/runs the Sense HAT sample. 

As part of that, I:

* Fixed the broken sample
* Bumped the framework to `net5.0`.
