### PR TITLE
Unseal GpioController

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
@@ -1,0 +1,307 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Iot.Device.Mcp25xxx.Register.MessageReceive;
+using Moq;
+using Xunit;
+
+namespace System.Device.Gpio.Tests
+{
+    public class GpioControllerSoftwareTests : IDisposable
+    {
+        private Mock<MockableGpioDriver> _mockedGpioDriver;
+
+        public GpioControllerSoftwareTests()
+        {
+            _mockedGpioDriver = new Mock<MockableGpioDriver>(MockBehavior.Default);
+            _mockedGpioDriver.CallBase = true;
+        }
+
+        public void Dispose()
+        {
+            _mockedGpioDriver.VerifyAll();
+        }
+
+        [Fact]
+        public void PinCountReportedCorrectly()
+        {
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            Assert.Equal(28, ctrl.PinCount);
+        }
+
+        [Fact]
+        public void OpenTwiceThrows()
+        {
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
+            ctrl.OpenPin(1);
+            Assert.Throws<InvalidOperationException>(() => ctrl.OpenPin(1));
+            ctrl.ClosePin(1);
+            Assert.Throws<InvalidOperationException>(() => ctrl.ClosePin(1));
+        }
+
+        [Fact]
+        public void WriteInputPinThrows()
+        {
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, It.IsAny<PinMode>())).Returns(true);
+            _mockedGpioDriver.Setup(x => x.SetPinModeEx(1, It.IsAny<PinMode>()));
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Input);
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+
+            ctrl.OpenPin(1, PinMode.Input);
+            Assert.Throws<InvalidOperationException>(() => ctrl.Write(1, PinValue.High));
+        }
+
+        [Fact]
+        public void GpioControllerCreateOpenClosePin()
+        {
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
+            _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
+            _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            Assert.NotNull(ctrl);
+            ctrl.OpenPin(1, PinMode.Output);
+            Assert.True(ctrl.IsPinOpen(1));
+            ctrl.Write(1, PinValue.High);
+            ctrl.ClosePin(1);
+            Assert.False(ctrl.IsPinOpen(1));
+        }
+
+        [Fact]
+        public void IsPinModeSupported()
+        {
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Input)).Returns(true);
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            Assert.NotNull(ctrl);
+            Assert.True(ctrl.IsPinModeSupported(1, PinMode.Input));
+        }
+
+        [Fact]
+        public void GetPinMode()
+        {
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            Assert.NotNull(ctrl);
+            // Not open
+            Assert.Throws<InvalidOperationException>(() => ctrl.GetPinMode(1));
+            ctrl.OpenPin(1);
+            Assert.Equal(PinMode.Output, ctrl.GetPinMode(1));
+        }
+
+        [Fact]
+        public void UsingBoardNumberingWorks()
+        {
+            // Our mock driver maps physical pin 2 to logical pin 1
+            _mockedGpioDriver.Setup(x => x.ConvertPinNumberToLogicalNumberingSchemeEx(2)).Returns(1);
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.SetPinModeEx(1, PinMode.Output));
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
+            _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
+            _mockedGpioDriver.Setup(x => x.ReadEx(1)).Returns(PinValue.High);
+            _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
+            var ctrl = new GpioController(PinNumberingScheme.Board, _mockedGpioDriver.Object);
+            ctrl.OpenPin(2, PinMode.Output);
+            ctrl.Write(2, PinValue.High);
+            Assert.Equal(PinValue.High, ctrl.Read(2));
+            ctrl.ClosePin(2);
+            ctrl.Dispose();
+        }
+
+        [Fact]
+        public void UsingLogicalNumberingDisposesTheRightPin()
+        {
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            ctrl.OpenPin(1, PinMode.Output);
+            ctrl.Write(1, PinValue.High);
+            // No close on the pin here, we want to check that the Controller's Dispose works correctly
+            ctrl.Dispose();
+        }
+
+        [Fact]
+        public void UsingBoardNumberingDisposesTheRightPin()
+        {
+            // Our mock driver maps physical pin 2 to logical pin 1
+            _mockedGpioDriver.Setup(x => x.ConvertPinNumberToLogicalNumberingSchemeEx(2)).Returns(1);
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.SetPinModeEx(1, PinMode.Output));
+            _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
+            var ctrl = new GpioController(PinNumberingScheme.Board, _mockedGpioDriver.Object);
+            ctrl.OpenPin(2, PinMode.Output);
+            // No close on the pin here, we want to check that the Controller's Dispose works correctly
+            ctrl.Dispose();
+        }
+
+        [Fact]
+        public void CallbackOnEventWorks()
+        {
+            // Our mock driver maps physical pin 2 to logical pin 1
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.AddCallbackForPinValueChangedEventEx(1,
+                PinEventTypes.Rising, It.IsAny<PinChangeEventHandler>()));
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            ctrl.OpenPin(1); // logical pin 1 on our test board
+            bool callbackSeen = false;
+            PinChangeEventHandler eventHandler = (sender, args) =>
+            {
+                callbackSeen = true;
+                Assert.Equal(1, args.PinNumber);
+                Assert.Equal(PinEventTypes.Falling, args.ChangeType);
+            };
+
+            ctrl.RegisterCallbackForPinValueChangedEvent(1, PinEventTypes.Rising, eventHandler);
+
+            _mockedGpioDriver.Object.FireEventHandler(1, PinEventTypes.Falling);
+
+            Assert.True(callbackSeen);
+
+            ctrl.UnregisterCallbackForPinValueChangedEvent(1, eventHandler);
+        }
+
+        [Fact]
+        public void WriteSpan()
+        {
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(2));
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(2, PinMode.Output)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(2)).Returns(PinMode.Output);
+            _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
+            _mockedGpioDriver.Setup(x => x.WriteEx(2, PinValue.Low));
+            _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
+            _mockedGpioDriver.Setup(x => x.ClosePinEx(2));
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            Assert.NotNull(ctrl);
+            ctrl.OpenPin(1, PinMode.Output);
+            ctrl.OpenPin(2, PinMode.Output);
+            Assert.True(ctrl.IsPinOpen(1));
+            Span<PinValuePair> towrite = stackalloc PinValuePair[2];
+            towrite[0] = new PinValuePair(1, PinValue.High);
+            towrite[1] = new PinValuePair(2, PinValue.Low);
+            ctrl.Write(towrite);
+            ctrl.ClosePin(1);
+            ctrl.ClosePin(2);
+            Assert.False(ctrl.IsPinOpen(1));
+        }
+
+        [Fact]
+        public void ReadSpan()
+        {
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(2));
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Input)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(2, PinMode.Input)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.ReadEx(1)).Returns(PinValue.Low);
+            _mockedGpioDriver.Setup(x => x.ReadEx(2)).Returns(PinValue.High);
+            _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
+            _mockedGpioDriver.Setup(x => x.ClosePinEx(2));
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            Assert.NotNull(ctrl);
+            ctrl.OpenPin(1, PinMode.Input);
+            ctrl.OpenPin(2, PinMode.Input);
+            Assert.True(ctrl.IsPinOpen(1));
+
+            // Invalid usage (we need to prefill the array)
+            // Was this the intended use case?
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                Span<PinValuePair> wrongArg = stackalloc PinValuePair[2];
+                ctrl.Read(wrongArg);
+            });
+
+            Span<PinValuePair> toread = stackalloc PinValuePair[2];
+            toread[0] = new PinValuePair(1, PinValue.Low);
+            toread[1] = new PinValuePair(2, PinValue.Low);
+            ctrl.Read(toread);
+            Assert.Equal(1, toread[0].PinNumber);
+            Assert.Equal(2, toread[1].PinNumber);
+            Assert.Equal(PinValue.Low, toread[0].PinValue);
+            Assert.Equal(PinValue.High, toread[1].PinValue);
+            ctrl.ClosePin(1);
+            ctrl.ClosePin(2);
+            Assert.False(ctrl.IsPinOpen(1));
+        }
+
+        [Fact]
+        public void WaitForEventAsyncFail()
+        {
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Input)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.WaitForEventEx(1, PinEventTypes.Rising | PinEventTypes.Falling, It.IsAny<CancellationToken>()))
+                .Returns(new WaitForEventResult()
+                {
+                    EventTypes = PinEventTypes.None, TimedOut = true
+                });
+            Assert.NotNull(ctrl);
+            ctrl.OpenPin(1, PinMode.Input);
+
+            var task = ctrl.WaitForEventAsync(1, PinEventTypes.Falling | PinEventTypes.Rising, TimeSpan.FromSeconds(0.01)).AsTask();
+            task.Wait(CancellationToken.None);
+            Assert.True(task.IsCompleted);
+            Assert.Null(task.Exception);
+            Assert.True(task.Result.TimedOut);
+            Assert.Equal(PinEventTypes.None, task.Result.EventTypes);
+        }
+
+        [Fact]
+        public void WaitForEventSuccess()
+        {
+            var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
+            _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+            _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Input)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.WaitForEventEx(1, PinEventTypes.Rising | PinEventTypes.Falling, It.IsAny<CancellationToken>()))
+                .Returns(new WaitForEventResult()
+                {
+                    EventTypes = PinEventTypes.Falling,
+                    TimedOut = false
+                });
+            Assert.NotNull(ctrl);
+            ctrl.OpenPin(1, PinMode.Input);
+
+            var result = ctrl.WaitForEvent(1, PinEventTypes.Falling | PinEventTypes.Rising, TimeSpan.FromSeconds(0.01));
+            Assert.False(result.TimedOut);
+            Assert.Equal(PinEventTypes.Falling, result.EventTypes);
+        }
+
+        // TODO: This is still broken. See #974
+        ////[Fact]
+        ////public void UsingBoardNumberingForCallbackWorks()
+        ////{
+        ////    // Our mock driver maps physical pin 2 to logical pin 1
+        ////    _mockedGpioDriver.Setup(x => x.ConvertPinNumberToLogicalNumberingSchemeEx(2)).Returns(1);
+        ////    _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
+        ////    _mockedGpioDriver.Setup(x => x.AddCallbackForPinValueChangedEventEx(1,
+        ////        PinEventTypes.Rising, It.IsAny<PinChangeEventHandler>()));
+        ////    var ctrl = new GpioController(PinNumberingScheme.Board, _mockedGpioDriver.Object);
+        ////    ctrl.OpenPin(2); // logical pin 1 on our test board
+        ////    bool callbackSeen = false;
+        ////    ctrl.RegisterCallbackForPinValueChangedEvent(2, PinEventTypes.Rising, (sender, args) =>
+        ////    {
+        ////        callbackSeen = true;
+        ////        Assert.Equal(2, args.PinNumber);
+        ////        Assert.Equal(PinEventTypes.Falling, args.ChangeType);
+        ////    });
+
+        ////    _mockedGpioDriver.Object.FireEventHandler(1, PinEventTypes.Falling);
+
+        ////    Assert.True(callbackSeen);
+        ////}
+
+    }
+}

