### PR TITLE
Add support for raspberry pi Compute Module 3+

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
@@ -176,6 +176,7 @@ namespace System.Device.Gpio
                     return Model.RaspberryPi3BPlus;
 
                 case 0x20A0:
+                case 0x2100:
                     return Model.RaspberryPiComputeModule3;
 
                 case 0x3111:


### PR DESCRIPTION
Fixes #1271 

This Pull request adds Raspberry Pi Compute module CM3+ to the list of supported devices.

Unfortunately I was not able to properly test the fix, as Visual studio did not load the project when checked out. I will happily try out if you could help me getting up to speed with the project.
