### PR TITLE
Update TFMs in samples and docs to make them consistent/correct

### DIFF
--- a/samples/serialport-arduino/README.md
+++ b/samples/serialport-arduino/README.md
@@ -61,7 +61,7 @@ edit the app and then to publish it (note: in many cases it might be easier to p
 dotnet publish
 ```
 
-publish command will produce binaries in `bin/Debug/netcoreapp3.1/linux-arm/publish`
+publish command will produce binaries in `bin/Debug/net5.0/linux-arm/publish`
 To run your app simply call it while in that directory
 
 ```

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
+++ b/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/devices/Ahtxx/Ahtxx.csproj
+++ b/src/devices/Ahtxx/Ahtxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Apa102/samples/Apa102.Samples.csproj
+++ b/src/devices/Apa102/samples/Apa102.Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Bmxx80/Bmxx80Base.cs
+++ b/src/devices/Bmxx80/Bmxx80Base.cs
@@ -83,7 +83,7 @@ namespace Iot.Device.Bmxx80
 
             ReadCalibrationData();
             Reset();
-#if NETCOREAPP2_1 || NETCOREAPP3_1
+#if NETCOREAPP2_1
             if (_calibrationData is null)
             {
                 throw new Exception("BMxx80 device is not correctly configured.");
@@ -304,7 +304,7 @@ namespace Iot.Device.Bmxx80
             BigEndian
         }
 
-#if !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP2_1
         [MemberNotNull(nameof(_calibrationData))]
 #endif
         private void ReadCalibrationData()

--- a/src/devices/Bmxx80/tests/Bmxx80.Tests.csproj
+++ b/src/devices/Bmxx80/tests/Bmxx80.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/devices/BoardLed/BoardLed.cs
+++ b/src/devices/BoardLed/BoardLed.cs
@@ -66,7 +66,7 @@ namespace Iot.Device.BoardLed
         {
             Name = name;
             Initialize();
-#if NETCOREAPP2_1 || NETCOREAPP3_1
+#if NETCOREAPP2_1
             if (_brightnessReader is null ||
                 _brightnessWriter is null ||
                 _maxBrightnessReader is null ||
@@ -145,7 +145,7 @@ namespace Iot.Device.BoardLed
             _triggerWriter.Flush();
         }
 
-#if !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP2_1
         [MemberNotNull(nameof(_brightnessReader), nameof(_brightnessWriter), nameof(_triggerReader), nameof(_triggerWriter), nameof(_maxBrightnessReader))]
 #endif
         private void Initialize()

--- a/src/devices/Card/Mifare/Mifare.csproj
+++ b/src/devices/Card/Mifare/Mifare.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Charlieplex/tests/Charlieplex.Tests.csproj
+++ b/src/devices/Charlieplex/tests/Charlieplex.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/devices/Common/tests/Common.Tests.csproj
+++ b/src/devices/Common/tests/Common.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/devices/Ft4222/Ft4222.csproj
+++ b/src/devices/Ft4222/Ft4222.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ft4222/samples/Ft4222.sample.csproj
+++ b/src/devices/Ft4222/samples/Ft4222.sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Hcsr04/Hcsr04.csproj
+++ b/src/devices/Hcsr04/Hcsr04.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Hcsr501/Hcsr501.csproj
+++ b/src/devices/Hcsr501/Hcsr501.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Hts221/Hts221.csproj
+++ b/src/devices/Hts221/Hts221.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Lps25h/Lps25h.csproj
+++ b/src/devices/Lps25h/Lps25h.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Max7219/samples/README.md
+++ b/src/devices/Max7219/samples/README.md
@@ -87,7 +87,7 @@ This example can also be cross-compiled on another machine and then executed on 
 
 * Synchronize published folder to the RaspPi via rsync over ssh
 
-        rsync -avz -e 'ssh' bin/Release/netcoreapp3.1/linux-arm/publish/  pi@192.168.1.192:/home/pi/max-sample/
+        rsync -avz -e 'ssh' bin/Release/net5.0/linux-arm/publish/  pi@192.168.1.192:/home/pi/max-sample/
 
 * Execute the program on the RaspPi or remote via SSH
 

--- a/src/devices/Mbi5027/samples/README.md
+++ b/src/devices/Mbi5027/samples/README.md
@@ -7,7 +7,7 @@ It supports GPIO and SPI. It supports daisy chaining. The test app supports up t
 The following example demonstrates the sample with the last two output not connected. They are detected as open or short, with a `Low` reading.
 
 ```console
-pi@raspberrypineapple:~/iot/src/devices/Mbi5027/samples $ ./bin/Debug/netcoreapp3.1/linux-arm/Mbi5027-driver
+pi@raspberrypineapple:~/iot/src/devices/Mbi5027/samples $ ./bin/Debug/net5.0/linux-arm/Mbi5027-driver
 Driver for Mbi5027
 Register bit length: 16
 Checking circuit

--- a/src/devices/Mcp23xxx/tests/Mcp23xxx.Tests.csproj
+++ b/src/devices/Mcp23xxx/tests/Mcp23xxx.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/devices/Mcp25xxx/tests/Mcp25xxx.Tests.csproj
+++ b/src/devices/Mcp25xxx/tests/Mcp25xxx.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/devices/Mpu9250/Mpu9250.csproj
+++ b/src/devices/Mpu9250/Mpu9250.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\Ak8963\Ak8963.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
 

--- a/src/devices/Nrf24l01/Nrf24l01.cs
+++ b/src/devices/Nrf24l01/Nrf24l01.cs
@@ -159,7 +159,7 @@ namespace Iot.Device.Nrf24l01
 
             Initialize(pinNumberingScheme, outputPower, dataRate, channel, gpioController);
             InitializePipe();
-#if NETCOREAPP2_1 || NETCOREAPP3_1
+#if NETCOREAPP2_1
             if (_gpio is null ||
                 Pipe0 is null ||
                 Pipe1 is null ||
@@ -260,7 +260,7 @@ namespace Iot.Device.Nrf24l01
         /// <summary>
         /// Initialize
         /// </summary>
-#if !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP2_1
         [MemberNotNull(nameof(_gpio))]
 #endif
         private void Initialize(PinNumberingScheme pinNumberingScheme, OutputPower outputPower, DataRate dataRate, byte channel, GpioController? gpioController)
@@ -292,7 +292,7 @@ namespace Iot.Device.Nrf24l01
         /// <summary>
         /// Initialize nRF24L01 Pipe
         /// </summary>
-#if !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP2_1
         [MemberNotNull(nameof(Pipe0), nameof(Pipe0), nameof(Pipe1), nameof(Pipe2), nameof(Pipe3), nameof(Pipe4), nameof(Pipe5))]
 #endif
         private void InitializePipe()

--- a/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
+++ b/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
+++ b/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/ServoMotor/tests/ServoMotor.Tests.csproj
+++ b/src/devices/ServoMotor/tests/ServoMotor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/devices/Shtc3/Shtc3.csproj
+++ b/src/devices/Shtc3/Shtc3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Ssd13xx/tests/Ssd13xx.Tests.csproj
+++ b/src/devices/Ssd13xx/tests/Ssd13xx.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/devices/Vl53L0X/Vl53L0X.cs
+++ b/src/devices/Vl53L0X/Vl53L0X.cs
@@ -77,7 +77,7 @@ namespace Iot.Device.Vl53L0X
             MaxTryReadSingle = 3;
             // Set longer range
             Precision = Precision.LongRange;
-#if NETCOREAPP2_1 || NETCOREAPP3_1
+#if NETCOREAPP2_1
             if (Information is null)
             {
                 throw new Exception("Vl53L0X device is not correctly configured.");
@@ -651,7 +651,7 @@ namespace Iot.Device.Vl53L0X
         /// Create the Info class. Initialization and closing sequences
         /// are coming form the official API
         /// </summary>
-#if !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP2_1
         [MemberNotNull(nameof(Information))]
 #endif
         private void GetInfo()

--- a/tools/DevicesApiTester/DeviceApiTester.csproj
+++ b/tools/DevicesApiTester/DeviceApiTester.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
     <TargetFrameworks Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('win'))">$(TargetFrameworks);net5.0-windows10.0.17763.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <Copyright>The .NET Foundation</Copyright>

--- a/tools/DevicesApiTester/DeviceApiTester.csproj
+++ b/tools/DevicesApiTester/DeviceApiTester.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <TargetFrameworks Condition="$(NETCoreSdkRuntimeIdentifier.StartsWith('win'))">$(TargetFrameworks);net5.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Copyright>The .NET Foundation</Copyright>
     <Company>The .NET Foundation</Company>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -8,5 +8,6 @@
     <IsPackable>false</IsPackable>
     <MainLibraryPath>$(MSBuildThisFileDirectory)../src/System.Device.Gpio/</MainLibraryPath>
     <Nullable>enable</Nullable>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 </Project>

--- a/tools/device-listing/device-listing.csproj
+++ b/tools/device-listing/device-listing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.csproj
+++ b/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There were a variety of TFMs in the repo that were not correct. 

I was not able to upgrade any of the test projects. I believe [sendToHelix.proj](https://github.com/dotnet/iot/blob/master/eng/sendToHelix.proj) needs to be updated but I could not figure out the right set of changes for it.

Let's merge this PR as-is (modulo feedback) and then fix the tests in a separate PR.