--- a/src/System.Device.Gpio.Tests/MockableGpioDriver.cs
+++ b/src/System.Device.Gpio.Tests/MockableGpioDriver.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace System.Device.Gpio.Tests
+{
+    /// <summary>
+    /// A wrapper class that exposes the internal protected methods, so that they can be mocked.
+    /// Note: To provide an expectation for this mock, be sure to set the <code>Callbase</code> property to true and then
+    /// set expectations on the Ex methods. Only loose behavior works.
+    /// </summary>
+    public abstract class MockableGpioDriver : GpioDriver
+    {
+        private PinChangeEventHandler? _event;
+
+        protected override int PinCount
+        {
+            get
+            {
+                return 28;
+            }
+        }
+
+        public void FireEventHandler(int forPin, PinEventTypes eventTypes)
+        {
+            _event?.Invoke(this, new PinValueChangedEventArgs(eventTypes, forPin));
+        }
+
+        public abstract int ConvertPinNumberToLogicalNumberingSchemeEx(int pinNumber);
+
+        protected override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            return ConvertPinNumberToLogicalNumberingSchemeEx(pinNumber);
+        }
+
+        public abstract void OpenPinEx(int pinNumber);
+
+        protected override void OpenPin(int pinNumber)
+        {
+            OpenPinEx(pinNumber);
+        }
+
+        public abstract void ClosePinEx(int pinNumber);
+
+        protected override void ClosePin(int pinNumber)
+        {
+            ClosePinEx(pinNumber);
+        }
+
+        public abstract void SetPinModeEx(int pinNumber, PinMode mode);
+
+        protected override void SetPinMode(int pinNumber, PinMode mode)
+        {
+            SetPinModeEx(pinNumber, mode);
+        }
+
+        public abstract PinMode GetPinModeEx(int pinNumber);
+
+        protected override PinMode GetPinMode(int pinNumber)
+        {
+            return GetPinModeEx(pinNumber);
+        }
+
+        public abstract bool IsPinModeSupportedEx(int pinNumber, PinMode mode);
+
+        protected override bool IsPinModeSupported(int pinNumber, PinMode mode)
+        {
+            return IsPinModeSupportedEx(pinNumber, mode);
+        }
+
+        public abstract PinValue ReadEx(int pinNumber);
+
+        protected override PinValue Read(int pinNumber)
+        {
+            return ReadEx(pinNumber);
+        }
+
+        public abstract void WriteEx(int pinNumber, PinValue value);
+
+        protected override void Write(int pinNumber, PinValue value)
+        {
+            WriteEx(pinNumber, value);
+        }
+
+        public abstract WaitForEventResult WaitForEventEx(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken);
+
+        protected override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
+        {
+            return WaitForEventEx(pinNumber, eventTypes, cancellationToken);
+        }
+
+        public abstract void AddCallbackForPinValueChangedEventEx(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback);
+
+        protected override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+        {
+            _event = callback;
+            AddCallbackForPinValueChangedEventEx(pinNumber, eventTypes, callback);
+        }
+
+        public abstract void RemoveCallbackForPinValueChangedEventEx(int pinNumber, PinChangeEventHandler callback);
+
+        protected override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
+        {
+            RemoveCallbackForPinValueChangedEventEx(pinNumber, callback);
+            _event = null!;
+        }
+    }
+}

