### PR TITLE
#1267 added support for Raspberry Pi 4 Model 0b3112 & 0c3112 in System.Device.Gpio

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
@@ -178,6 +178,7 @@ namespace System.Device.Gpio
                 case 0x20A0:
                     return Model.RaspberryPiComputeModule3;
 
+                case 0x3112:
                 case 0x3111:
                     return Model.RaspberryPi4;
 


### PR DESCRIPTION
Fixes #1267

Added support for Raspberry Pi 4 Model 0b3112 & 0c3112 in System.Device.Gpio