--- a/src/System.Device.Gpio.Tests/MockableGpioDriver.cs
+++ b/src/System.Device.Gpio.Tests/MockableGpioDriver.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;

--- a/src/System.Device.Gpio.Tests/PinValueTests.cs
+++ b/src/System.Device.Gpio.Tests/PinValueTests.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace System.Device.Gpio.Tests
+{
+    public class PinValueTests
+    {
+        [Fact]
+        public void VerifyConstants()
+        {
+            Assert.True(PinValue.High.Equals(1));
+            Assert.True(PinValue.Low.Equals(0));
+        }
+
+        [Fact]
+        public void VerifyEquality()
+        {
+            Assert.True(PinValue.High == 1);
+            Assert.True(PinValue.Low == 0);
+        }
+
+        [Fact]
+        public void VerifyInequality()
+        {
+            Assert.True(PinValue.High != 0);
+            Assert.True(PinValue.Low != 1);
+            Assert.True(PinValue.Low != 2);
+        }
+
+        [Fact]
+        public void Inverse()
+        {
+            Assert.Equal(PinValue.Low, !PinValue.High);
+            Assert.Equal(PinValue.High, !PinValue.Low);
+        }
+    }
+}

--- a/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
+++ b/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.14.7" />
     <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
 

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -182,7 +182,7 @@ namespace System.Device.Gpio
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <returns>The status if the pin is open or closed.</returns>
-        public virtual bool IsPinOpen(int pinNumber)
+        public bool IsPinOpen(int pinNumber)
         {
             return _openPins.Contains(pinNumber);
         }

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -77,7 +77,7 @@ namespace System.Device.Gpio
         /// <returns>The logical pin number in the controller's numbering scheme.</returns>
         protected virtual int GetLogicalPinNumber(int pinNumber, PinNumberingScheme givenScheme)
         {
-            return (NumberingScheme == PinNumberingScheme.Logical) ? pinNumber : _driver.ConvertPinNumberToLogicalNumberingScheme(pinNumber);
+            return (givenScheme == PinNumberingScheme.Logical) ? pinNumber : _driver.ConvertPinNumberToLogicalNumberingScheme(pinNumber);
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace System.Device.Gpio
             int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             if (!_openPins.Contains(logicalPinNumber))
             {
-                throw new InvalidOperationException($"Can not write to pin {logicalPinNumber} because it is not open.");
+                throw new InvalidOperationException($"Can not read from pin {logicalPinNumber} because it is not open.");
             }
 
             return _driver.Read(logicalPinNumber);

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -73,8 +73,9 @@ namespace System.Device.Gpio
         /// Gets the logical pin number in the controller's numbering scheme.
         /// </summary>
         /// <param name="pinNumber">The pin number</param>
+        /// <param name="givenScheme">The scheme for the pin number</param>
         /// <returns>The logical pin number in the controller's numbering scheme.</returns>
-        protected virtual int GetLogicalPinNumber(int pinNumber)
+        protected virtual int GetLogicalPinNumber(int pinNumber, PinNumberingScheme givenScheme)
         {
             return (NumberingScheme == PinNumberingScheme.Logical) ? pinNumber : _driver.ConvertPinNumberToLogicalNumberingScheme(pinNumber);
         }
@@ -85,7 +86,7 @@ namespace System.Device.Gpio
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         public virtual void OpenPin(int pinNumber)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             if (_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException($"Pin {logicalPinNumber} is already open.");
@@ -112,10 +113,22 @@ namespace System.Device.Gpio
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         public void ClosePin(int pinNumber)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            ClosePin(pinNumber, NumberingScheme);
+        }
+
+        /// <summary>
+        /// Closes an open pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number.</param>
+        /// <param name="numberingScheme">Numbering scheme for the given pin</param>
+        /// <remarks>Internal use, to make Dispose work consistently</remarks>
+        protected virtual void ClosePin(int pinNumber, PinNumberingScheme numberingScheme)
+        {
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, numberingScheme);
+
             if (!_openPins.Contains(logicalPinNumber))
             {
-                throw new InvalidOperationException($"Can not close pin {logicalPinNumber} because it is not open.");
+                throw new InvalidOperationException($"Can not close pin {pinNumber} because it is not open.");
             }
 
             _driver.ClosePin(logicalPinNumber);
@@ -129,7 +142,7 @@ namespace System.Device.Gpio
         /// <param name="mode">The mode to be set.</param>
         public virtual void SetPinMode(int pinNumber, PinMode mode)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException($"Can not set a mode to pin {logicalPinNumber} because it is not open.");
@@ -150,7 +163,7 @@ namespace System.Device.Gpio
         /// <returns>The mode of the pin.</returns>
         public virtual PinMode GetPinMode(int pinNumber)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException($"Can not get the mode of pin {logicalPinNumber} because it is not open.");
@@ -166,7 +179,7 @@ namespace System.Device.Gpio
         /// <returns>The status if the pin is open or closed.</returns>
         public virtual bool IsPinOpen(int pinNumber)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             return _openPins.Contains(logicalPinNumber);
         }
 
@@ -178,7 +191,7 @@ namespace System.Device.Gpio
         /// <returns>The status if the pin supports the mode.</returns>
         public virtual bool IsPinModeSupported(int pinNumber, PinMode mode)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             return _driver.IsPinModeSupported(logicalPinNumber, mode);
         }
 
@@ -189,7 +202,7 @@ namespace System.Device.Gpio
         /// <returns>The value of the pin.</returns>
         public virtual PinValue Read(int pinNumber)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException($"Can not write to pin {logicalPinNumber} because it is not open.");
@@ -205,7 +218,7 @@ namespace System.Device.Gpio
         /// <param name="value">The value to be written to the pin.</param>
         public virtual void Write(int pinNumber, PinValue value)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException($"Can not write to pin {logicalPinNumber} because it is not open.");
@@ -243,7 +256,7 @@ namespace System.Device.Gpio
         /// <returns>A structure that contains the result of the waiting operation.</returns>
         public virtual WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException($"Can not wait for events from pin {logicalPinNumber} because it is not open.");
@@ -276,7 +289,7 @@ namespace System.Device.Gpio
         /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
         public virtual ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, CancellationToken token)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException($"Can not wait for events from pin {logicalPinNumber} because it is not open.");
@@ -293,7 +306,7 @@ namespace System.Device.Gpio
         /// <param name="callback">The callback method that will be invoked.</param>
         public virtual void RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException($"Can not add callback for pin {logicalPinNumber} because it is not open.");
@@ -309,7 +322,7 @@ namespace System.Device.Gpio
         /// <param name="callback">The callback method that will be invoked.</param>
         public virtual void UnregisterCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
         {
-            int logicalPinNumber = GetLogicalPinNumber(pinNumber);
+            int logicalPinNumber = GetLogicalPinNumber(pinNumber, NumberingScheme);
             if (!_openPins.Contains(logicalPinNumber))
             {
                 throw new InvalidOperationException($"Can not remove callback for pin {logicalPinNumber} because it is not open.");
@@ -318,11 +331,17 @@ namespace System.Device.Gpio
             _driver.RemoveCallbackForPinValueChangedEvent(logicalPinNumber, callback);
         }
 
-        private void Dispose(bool disposing)
+        /// <summary>
+        /// Disposes this instance and closes all open pins associated with this controller.
+        /// </summary>
+        /// <param name="disposing">True to dispose all instances, false to dispose only unmanaged resources</param>
+        protected virtual void Dispose(bool disposing)
         {
-            foreach (int pin in _openPins)
+            var tempList = new List<int>(_openPins); // Because ClosePin modifies this list
+            foreach (int pin in tempList)
             {
-                _driver.ClosePin(pin);
+                // We need to call this special overload, because the _openPins list always contains logical numbers.
+                ClosePin(pin, PinNumberingScheme.Logical);
             }
 
             _openPins.Clear();

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -26,8 +26,8 @@ namespace System.Device.Gpio
         private const string HummingBoardProduct = "HummingBoard-Edge";
         private const string HummingBoardHardware = @"Freescale i.MX6 Quad/DualLite (Device Tree)";
 
-        private readonly GpioDriver _driver;
         private readonly HashSet<int> _openPins;
+        private GpioDriver _driver;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GpioController"/> class that will use the logical pin numbering scheme as default.
@@ -344,7 +344,8 @@ namespace System.Device.Gpio
             }
 
             _openPins.Clear();
-            _driver.Dispose();
+            _driver?.Dispose();
+            _driver = null!;
         }
 
         /// <inheritdoc/>

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -12,7 +12,7 @@ namespace System.Device.Gpio
     /// <summary>
     /// Represents a general-purpose I/O (GPIO) controller.
     /// </summary>
-    public sealed class GpioController : IDisposable
+    public class GpioController : IDisposable
     {
         // Constants used to check the hardware on linux
         private const string CpuInfoPath = "/proc/cpuinfo";
@@ -50,6 +50,16 @@ namespace System.Device.Gpio
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="GpioController"/> class that will use the specified numbering scheme.
+        /// The controller will default to use the driver that best applies given the platform the program is executing on.
+        /// </summary>
+        /// <param name="numberingScheme">The numbering scheme used to represent pins provided by the controller.</param>
+        public GpioController(PinNumberingScheme numberingScheme)
+            : this(numberingScheme, GetBestDriverForBoard())
+        {
+        }
+
+        /// <summary>
         /// The numbering scheme used to represent pins provided by the controller.
         /// </summary>
         public PinNumberingScheme NumberingScheme { get; }
@@ -57,14 +67,14 @@ namespace System.Device.Gpio
         /// <summary>
         /// The number of pins provided by the controller.
         /// </summary>
-        public int PinCount => _driver.PinCount;
+        public virtual int PinCount => _driver.PinCount;
 
         /// <summary>
         /// Gets the logical pin number in the controller's numbering scheme.
         /// </summary>
-        /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
+        /// <param name="pinNumber">The pin number</param>
         /// <returns>The logical pin number in the controller's numbering scheme.</returns>
-        private int GetLogicalPinNumber(int pinNumber)
+        protected virtual int GetLogicalPinNumber(int pinNumber)
         {
             return (NumberingScheme == PinNumberingScheme.Logical) ? pinNumber : _driver.ConvertPinNumberToLogicalNumberingScheme(pinNumber);
         }
@@ -73,7 +83,7 @@ namespace System.Device.Gpio
         /// Opens a pin in order for it to be ready to use.
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
-        public void OpenPin(int pinNumber)
+        public virtual void OpenPin(int pinNumber)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (_openPins.Contains(logicalPinNumber))
@@ -90,7 +100,7 @@ namespace System.Device.Gpio
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <param name="mode">The mode to be set.</param>
-        public void OpenPin(int pinNumber, PinMode mode)
+        public virtual void OpenPin(int pinNumber, PinMode mode)
         {
             OpenPin(pinNumber);
             SetPinMode(pinNumber, mode);
@@ -117,7 +127,7 @@ namespace System.Device.Gpio
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <param name="mode">The mode to be set.</param>
-        public void SetPinMode(int pinNumber, PinMode mode)
+        public virtual void SetPinMode(int pinNumber, PinMode mode)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
@@ -138,7 +148,7 @@ namespace System.Device.Gpio
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <returns>The mode of the pin.</returns>
-        public PinMode GetPinMode(int pinNumber)
+        public virtual PinMode GetPinMode(int pinNumber)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
@@ -154,7 +164,7 @@ namespace System.Device.Gpio
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <returns>The status if the pin is open or closed.</returns>
-        public bool IsPinOpen(int pinNumber)
+        public virtual bool IsPinOpen(int pinNumber)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             return _openPins.Contains(logicalPinNumber);
@@ -166,7 +176,7 @@ namespace System.Device.Gpio
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <param name="mode">The mode to check.</param>
         /// <returns>The status if the pin supports the mode.</returns>
-        public bool IsPinModeSupported(int pinNumber, PinMode mode)
+        public virtual bool IsPinModeSupported(int pinNumber, PinMode mode)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             return _driver.IsPinModeSupported(logicalPinNumber, mode);
@@ -177,7 +187,7 @@ namespace System.Device.Gpio
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <returns>The value of the pin.</returns>
-        public PinValue Read(int pinNumber)
+        public virtual PinValue Read(int pinNumber)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
@@ -193,7 +203,7 @@ namespace System.Device.Gpio
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <param name="value">The value to be written to the pin.</param>
-        public void Write(int pinNumber, PinValue value)
+        public virtual void Write(int pinNumber, PinValue value)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
@@ -216,7 +226,7 @@ namespace System.Device.Gpio
         /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="timeout">The time to wait for the event.</param>
         /// <returns>A structure that contains the result of the waiting operation.</returns>
-        public WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, TimeSpan timeout)
+        public virtual WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, TimeSpan timeout)
         {
             using (CancellationTokenSource tokenSource = new CancellationTokenSource(timeout))
             {
@@ -231,7 +241,7 @@ namespace System.Device.Gpio
         /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A structure that contains the result of the waiting operation.</returns>
-        public WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
+        public virtual WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
@@ -264,7 +274,7 @@ namespace System.Device.Gpio
         /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="token">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
-        public ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, CancellationToken token)
+        public virtual ValueTask<WaitForEventResult> WaitForEventAsync(int pinNumber, PinEventTypes eventTypes, CancellationToken token)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
@@ -281,7 +291,7 @@ namespace System.Device.Gpio
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <param name="eventTypes">The event types to wait for.</param>
         /// <param name="callback">The callback method that will be invoked.</param>
-        public void RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+        public virtual void RegisterCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
@@ -297,7 +307,7 @@ namespace System.Device.Gpio
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>
         /// <param name="callback">The callback method that will be invoked.</param>
-        public void UnregisterCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
+        public virtual void UnregisterCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
         {
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
             if (!_openPins.Contains(logicalPinNumber))
@@ -323,6 +333,7 @@ namespace System.Device.Gpio
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -351,16 +362,11 @@ namespace System.Device.Gpio
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="GpioController"/> class that will use the specified numbering scheme.
-        /// The controller will default to use the driver that best applies given the platform the program is executing on.
+        /// Tries to create the GPIO driver that best matches the current hardware
         /// </summary>
-        /// <param name="numberingScheme">The numbering scheme used to represent pins provided by the controller.</param>
-        public GpioController(PinNumberingScheme numberingScheme)
-            : this(numberingScheme, GetBestDriverForBoard())
-        {
-        }
-
-        private static GpioDriver GetBestDriverForBoard()
+        /// <returns>An instance of a GpioDriver that best matches the current hardware</returns>
+        /// <exception cref="PlatformNotSupportedException">No matching driver could be found</exception>
+        protected static GpioDriver GetBestDriverForBoard()
         {
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -351,7 +351,6 @@ namespace System.Device.Gpio
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         /// <summary>


### PR DESCRIPTION
As discussed in several tickets and PRs already: this unseals the GpioController and changes its public API to virtual methods. 

In addition, I fixed the PinNumberingScheme.Board use case. Now all methods do a proper translation to the logical scheme the driver is using. The bug #974 is still open, though. This requires further thought and possibly an interface change. 

Unit testing for all methods provided as well (using a bit of a hacky approach to mocking, but there's no other way given that all the methods of the GpioDriver class are internal protected). At least the MockableGpioDriver class is reusable.
