### PR TITLE
Update to latest stylecop

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -8,7 +8,7 @@ file which is not marked as such, making StyleCop fail. -->
   </PropertyGroup>
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" Link="stylecop.json" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.261">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
@@ -9,8 +9,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-#pragma warning disable SA1011 // Closing square brackets should be spaced correctly https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2927
-
 namespace System.Device.Gpio.Drivers
 {
     /// <summary>

--- a/src/devices/Ads1115/samples/Program.cs
+++ b/src/devices/Ads1115/samples/Program.cs
@@ -11,7 +11,7 @@ using UnitsNet;
 
 // set I2C bus ID: 1
 // ADS1115 Addr Pin connect to GND
-I2cConnectionSettings settings = new (1, (int)I2cAddress.GND);
+I2cConnectionSettings settings = new(1, (int)I2cAddress.GND);
 // get I2cDevice (in Linux)
 I2cDevice device = I2cDevice.Create(settings);
 

--- a/src/devices/Adxl345/samples/Program.cs
+++ b/src/devices/Adxl345/samples/Program.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Device.Spi;
 using Iot.Device.Adxl345;
 
-SpiConnectionSettings settings = new (0, 0)
+SpiConnectionSettings settings = new(0, 0)
 {
     ClockFrequency = Adxl345.SpiClockFrequency,
     Mode = Adxl345.SpiMode

--- a/src/devices/Ags01db/samples/Program.cs
+++ b/src/devices/Ags01db/samples/Program.cs
@@ -6,7 +6,7 @@ using System.Device.I2c;
 using System.Threading;
 using Iot.Device.Ags01db;
 
-I2cConnectionSettings settings = new (1, Ags01db.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Ags01db.DefaultI2cAddress);
 I2cDevice device = I2cDevice.Create(settings);
 
 using Ags01db sensor = new Ags01db(device);

--- a/src/devices/Ahtxx/samples/Program.cs
+++ b/src/devices/Ahtxx/samples/Program.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using Iot.Device.Ahtxx;
 
 const int I2cBus = 1;
-I2cConnectionSettings i2cSettings = new (I2cBus, Aht20.DefaultI2cAddress);
+I2cConnectionSettings i2cSettings = new(I2cBus, Aht20.DefaultI2cAddress);
 I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);
 
 // For AHT10 or AHT15 use:

--- a/src/devices/Ak8963/samples/Program.cs
+++ b/src/devices/Ak8963/samples/Program.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Numerics;
 using Iot.Device.Magnetometer;
 
-I2cConnectionSettings mpui2CConnectionSettingmpus = new (1, Ak8963.DefaultI2cAddress);
+I2cConnectionSettings mpui2CConnectionSettingmpus = new(1, Ak8963.DefaultI2cAddress);
 using Ak8963 ak8963 = new Ak8963(I2cDevice.Create(mpui2CConnectionSettingmpus));
 Console.WriteLine(
     "Magnetometer calibration is taking couple of seconds, move your sensor in all possible directions! Make sure you don't have a magnet or phone close by.");

--- a/src/devices/Bh1745/Bh1745.cs
+++ b/src/devices/Bh1745/Bh1745.cs
@@ -43,7 +43,7 @@ namespace Iot.Device.Bh1745
         {
             _i2cDevice = device;
             // ChannelCompensationMultipliers: Red, Green, Blue, Clear
-            ChannelCompensationMultipliers = new (2.2, 1.0, 1.8, 10.0);
+            ChannelCompensationMultipliers = new(2.2, 1.0, 1.8, 10.0);
 
             // reset device and set default configuration
             InitDevice();

--- a/src/devices/Bh1745/samples/Program.CustomConfiguration.cs
+++ b/src/devices/Bh1745/samples/Program.CustomConfiguration.cs
@@ -17,7 +17,7 @@ using Bh1745 i2cBh1745 = new Bh1745(i2cDevice)
 {
     // multipliers affect the compensated values
     // ChannelCompensationMultipliers:  Red, Green, Blue, Clear
-    ChannelCompensationMultipliers = new (2.5, 0.9, 1.9, 9.5),
+    ChannelCompensationMultipliers = new(2.5, 0.9, 1.9, 9.5),
 
     // set custom  measurement time
     MeasurementTime = MeasurementTime.Ms1280,

--- a/src/devices/Bh1745/samples/Program.cs
+++ b/src/devices/Bh1745/samples/Program.cs
@@ -10,7 +10,7 @@ using Iot.Device.Bh1745;
 const int busId = 1;
 
 // create device
-I2cConnectionSettings i2cSettings = new (busId, Bh1745.DefaultI2cAddress);
+I2cConnectionSettings i2cSettings = new(busId, Bh1745.DefaultI2cAddress);
 using I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);
 using Bh1745 i2cBh1745 = new Bh1745(i2cDevice);
 // wait for first measurement

--- a/src/devices/Bh1750fvi/samples/Program.cs
+++ b/src/devices/Bh1750fvi/samples/Program.cs
@@ -6,7 +6,7 @@ using System.Device.I2c;
 using System.Threading;
 using Iot.Device.Bh1750fvi;
 
-I2cConnectionSettings settings = new (busId: 1, (int)I2cAddress.AddPinLow);
+I2cConnectionSettings settings = new(busId: 1, (int)I2cAddress.AddPinLow);
 using I2cDevice device = I2cDevice.Create(settings);
 using Bh1750fvi sensor = new Bh1750fvi(device);
 while (true)

--- a/src/devices/Bmp180/samples/Program.cs
+++ b/src/devices/Bmp180/samples/Program.cs
@@ -13,10 +13,10 @@ Console.WriteLine("Hello Bmp180!");
 // bus id on the raspberry pi 3
 const int busId = 1;
 
-I2cConnectionSettings i2cSettings = new (busId, Bmp180.DefaultI2cAddress);
+I2cConnectionSettings i2cSettings = new(busId, Bmp180.DefaultI2cAddress);
 using I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);
 
-using Bmp180 i2cBmp280 = new Bmp180(i2cDevice);
+using Bmp180 i2cBmp280 = new(i2cDevice);
 // set samplings
 i2cBmp280.SetSampling(Sampling.Standard);
 

--- a/src/devices/Bmxx80/samples/Bme280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme280.sample.cs
@@ -17,7 +17,7 @@ const int busId = 1;
 // set this to the current sea level pressure in the area for correct altitude readings
 Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
 
-I2cConnectionSettings i2cSettings = new (busId, Bme280.DefaultI2cAddress);
+I2cConnectionSettings i2cSettings = new(busId, Bme280.DefaultI2cAddress);
 using I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);
 using Bme280 bme80 = new Bme280(i2cDevice)
 {

--- a/src/devices/Bmxx80/samples/Bme680.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme680.sample.cs
@@ -16,7 +16,7 @@ const int busId = 1;
 // set this to the current sea level pressure in the area for correct altitude readings
 Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
 
-I2cConnectionSettings i2cSettings = new (busId, Bme680.DefaultI2cAddress);
+I2cConnectionSettings i2cSettings = new(busId, Bme680.DefaultI2cAddress);
 I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);
 
 using Bme680 bme680 = new Bme680(i2cDevice, Temperature.FromDegreesCelsius(20.0));

--- a/src/devices/Bmxx80/samples/Bmp280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bmp280.sample.cs
@@ -19,7 +19,7 @@ const int busId = 1;
 // set this to the current sea level pressure in the area for correct altitude readings
 Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
 
-I2cConnectionSettings i2cSettings = new (busId, Bmp280.DefaultI2cAddress);
+I2cConnectionSettings i2cSettings = new(busId, Bmp280.DefaultI2cAddress);
 I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);
 using var i2CBmp280 = new Bmp280(i2cDevice);
 

--- a/src/devices/Bno055/samples/Program.cs
+++ b/src/devices/Bno055/samples/Program.cs
@@ -9,7 +9,7 @@ using Iot.Device.Bno055;
 
 Console.WriteLine("Hello BNO055!");
 using I2cDevice i2cDevice = I2cDevice.Create(new I2cConnectionSettings(1, Bno055Sensor.DefaultI2cAddress));
-using Bno055Sensor bno055Sensor = new (i2cDevice);
+using Bno055Sensor bno055Sensor = new(i2cDevice);
 Console.WriteLine(
     $"Id: {bno055Sensor.Info.ChipId}, AccId: {bno055Sensor.Info.AcceleratorId}, GyroId: {bno055Sensor.Info.GyroscopeId}, MagId: {bno055Sensor.Info.MagnetometerId}");
 Console.WriteLine(

--- a/src/devices/BoardLed/samples/Program.cs
+++ b/src/devices/BoardLed/samples/Program.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using Iot.Device.BoardLed;
 
 // Open the green led on Raspberry Pi.
-using BoardLed led = new ("led0");
+using BoardLed led = new("led0");
 
 string defaultTrigger = led.Trigger;
 

--- a/src/devices/BrickPi3/BrickPi3.cs
+++ b/src/devices/BrickPi3/BrickPi3.cs
@@ -851,7 +851,6 @@ namespace Iot.Device.BrickPi3
             throw new IOException($"{nameof(GetSensor)}  error: Sensor not configured or not supported.");
         }
 
-#pragma warning disable SA1011
         /// <summary>
         /// Set the sensor type
         /// </summary>
@@ -871,7 +870,6 @@ namespace Iot.Device.BrickPi3
         /// </param>
         public void SetSensorType(byte port, SensorType type, int[]? param = null)
         {
-#pragma warning restore SA1011
             for (int p = 0; p < 4; p++)
             {
                 if ((port & (1 << p)) > 0)

--- a/src/devices/Card/CreditCard/BerSplitter.cs
+++ b/src/devices/Card/CreditCard/BerSplitter.cs
@@ -30,18 +30,18 @@ namespace Iot.Device.Card.CreditCardProcessing
                 try
                 {
                     var resTag = DecodeTag(toSplit.Slice(index));
-                    var tagNumber = resTag.Item1;
+                    var tagNumber = resTag.TagNumber;
                     // Need to move index depending on how many has been read
-                    index += resTag.Item2;
+                    index += resTag.NumberElements;
                     var resSize = DecodeSize(toSplit.Slice(index));
-                    var data = new byte[resSize.Item1];
+                    var data = new byte[resSize.Size];
                     var elem = new Tag(
                         tagNumber,
                         data);
                     Tags.Add(elem);
-                    index += resSize.Item2;
-                    toSplit.Slice(index, resSize.Item1).CopyTo(elem.Data);
-                    index += resSize.Item1;
+                    index += resSize.NumBytes;
+                    toSplit.Slice(index, resSize.Size).CopyTo(elem.Data);
+                    index += resSize.Size;
 
                 }
                 catch (Exception ex) when (ex is ArgumentOutOfRangeException || ex is OverflowException)
@@ -52,7 +52,7 @@ namespace Iot.Device.Card.CreditCardProcessing
             }
         }
 
-        private (uint tagNumber, byte numberElements) DecodeTag(ReadOnlySpan<byte> toSplit)
+        private (uint TagNumber, byte NumberElements) DecodeTag(ReadOnlySpan<byte> toSplit)
         {
             uint tagValue = toSplit[0];
             byte index = 1;
@@ -70,7 +70,7 @@ namespace Iot.Device.Card.CreditCardProcessing
             return (tagValue, index);
         }
 
-        private (int size, byte numBytes) DecodeSize(ReadOnlySpan<byte> toSplit)
+        private (int Size, byte NumBytes) DecodeSize(ReadOnlySpan<byte> toSplit)
         {
             // Case infinite
             if (toSplit[0] == 0b1000_0000)

--- a/src/devices/Card/CreditCard/TagList.cs
+++ b/src/devices/Card/CreditCard/TagList.cs
@@ -14,7 +14,7 @@ namespace Iot.Device.Card.CreditCardProcessing
         /// List of Tags description, source, conversion for display as well as if they are templates or contain Data Object Link
         /// This list is coming from the EMV documentation, see EMV book 3, Annexe A
         /// </summary>
-        public static List<TagDetails> Tags = new ()
+        public static List<TagDetails> Tags = new()
         {
             new TagDetails() { TagNumber = 0x06, Source = Source.Icc, Decoder = ConversionType.ByteArray, Description = "Object Identifier (OID)", IsTemplate = false, IsDol = false },
             new TagDetails() { TagNumber = 0x41, Source = Source.Icc, Decoder = ConversionType.ByteArray, Description = "Country code and national data", IsTemplate = false, IsDol = false },

--- a/src/devices/Card/Mifare/MifareCard.cs
+++ b/src/devices/Card/Mifare/MifareCard.cs
@@ -111,7 +111,7 @@ namespace Iot.Device.Card.Mifare
         /// </summary>
         /// <param name="accessSector">the access sector</param>
         /// <returns>the 3 bytes for configuration</returns>
-        public (byte b6, byte b7, byte b8) EncodeSectorTailer(AccessSector accessSector)
+        public (byte B6, byte B7, byte B8) EncodeSectorTailer(AccessSector accessSector)
         {
             byte c1 = 0;
             byte c2 = 0;
@@ -197,7 +197,7 @@ namespace Iot.Device.Card.Mifare
         /// <param name="blockNumber">The block sector to encode</param>
         /// <param name="accessType">The access type to encode</param>
         /// <returns>The encoded sector tailer for the specific block</returns>
-        public (byte b6, byte b7, byte b8) EncodeSectorTailer(byte blockNumber, AccessType accessType)
+        public (byte B6, byte B7, byte B8) EncodeSectorTailer(byte blockNumber, AccessType accessType)
         {
             blockNumber = (byte)(blockNumber % 4);
 
@@ -445,7 +445,7 @@ namespace Iot.Device.Card.Mifare
         /// <param name="accessSector">The access desired</param>
         /// <param name="accessTypes">An array of 3 AccessType determining access of each block</param>
         /// <returns>The 3 bytes encoding the rights</returns>
-        public (byte b6, byte b7, byte b8) EncodeSectorAndClockTailer(AccessSector accessSector, AccessType[] accessTypes)
+        public (byte B6, byte B7, byte B8) EncodeSectorAndClockTailer(AccessSector accessSector, AccessType[] accessTypes)
         {
             if (accessTypes.Length != 3)
             {
@@ -453,15 +453,15 @@ namespace Iot.Device.Card.Mifare
             }
 
             var tupleRes = EncodeSectorTailer(accessSector);
-            byte b6 = tupleRes.Item1;
-            byte b7 = tupleRes.Item2;
-            byte b8 = tupleRes.Item3;
+            byte b6 = tupleRes.B6;
+            byte b7 = tupleRes.B7;
+            byte b8 = tupleRes.B8;
             for (byte i = 0; i < 3; i++)
             {
                 tupleRes = EncodeSectorTailer(i, accessTypes[i]);
-                b6 |= tupleRes.Item1;
-                b7 |= tupleRes.Item2;
-                b8 |= tupleRes.Item3;
+                b6 |= tupleRes.B6;
+                b7 |= tupleRes.B7;
+                b8 |= tupleRes.B8;
             }
 
             return (b6, b7, b8);
@@ -471,7 +471,7 @@ namespace Iot.Device.Card.Mifare
         /// Encode with default value the access sector and tailer blocks
         /// </summary>
         /// <returns></returns>
-        public (byte b6, byte b7, byte b8) EncodeDefaultSectorAndBlockTailer() => (0xFF, 0x07, 0x80);
+        public (byte B6, byte B7, byte B8) EncodeDefaultSectorAndBlockTailer() => (0xFF, 0x07, 0x80);
 
         /// <summary>
         /// From the ATAQ ans SAK data find common card capacity

--- a/src/devices/Card/Mifare/MifareCard.cs
+++ b/src/devices/Card/Mifare/MifareCard.cs
@@ -23,7 +23,6 @@ namespace Iot.Device.Card.Mifare
         /// </summary>
         public MifareCardCommand Command { get; set; }
 
-#pragma warning disable SA1011
         /// <summary>
         /// Key A Used for encryption/decryption
         /// </summary>

--- a/src/devices/Card/Rfid/Data106kbpsTypeA.cs
+++ b/src/devices/Card/Rfid/Data106kbpsTypeA.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable SA1011
-
 namespace Iot.Device.Rfid
 {
     /// <summary>

--- a/src/devices/CharacterLcd/LcdCharacterEncodingFactory.cs
+++ b/src/devices/CharacterLcd/LcdCharacterEncodingFactory.cs
@@ -387,13 +387,13 @@ namespace Iot.Device.CharacterLcd
             // Need to copy the static map, we must not update that
             Dictionary<char, byte> newMap = romName switch
             {
-                "A00" => new (DefaultA00Map),
-                "A02" => new (DefaultA02Map),
-                "SplC780" => new (DefaultSplC780Map),
-                _ => new (DefaultCustomMap),
+                "A00" => new(DefaultA00Map),
+                "A02" => new(DefaultA02Map),
+                "SplC780" => new(DefaultSplC780Map),
+                _ => new(DefaultCustomMap),
             };
 
-            List<byte[]> extraCharacters = new ();
+            List<byte[]> extraCharacters = new();
             bool supported = AssignLettersForCurrentCulture(newMap, culture, romName, extraCharacters, maxNumberOfCustomCharacters);
 
             if (!newMap.ContainsKey(unknownLetter))

--- a/src/devices/CharacterLcd/LcdCharacterEncodingFactory.cs
+++ b/src/devices/CharacterLcd/LcdCharacterEncodingFactory.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 
-#pragma warning disable SA1011
-
 namespace Iot.Device.CharacterLcd
 {
     /// <summary>

--- a/src/devices/CharacterLcd/samples/Program.cs
+++ b/src/devices/CharacterLcd/samples/Program.cs
@@ -25,7 +25,7 @@ void UsingGpioPins()
 void UsingMcp()
 {
     using I2cDevice i2cDevice = I2cDevice.Create(new I2cConnectionSettings(1, 0x21));
-    using Mcp23008 driver = new (i2cDevice);
+    using Mcp23008 driver = new(i2cDevice);
     int[] dataPins = { 3, 4, 5, 6 };
     int registerSelectPin = 1;
     int enablePin = 2;

--- a/src/devices/Charlieplex/CharlieplexSegment.cs
+++ b/src/devices/Charlieplex/CharlieplexSegment.cs
@@ -44,7 +44,7 @@ namespace Iot.Device.Multiplexing
             }
 
             _shouldDispose = shouldDispose || gpioController is null;
-            _gpioController = gpioController ?? new ();
+            _gpioController = gpioController ?? new();
 
             // first two pins will be needed as Output.
             _gpioController.OpenPin(pins[0], PinMode.Output);

--- a/src/devices/Charlieplex/samples/Program.cs
+++ b/src/devices/Charlieplex/samples/Program.cs
@@ -13,7 +13,7 @@ for (int i = 0; i < charlieSegmentLength; i++)
     Console.WriteLine($"Node {i} -- Anode: {node.Anode}; Cathode: {node.Cathode}");
 }
 
-using CharlieplexSegment charlie = new (pins, charlieSegmentLength);
+using CharlieplexSegment charlie = new(pins, charlieSegmentLength);
 var twoSeconds = TimeSpan.FromSeconds(2);
 
 Console.WriteLine("Light all LEDs");

--- a/src/devices/Common/Iot/Device/Graphics/BdfFont.cs
+++ b/src/devices/Common/Iot/Device/Graphics/BdfFont.cs
@@ -8,8 +8,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#pragma warning disable SA1011 // Closing square brackets should be spaced correctly https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2927
-
 namespace Iot.Device.Graphics
 {
     /// <summary>

--- a/src/devices/CpuTemperature/CpuTemperature.cs
+++ b/src/devices/CpuTemperature/CpuTemperature.cs
@@ -127,7 +127,7 @@ namespace Iot.Device.CpuTemperature
         /// Returns all known temperature sensor values.
         /// </summary>
         /// <returns>A list of name/value pairs for temperature sensors</returns>
-        public List<(string, Temperature)> ReadTemperatures()
+        public List<(string Sensor, Temperature Temperature)> ReadTemperatures()
         {
             if (!_windows)
             {

--- a/src/devices/CpuTemperature/samples/Program.cs
+++ b/src/devices/CpuTemperature/samples/Program.cs
@@ -15,9 +15,9 @@ while (!Console.KeyAvailable)
         var temperature = cpuTemperature.ReadTemperatures();
         foreach (var entry in temperature)
         {
-            if (!double.IsNaN(entry.Item2.DegreesCelsius))
+            if (!double.IsNaN(entry.Temperature.DegreesCelsius))
             {
-                Console.WriteLine($"Temperature from {entry.Item1.ToString()}: {entry.Item2.DegreesCelsius} °C");
+                Console.WriteLine($"Temperature from {entry.Sensor.ToString()}: {entry.Temperature.DegreesCelsius} °C");
             }
             else
             {

--- a/src/devices/Dhtxx/samples/Program.cs
+++ b/src/devices/Dhtxx/samples/Program.cs
@@ -20,10 +20,10 @@ if (choice.KeyChar == '1')
 {
     Console.WriteLine("Press any key to stop the reading");
     // Init DHT10 through I2C
-    I2cConnectionSettings settings = new (1, Dht10.DefaultI2cAddress);
+    I2cConnectionSettings settings = new(1, Dht10.DefaultI2cAddress);
     I2cDevice device = I2cDevice.Create(settings);
 
-    using Dht10 dht = new (device);
+    using Dht10 dht = new(device);
     Dht(dht);
     return;
 }
@@ -47,7 +47,7 @@ switch (choice.KeyChar)
 {
     case '2':
         Console.WriteLine($"Reading temperature and humidity on DHT11, pin {pin}");
-        using (Dht11 dht11 = new (pin))
+        using (Dht11 dht11 = new(pin))
         {
             Dht(dht11);
         }
@@ -55,7 +55,7 @@ switch (choice.KeyChar)
         break;
     case '3':
         Console.WriteLine($"Reading temperature and humidity on DHT12, pin {pin}");
-        using (Dht12 dht12 = new (pin))
+        using (Dht12 dht12 = new(pin))
         {
             Dht(dht12);
         }
@@ -63,7 +63,7 @@ switch (choice.KeyChar)
         break;
     case '4':
         Console.WriteLine($"Reading temperature and humidity on DHT21, pin {pin}");
-        using (Dht21 dht21 = new (pin))
+        using (Dht21 dht21 = new(pin))
         {
             Dht(dht21);
         }
@@ -71,7 +71,7 @@ switch (choice.KeyChar)
         break;
     case '5':
         Console.WriteLine($"Reading temperature and humidity on DHT22, pin {pin}");
-        using (Dht22 dht22 = new (pin))
+        using (Dht22 dht22 = new(pin))
         {
             Dht(dht22);
         }

--- a/src/devices/Display/samples/Program.cs
+++ b/src/devices/Display/samples/Program.cs
@@ -9,7 +9,7 @@ using Iot.Device.Display;
 const string SupportedCharacters = "0123456789aAbBcCdDeEfFgGhHiIjJlLnNoOpPrRsStuUyYzZ-=_|°[]     ";
 
 // Initialize display (busId = 1 for Raspberry Pi 2 & 3)
-using Large4Digit7SegmentDisplay display = new (I2cDevice.Create(new I2cConnectionSettings(busId: 1, Ht16k33.DefaultI2cAddress)))
+using Large4Digit7SegmentDisplay display = new(I2cDevice.Create(new I2cConnectionSettings(busId: 1, Ht16k33.DefaultI2cAddress)))
     {
         // Set max brightness
         Brightness = Ht16k33.MaxBrightness

--- a/src/devices/ExplorerHat/Led.cs
+++ b/src/devices/ExplorerHat/Led.cs
@@ -32,7 +32,7 @@ namespace Iot.Device.ExplorerHat
         /// <param name="shouldDispose">True to dispose the Gpio Controller</param>
         internal Led(int pin, GpioController? controller = null, bool shouldDispose = true)
         {
-            _controller = controller ?? new ();
+            _controller = controller ?? new();
             _shouldDispose = shouldDispose || controller is null;
             Pin = pin;
             IsOn = false;

--- a/src/devices/ExplorerHat/Lights.cs
+++ b/src/devices/ExplorerHat/Lights.cs
@@ -69,15 +69,15 @@ namespace Iot.Device.ExplorerHat
         /// <param name="shouldDispose">True to dispose the Gpio Controller</param>
         internal Lights(GpioController? controller = null, bool shouldDispose = true)
         {
-            _controller = controller ?? new ();
+            _controller = controller ?? new();
             _shouldDispose = shouldDispose || controller is null;
 
             LedArray = new List<Led>()
             {
-                new (LED1_PIN, _controller),
-                new (LED2_PIN, _controller),
-                new (LED3_PIN, _controller),
-                new (LED4_PIN, _controller)
+                new(LED1_PIN, _controller),
+                new(LED2_PIN, _controller),
+                new(LED3_PIN, _controller),
+                new(LED4_PIN, _controller)
             };
         }
 

--- a/src/devices/ExplorerHat/Motors.cs
+++ b/src/devices/ExplorerHat/Motors.cs
@@ -69,7 +69,7 @@ namespace Iot.Device.ExplorerHat
         /// <param name="shouldDispose">True to dispose the Gpio Controller</param>
         internal Motors(GpioController? controller = null, bool shouldDispose = true)
         {
-            _controller = controller ?? new ();
+            _controller = controller ?? new();
             _shouldDispose = shouldDispose || controller is null;
 
             _motorArray = new List<DCMotor.DCMotor>()

--- a/src/devices/ExplorerHat/samples/Program.cs
+++ b/src/devices/ExplorerHat/samples/Program.cs
@@ -5,7 +5,7 @@ using System;
 using System.Threading;
 using Iot.Device.ExplorerHat;
 
-using ExplorerHat hat = new ();
+using ExplorerHat hat = new();
 // All lights on
 hat.Lights.On();
 Thread.Sleep(1000);

--- a/src/devices/Ft4222/Ft4222Spi.cs
+++ b/src/devices/Ft4222/Ft4222Spi.cs
@@ -89,7 +89,7 @@ namespace Iot.Device.Ft4222
         // Maximum is the System Clock / 1 = 80 MHz
         // Minimum is the System Clock / 512 = 24 / 256 = 93.75 KHz
         // Always take the below frequency to avoid over clocking
-        private (FtClockRate clk, SpiClock spiClk) CalculateBestClockRate() => _settings.ClockFrequency switch
+        private (FtClockRate Clk, SpiClock SpiClk) CalculateBestClockRate() => _settings.ClockFrequency switch
         {
             < 187500 => (FtClockRate.Clock24MHz, SpiClock.DivideBy256),
             < 234375 => (FtClockRate.Clock48MHz, SpiClock.DivideBy256),

--- a/src/devices/Ft4222/FtCommon.cs
+++ b/src/devices/Ft4222/FtCommon.cs
@@ -80,7 +80,7 @@ namespace Iot.Device.Ft4222
         /// Get the versions of the chipset and dll
         /// </summary>
         /// <returns>Both the chipset and dll versions</returns>
-        public static (Version? chip, Version? dll) GetVersions()
+        public static (Version? Chip, Version? Dll) GetVersions()
         {
             // First, let's find a device
             var devices = GetDevices();

--- a/src/devices/Ft4222/samples/Program.cs
+++ b/src/devices/Ft4222/samples/Program.cs
@@ -57,9 +57,9 @@ if (key.KeyChar == '4')
 
 void TestI2c()
 {
-    using Ft4222I2c ftI2c = new (new I2cConnectionSettings(0, Bno055Sensor.DefaultI2cAddress));
+    using Ft4222I2c ftI2c = new(new I2cConnectionSettings(0, Bno055Sensor.DefaultI2cAddress));
 
-    Bno055Sensor bno055Sensor = new (ftI2c);
+    Bno055Sensor bno055Sensor = new(ftI2c);
 
     Console.WriteLine($"Id: {bno055Sensor.Info.ChipId}, AccId: {bno055Sensor.Info.AcceleratorId}, GyroId: {bno055Sensor.Info.GyroscopeId}, MagId: {bno055Sensor.Info.MagnetometerId}");
     Console.WriteLine($"Firmware version: {bno055Sensor.Info.FirmwareVersion}, Bootloader: {bno055Sensor.Info.BootloaderVersion}");
@@ -69,7 +69,7 @@ void TestI2c()
 
 void TestSpi()
 {
-    using Ft4222Spi ftSpi = new (new SpiConnectionSettings(0, 1) { ClockFrequency = 1_000_000, Mode = SpiMode.Mode0 });
+    using Ft4222Spi ftSpi = new(new SpiConnectionSettings(0, 1) { ClockFrequency = 1_000_000, Mode = SpiMode.Mode0 });
 
     while (!Console.KeyAvailable)
     {
@@ -83,7 +83,7 @@ void TestSpi()
 void TestGpio()
 {
     const int Gpio2 = 2;
-    using GpioController gpioController = new (PinNumberingScheme.Board, new Ft4222Gpio());
+    using GpioController gpioController = new(PinNumberingScheme.Board, new Ft4222Gpio());
 
     // Opening GPIO2
     gpioController.OpenPin(Gpio2);
@@ -112,7 +112,7 @@ void TestGpio()
 void TestEvents()
 {
     const int Gpio2 = 2;
-    using GpioController gpioController = new (PinNumberingScheme.Board, new Ft4222Gpio());
+    using GpioController gpioController = new(PinNumberingScheme.Board, new Ft4222Gpio());
 
     // Opening GPIO2
     gpioController.OpenPin(Gpio2);

--- a/src/devices/GoPiGo3/GoPiGo3.cs
+++ b/src/devices/GoPiGo3/GoPiGo3.cs
@@ -59,8 +59,8 @@ namespace Iot.Device.GoPiGo3
         /// </summary>
         public GroveSensor[] GroveSensor = new GroveSensor[2]
             {
-                new (GrovePort.Grove1),
-                new (GrovePort.Grove2)
+                new(GrovePort.Grove1),
+                new(GrovePort.Grove2)
             };
 
         /// <summary>

--- a/src/devices/GoPiGo3/GoPiGo3.cs
+++ b/src/devices/GoPiGo3/GoPiGo3.cs
@@ -759,7 +759,6 @@ namespace Iot.Device.GoPiGo3
                 throw new ArgumentException(nameof(port), $"Port unsupported. Must be either {nameof(GrovePort.Grove1)} or {nameof(GrovePort.Grove2)}.");
             }
 
-#pragma warning disable SA1011
             byte[]? outArray = null;
             byte[]? reply = null;
             switch (GroveSensor[port_index].SensorType)

--- a/src/devices/GrovePi/GrovePi.cs
+++ b/src/devices/GrovePi/GrovePi.cs
@@ -65,7 +65,6 @@ namespace Iot.Device.GrovePiDevice
         public Version GetFirmwareVerion()
         {
             WriteCommand(GrovePiCommand.Version, 0, 0, 0);
-#pragma warning disable SA1011
             byte[]? inArray = ReadCommand(GrovePiCommand.Version, 0);
             if (inArray is object)
             {

--- a/src/devices/GrovePi/samples/Program.cs
+++ b/src/devices/GrovePi/samples/Program.cs
@@ -11,7 +11,7 @@ using Iot.Device.GrovePiDevice.Sensors;
 
 Console.WriteLine("Hello GrovePi!");
 PinValue relay = PinValue.Low;
-I2cConnectionSettings i2CConnectionSettings = new (1, GrovePi.DefaultI2cAddress);
+I2cConnectionSettings i2CConnectionSettings = new(1, GrovePi.DefaultI2cAddress);
 using GrovePi grovePi = new GrovePi(I2cDevice.Create(i2CConnectionSettings));
 Console.WriteLine($"Manufacturer :{grovePi.GrovePiInfo.Manufacturer}");
 Console.WriteLine($"Board: {grovePi.GrovePiInfo.Board}");
@@ -22,8 +22,8 @@ grovePi.PinMode(GrovePort.DigitalPin2, PinMode.Output);
 grovePi.PinMode(GrovePort.DigitalPin3, PinMode.Output);
 grovePi.PinMode(GrovePort.DigitalPin4, PinMode.Input);
 // 2 high level classes
-UltrasonicSensor ultrasonic = new (grovePi, GrovePort.DigitalPin6);
-DhtSensor dhtSensor = new (grovePi, GrovePort.DigitalPin7, DhtType.Dht11);
+UltrasonicSensor ultrasonic = new(grovePi, GrovePort.DigitalPin6);
+DhtSensor dhtSensor = new(grovePi, GrovePort.DigitalPin7, DhtType.Dht11);
 int poten = 0;
 while (!Console.KeyAvailable)
 {

--- a/src/devices/Hcsr04/Hcsr04.cs
+++ b/src/devices/Hcsr04/Hcsr04.cs
@@ -38,7 +38,7 @@ namespace Iot.Device.Hcsr04
         public Hcsr04(GpioController? gpioController, int triggerPin, int echoPin, bool shouldDispose = true)
         {
             _shouldDispose = shouldDispose || gpioController is null;
-            _controller = gpioController ?? new ();
+            _controller = gpioController ?? new();
             _echo = echoPin;
             _trigger = triggerPin;
 

--- a/src/devices/Hcsr04/samples/Program.cs
+++ b/src/devices/Hcsr04/samples/Program.cs
@@ -8,7 +8,7 @@ using UnitsNet;
 
 Console.WriteLine("Hello Hcsr04 Sample!");
 
-using Hcsr04 sonar = new (4, 17);
+using Hcsr04 sonar = new(4, 17);
 while (true)
 {
     if (sonar.TryGetDistance(out Length distance))

--- a/src/devices/Hcsr501/samples/Program.cs
+++ b/src/devices/Hcsr501/samples/Program.cs
@@ -9,10 +9,10 @@ using Iot.Device.Hcsr501;
 const int Hcsr501Pin = 17;
 const int LedPin = 27;
 
-using GpioController ledController = new ();
+using GpioController ledController = new();
 ledController.OpenPin(LedPin, PinMode.Output);
 
-using Hcsr501 sensor = new (Hcsr501Pin);
+using Hcsr501 sensor = new(Hcsr501Pin);
 while (true)
 {
     // adjusting the detection distance and time by rotating the potentiometer on the sensor

--- a/src/devices/Hmc5883l/samples/Program.cs
+++ b/src/devices/Hmc5883l/samples/Program.cs
@@ -6,9 +6,9 @@ using System.Device.I2c;
 using System.Threading;
 using Iot.Device.Hmc5883l;
 
-I2cConnectionSettings settings = new (1, Hmc5883l.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Hmc5883l.DefaultI2cAddress);
 using I2cDevice device = I2cDevice.Create(settings);
-using Hmc5883l sensor = new (device);
+using Hmc5883l sensor = new(device);
 while (true)
 {
     // read heading

--- a/src/devices/Hts221/Hts221.cs
+++ b/src/devices/Hts221/Hts221.cs
@@ -103,7 +103,7 @@ namespace Iot.Device.Hts221
             return y0 + (x - x0) * yrange / xrange;
         }
 
-        private (ushort t0x8, ushort t1x8) GetTemperatureCalibrationPointsCelsius()
+        private (ushort T0x8, ushort T1x8) GetTemperatureCalibrationPointsCelsius()
         {
             Span<byte> t0t1Lsb = stackalloc byte[2];
             Read(Register.Temperature0LsbDegCx8, t0t1Lsb);
@@ -114,7 +114,7 @@ namespace Iot.Device.Hts221
             return (t0, t1);
         }
 
-        private (short t0, short t1) GetTemperatureCalibrationPointsRaw()
+        private (short T0, short T1) GetTemperatureCalibrationPointsRaw()
         {
             Span<byte> t0t1 = stackalloc byte[4];
             Read(Register.Temperature0Raw, t0t1);
@@ -123,14 +123,14 @@ namespace Iot.Device.Hts221
             return (t0, t1);
         }
 
-        private (byte h0, byte h1) GetHumidityCalibrationPointsRH()
+        private (byte H0, byte H1) GetHumidityCalibrationPointsRH()
         {
             Span<byte> h0h1 = stackalloc byte[2];
             Read(Register.Humidity0rHx2, h0h1);
             return (h0h1[0], h0h1[1]);
         }
 
-        private (short h0, short h1) GetHumidityCalibrationPointsRaw()
+        private (short H0, short H1) GetHumidityCalibrationPointsRaw()
         {
             // space in addressing between both registers therefore do 2 reads
             short h0 = ReadInt16(Register.Humidity0Raw);

--- a/src/devices/Hts221/samples/Program.cs
+++ b/src/devices/Hts221/samples/Program.cs
@@ -11,7 +11,7 @@ using UnitsNet;
 // I2C address on SenseHat board
 const int I2cAddress = 0x5F;
 
-using Hts221 th = new (CreateI2cDevice());
+using Hts221 th = new(CreateI2cDevice());
 while (true)
 {
     var tempValue = th.Temperature;
@@ -28,6 +28,6 @@ while (true)
 
 I2cDevice CreateI2cDevice()
 {
-    I2cConnectionSettings settings = new (1, I2cAddress);
+    I2cConnectionSettings settings = new(1, I2cAddress);
     return I2cDevice.Create(settings);
 }

--- a/src/devices/Ina219/Ina219.cs
+++ b/src/devices/Ina219/Ina219.cs
@@ -31,7 +31,7 @@ namespace Iot.Device.Adc
 
         // These values are the datasheet defined delays in micro seconds between requesting a Current or Power value from the INA219 and the ADC sampling having completed
         // along with any conversions.
-        private static readonly Dictionary<Ina219AdcResolutionOrSamples, int> s_readDelays = new ()
+        private static readonly Dictionary<Ina219AdcResolutionOrSamples, int> s_readDelays = new()
         {
             { Ina219AdcResolutionOrSamples.Adc9Bit, 84 },
             { Ina219AdcResolutionOrSamples.Adc10Bit, 148 },

--- a/src/devices/Ina219/samples/Program.cs
+++ b/src/devices/Ina219/samples/Program.cs
@@ -11,7 +11,7 @@ const byte Adafruit_Ina219_I2cAddress = 0x40;
 const byte Adafruit_Ina219_I2cBus = 0x1;
 
 // create an INA219 device on I2C bus 1 addressing channel 64
-using Ina219 device = new (new I2cConnectionSettings(Adafruit_Ina219_I2cBus, Adafruit_Ina219_I2cAddress));
+using Ina219 device = new(new I2cConnectionSettings(Adafruit_Ina219_I2cBus, Adafruit_Ina219_I2cAddress));
 // reset the device
 device.Reset();
 

--- a/src/devices/LiquidLevel/samples/LiquidLevelSwitch.sample.cs
+++ b/src/devices/LiquidLevel/samples/LiquidLevelSwitch.sample.cs
@@ -6,7 +6,7 @@ using System.Device.Gpio;
 using System.Threading;
 using Iot.Device.LiquidLevel;
 
-using LiquidLevelSwitch sensor = new (23, PinValue.Low);
+using LiquidLevelSwitch sensor = new(23, PinValue.Low);
 while (true)
 {
     // read liquid level switch

--- a/src/devices/LiquidLevel/samples/Llc200d3sh.sample.cs
+++ b/src/devices/LiquidLevel/samples/Llc200d3sh.sample.cs
@@ -5,7 +5,7 @@ using System;
 using System.Threading;
 using Iot.Device.LiquidLevel;
 
-using Llc200d3sh sensor = new (23);
+using Llc200d3sh sensor = new(23);
 while (true)
 {
     // read liquid level switch

--- a/src/devices/Lm75/samples/Program.cs
+++ b/src/devices/Lm75/samples/Program.cs
@@ -6,10 +6,10 @@ using System.Device.I2c;
 using System.Threading;
 using Iot.Device.Lm75;
 
-I2cConnectionSettings settings = new (1, Lm75.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Lm75.DefaultI2cAddress);
 using I2cDevice device = I2cDevice.Create(settings);
 
-using Lm75 sensor = new (device);
+using Lm75 sensor = new(device);
 while (true)
 {
     // read temperature

--- a/src/devices/Lps25h/samples/Program.cs
+++ b/src/devices/Lps25h/samples/Program.cs
@@ -14,7 +14,7 @@ const int I2cAddress = 0x5c;
 // set this to the current sea level pressure in the area for correct altitude readings
 var defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
 
-using Lps25h th = new (CreateI2cDevice());
+using Lps25h th = new(CreateI2cDevice());
 while (true)
 {
     Temperature tempValue = th.Temperature;
@@ -29,6 +29,6 @@ while (true)
 
 I2cDevice CreateI2cDevice()
 {
-    I2cConnectionSettings settings = new (1, I2cAddress);
+    I2cConnectionSettings settings = new(1, I2cAddress);
     return I2cDevice.Create(settings);
 }

--- a/src/devices/Lsm9Ds1/samples/Lsm9Ds1.AccelerometerAndGyroscope.Sample.cs
+++ b/src/devices/Lsm9Ds1/samples/Lsm9Ds1.AccelerometerAndGyroscope.Sample.cs
@@ -13,7 +13,7 @@ namespace Iot.Device.Lsm9Ds1.Samples
 
         public static void Run()
         {
-            using Lsm9Ds1AccelerometerAndGyroscope ag = new (CreateI2cDevice());
+            using Lsm9Ds1AccelerometerAndGyroscope ag = new(CreateI2cDevice());
             while (true)
             {
                 Console.WriteLine($"Acceleration={ag.Acceleration}");
@@ -24,7 +24,7 @@ namespace Iot.Device.Lsm9Ds1.Samples
 
         private static I2cDevice CreateI2cDevice()
         {
-            I2cConnectionSettings settings = new (1, I2cAddress);
+            I2cConnectionSettings settings = new(1, I2cAddress);
             return I2cDevice.Create(settings);
         }
     }

--- a/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Magnetometer.Sample.cs
+++ b/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Magnetometer.Sample.cs
@@ -16,7 +16,7 @@ namespace Iot.Device.Lsm9Ds1.Samples
 
         public static void Run()
         {
-            using (Lsm9Ds1Magnetometer m = new (CreateI2cDevice()))
+            using (Lsm9Ds1Magnetometer m = new(CreateI2cDevice()))
             {
                 Console.WriteLine("Calibrating...");
                 Console.WriteLine("Move the sensor around Z for the next 20 seconds, try covering every angle");
@@ -83,7 +83,7 @@ namespace Iot.Device.Lsm9Ds1.Samples
 
         private static I2cDevice CreateI2cDevice()
         {
-            I2cConnectionSettings settings = new (1, I2cAddress);
+            I2cConnectionSettings settings = new(1, I2cAddress);
             return I2cDevice.Create(settings);
         }
     }

--- a/src/devices/Max44009/samples/Program.cs
+++ b/src/devices/Max44009/samples/Program.cs
@@ -6,11 +6,11 @@ using System.Device.I2c;
 using System.Threading;
 using Iot.Device.Max44009;
 
-I2cConnectionSettings settings = new (1, Max44009.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Max44009.DefaultI2cAddress);
 using I2cDevice device = I2cDevice.Create(settings);
 
 // integration time is 100ms
-using Max44009 sensor = new (device, IntegrationTime.Time100);
+using Max44009 sensor = new(device, IntegrationTime.Time100);
 while (true)
 {
     // read illuminance

--- a/src/devices/Max7219/samples/Program.cs
+++ b/src/devices/Max7219/samples/Program.cs
@@ -15,13 +15,13 @@ if (args is { Length: > 0 })
 
 Console.WriteLine(message);
 
-SpiConnectionSettings connectionSettings = new (0, 0)
+SpiConnectionSettings connectionSettings = new(0, 0)
 {
     ClockFrequency = Iot.Device.Max7219.Max7219.SpiClockFrequency,
     Mode = Iot.Device.Max7219.Max7219.SpiMode
 };
 using SpiDevice spi = SpiDevice.Create(connectionSettings);
-using Max7219 devices = new (spi, cascadedDevices: 4);
+using Max7219 devices = new(spi, cascadedDevices: 4);
 // initialize the devices
 devices.Init();
 
@@ -62,7 +62,7 @@ foreach (RotationType rotation in Enum.GetValues(typeof(RotationType)))
 // reinitialize device and show message using the matrix graphics
 devices.Init();
 devices.Rotation = RotationType.Right;
-MatrixGraphics graphics = new (devices, Fonts.Default);
+MatrixGraphics graphics = new(devices, Fonts.Default);
 foreach (var font in new[]
 {
     Fonts.CP437, Fonts.LCD, Fonts.Sinclair, Fonts.Tiny, Fonts.CyrillicUkrainian

--- a/src/devices/Mbi5027/samples/Program.cs
+++ b/src/devices/Mbi5027/samples/Program.cs
@@ -7,8 +7,8 @@ using System.Device.Spi;
 using System.Threading;
 using Iot.Device.Multiplexing;
 
-using Mbi5027 sr = new (Mbi5027PinMapping.Complete);
-CancellationTokenSource cancellationSource = new ();
+using Mbi5027 sr = new(Mbi5027PinMapping.Complete);
+CancellationTokenSource cancellationSource = new();
 Console.CancelKeyPress += (s, e) =>
 {
     e.Cancel = true;

--- a/src/devices/Mcp23xxx/samples/Program.cs
+++ b/src/devices/Mcp23xxx/samples/Program.cs
@@ -13,7 +13,7 @@ int s_deviceAddress = 0x20;
 Console.WriteLine("Hello Mcp23xxx!");
 
 using Mcp23xxx mcp23xxx = GetMcp23xxxDevice(Mcp23xxxDevice.Mcp23017);
-using GpioController controllerUsingMcp = new (PinNumberingScheme.Logical, mcp23xxx);
+using GpioController controllerUsingMcp = new(PinNumberingScheme.Logical, mcp23xxx);
 // Samples are currently written specifically for the 16 bit variant
 if (mcp23xxx is Mcp23x1x mcp23x1x)
 {
@@ -29,7 +29,7 @@ if (mcp23xxx is Mcp23x1x mcp23x1x)
 // Program methods
 Mcp23xxx GetMcp23xxxDevice(Mcp23xxxDevice mcp23xxxDevice)
 {
-    I2cConnectionSettings i2cConnectionSettings = new (1, s_deviceAddress);
+    I2cConnectionSettings i2cConnectionSettings = new(1, s_deviceAddress);
     I2cDevice i2cDevice = I2cDevice.Create(i2cConnectionSettings);
 
     // I2C.
@@ -45,7 +45,7 @@ Mcp23xxx GetMcp23xxxDevice(Mcp23xxxDevice mcp23xxxDevice)
             return new Mcp23018(i2cDevice);
     }
 
-    SpiConnectionSettings spiConnectionSettings = new (0, 0)
+    SpiConnectionSettings spiConnectionSettings = new(0, 0)
     {
         ClockFrequency = 1000000, Mode = SpiMode.Mode0
     };

--- a/src/devices/Mcp23xxx/tests/Mcp23xxxTest.cs
+++ b/src/devices/Mcp23xxx/tests/Mcp23xxxTest.cs
@@ -115,7 +115,6 @@ namespace Iot.Device.Mcp23xxx.Tests
             private readonly bool _isSpi;
             // OLATB address is 0x15
             private readonly byte[] _registers;
-#pragma warning disable SA1011
             private byte[]? _lastReadBuffer;
             private byte[]? _lastWriteBuffer;
 

--- a/src/devices/Mcp25xxx/samples/Program.cs
+++ b/src/devices/Mcp25xxx/samples/Program.cs
@@ -34,7 +34,7 @@ ReadAllRegistersWithDetails(mcp25xxx);
 // Methods
 Mcp25xxx GetMcp25xxxDevice()
 {
-    SpiConnectionSettings spiConnectionSettings = new (0, 0);
+    SpiConnectionSettings spiConnectionSettings = new(0, 0);
     SpiDevice spiDevice = SpiDevice.Create(spiConnectionSettings);
     return new Mcp25625(spiDevice);
 }

--- a/src/devices/Mcp25xxx/tests/Mcp25xxxSpiDevice.cs
+++ b/src/devices/Mcp25xxx/tests/Mcp25xxxSpiDevice.cs
@@ -9,7 +9,6 @@ namespace Iot.Device.Mcp25xxx.Tests
     public class Mcp25xxxSpiDevice : SpiDevice
     {
         public override SpiConnectionSettings ConnectionSettings => throw new NotImplementedException();
-#pragma warning disable SA1011
         public byte[]? LastReadBuffer { get; set; }
 
         public byte LastReadByte { get; set; }

--- a/src/devices/Mcp3428/samples/Program.cs
+++ b/src/devices/Mcp3428/samples/Program.cs
@@ -8,9 +8,9 @@ using System.Threading;
 using Iot.Device.Mcp3428;
 
 Console.WriteLine("Hello Mcp3428 Sample!");
-I2cConnectionSettings options = new (1, Mcp3428.I2CAddressFromPins(PinState.Low, PinState.Low));
+I2cConnectionSettings options = new(1, Mcp3428.I2CAddressFromPins(PinState.Low, PinState.Low));
 using I2cDevice i2cDevice = I2cDevice.Create(options);
-using Mcp3428 adc = new (i2cDevice, AdcMode.OneShot, resolution: AdcResolution.Bit16, pgaGain: AdcGain.X1);
+using Mcp3428 adc = new(i2cDevice, AdcMode.OneShot, resolution: AdcResolution.Bit16, pgaGain: AdcGain.X1);
 var watch = new Stopwatch();
 watch.Start();
 while (true)

--- a/src/devices/Mcp9808/samples/Program.cs
+++ b/src/devices/Mcp9808/samples/Program.cs
@@ -6,7 +6,7 @@ using System.Device.I2c;
 using System.Threading;
 using Iot.Device.Mcp9808;
 
-I2cConnectionSettings settings = new (1, Mcp9808.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Mcp9808.DefaultI2cAddress);
 using I2cDevice device = I2cDevice.Create(settings);
 
 using Mcp9808 sensor = new Mcp9808(device);

--- a/src/devices/Media/SoundDevice/samples/Program.cs
+++ b/src/devices/Media/SoundDevice/samples/Program.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Iot.Device.Media;
 
-SoundConnectionSettings settings = new ();
+SoundConnectionSettings settings = new();
 using SoundDevice device = SoundDevice.Create(settings);
 
 string path = Directory.GetCurrentDirectory();

--- a/src/devices/Media/VideoDevice/samples/Program.cs
+++ b/src/devices/Media/VideoDevice/samples/Program.cs
@@ -6,7 +6,7 @@ using System.Drawing;
 using System.IO;
 using Iot.Device.Media;
 
-VideoConnectionSettings settings = new (0, (2560, 1920), PixelFormat.JPEG);
+VideoConnectionSettings settings = new(0, (2560, 1920), PixelFormat.JPEG);
 using VideoDevice device = VideoDevice.Create(settings);
 
 // Get the supported formats of the device

--- a/src/devices/Mhz19b/samples/Program.cs
+++ b/src/devices/Mhz19b/samples/Program.cs
@@ -10,14 +10,14 @@ using Iot.Device.Mhz19b;
 using UnitsNet;
 
 // create serial port using the setting acc. to datasheet, pg. 7, sec. general settings
-using SerialPort serialPort = new ("/dev/serial0", 9600, Parity.None, 8, StopBits.One)
+using SerialPort serialPort = new("/dev/serial0", 9600, Parity.None, 8, StopBits.One)
 {
     Encoding = Encoding.ASCII,
     ReadTimeout = 1000,
     WriteTimeout = 1000
 };
 serialPort.Open();
-using Mhz19b sensor = new (serialPort.BaseStream, true);
+using Mhz19b sensor = new(serialPort.BaseStream, true);
 
 // Alternatively you can let the binding create the serial port stream:
 // Mhz19b sensor = new Mhz19b("/dev/serial0");

--- a/src/devices/Mlx90614/samples/Program.cs
+++ b/src/devices/Mlx90614/samples/Program.cs
@@ -6,10 +6,10 @@ using System.Device.I2c;
 using System.Threading;
 using Iot.Device.Mlx90614;
 
-I2cConnectionSettings settings = new (1, Mlx90614.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Mlx90614.DefaultI2cAddress);
 using I2cDevice i2cDevice = I2cDevice.Create(settings);
 
-using Mlx90614 sensor = new (i2cDevice);
+using Mlx90614 sensor = new(i2cDevice);
 while (true)
 {
     Console.WriteLine($"Ambient: {sensor.ReadAmbientTemperature().DegreesCelsius} ℃");

--- a/src/devices/MotorHat/samples/Program.cs
+++ b/src/devices/MotorHat/samples/Program.cs
@@ -14,8 +14,8 @@ Stopwatch sw = Stopwatch.StartNew();
 // var busId = 1;
 // var selectedI2cAddress = 0b000000;     // A5 A4 A3 A2 A1 A0
 // var deviceAddress = MotorHat.I2cAddressBase + selectedI2cAddress;
-// I2cConnectionSettings settings = new (busId, deviceAddress);
-using MotorHat motorHat = new ();
+// I2cConnectionSettings settings = new(busId, deviceAddress);
+using MotorHat motorHat = new();
 using DCMotor motor = motorHat.CreateDCMotor(1);
 
 bool done = false;

--- a/src/devices/Mpr121/samples/Program.cs
+++ b/src/devices/Mpr121/samples/Program.cs
@@ -8,7 +8,7 @@ using Iot.Device.Mpr121;
 using I2cDevice i2cDevice = I2cDevice.Create(new I2cConnectionSettings(busId: 1, deviceAddress: Mpr121.DefaultI2cAddress));
 
 // Initialize controller with default configuration and auto-refresh the channel statuses every 100 ms.
-using Mpr121 mpr121 = new (i2cDevice: i2cDevice, periodRefresh: 100);
+using Mpr121 mpr121 = new(i2cDevice: i2cDevice, periodRefresh: 100);
 
 Console.Clear();
 Console.CursorVisible = false;

--- a/src/devices/Mpu9250/Mpu6500.cs
+++ b/src/devices/Mpu9250/Mpu6500.cs
@@ -500,7 +500,7 @@ namespace Iot.Device.Imu
         /// The result bias will be stored in the AcceloremeterBias and GyroscopeBias
         /// </summary>
         /// <returns>Gyroscope and accelerometer bias</returns>
-        public (Vector3 gyroscopeBias, Vector3 accelerometerBias) CalibrateGyroscopeAccelerometer()
+        public (Vector3 GyroscopeBias, Vector3 AccelerometerBias) CalibrateGyroscopeAccelerometer()
         {
             // = 131 LSB/degrees/sec
             const int GyroSensitivity = 131;
@@ -692,7 +692,7 @@ namespace Iot.Device.Imu
         /// ]]>
         /// </summary>
         /// <returns>the gyroscope and accelerometer vectors</returns>
-        public (Vector3 gyroscopeAverage, Vector3 accelerometerAverage) RunGyroscopeAccelerometerSelfTest()
+        public (Vector3 GyroscopeAverage, Vector3 AccelerometerAverage) RunGyroscopeAccelerometerSelfTest()
         {
             // Used for the number of cycles to run the test
             // Value is 200 according to documentation AN-MPU-9250A-03

--- a/src/devices/Mpu9250/samples/Program.cs
+++ b/src/devices/Mpu9250/samples/Program.cs
@@ -24,12 +24,12 @@ else
 
 void MagnetometerCalibrationDeepDive(int calibrationCount)
 {
-    I2cConnectionSettings mpui2CConnectionSettingmpus = new (1, Mpu9250.DefaultI2cAddress);
-    using Mpu9250 mpu9250 = new (I2cDevice.Create(mpui2CConnectionSettingmpus));
+    I2cConnectionSettings mpui2CConnectionSettingmpus = new(1, Mpu9250.DefaultI2cAddress);
+    using Mpu9250 mpu9250 = new(I2cDevice.Create(mpui2CConnectionSettingmpus));
     mpu9250.MagnetometerOutputBitMode = OutputBitMode.Output16bit;
     mpu9250.MagnetometerMeasurementMode = MeasurementMode.ContinuousMeasurement100Hz;
     Console.WriteLine("Please move the magnetometer during calibration");
-    using StreamWriter ioWriter = new ("mag.csv");
+    using StreamWriter ioWriter = new("mag.csv");
     // First we read the data without calibration at all
     Console.WriteLine("Reading magnetometer data without calibration");
     ioWriter.WriteLine($"X;Y;Z");
@@ -83,7 +83,7 @@ void MagnetometerCalibrationDeepDive(int calibrationCount)
 
 void MainTest()
 {
-    I2cConnectionSettings mpui2CConnectionSettingmpus = new (1, Mpu9250.DefaultI2cAddress);
+    I2cConnectionSettings mpui2CConnectionSettingmpus = new(1, Mpu9250.DefaultI2cAddress);
     using Mpu9250 mpu9250 = new Mpu9250(I2cDevice.Create(mpui2CConnectionSettingmpus));
     Console.WriteLine($"Check version magnetometer: {mpu9250.GetMagnetometerVersion()}");
     Console.WriteLine(
@@ -102,12 +102,12 @@ void MainTest()
 
     var resSelfTest = mpu9250.RunGyroscopeAccelerometerSelfTest();
     Console.WriteLine($"Self test:");
-    Console.WriteLine($"Gyro X = {resSelfTest.Item1.X} vs >0.005");
-    Console.WriteLine($"Gyro Y = {resSelfTest.Item1.Y} vs >0.005");
-    Console.WriteLine($"Gyro Z = {resSelfTest.Item1.Z} vs >0.005");
-    Console.WriteLine($"Acc X = {resSelfTest.Item2.X} vs >0.005 & <0.015");
-    Console.WriteLine($"Acc Y = {resSelfTest.Item2.Y} vs >0.005 & <0.015");
-    Console.WriteLine($"Acc Z = {resSelfTest.Item2.Z} vs >0.005 & <0.015");
+    Console.WriteLine($"Gyro X = {resSelfTest.GyroscopeAverage.X} vs >0.005");
+    Console.WriteLine($"Gyro Y = {resSelfTest.GyroscopeAverage.Y} vs >0.005");
+    Console.WriteLine($"Gyro Z = {resSelfTest.GyroscopeAverage.Z} vs >0.005");
+    Console.WriteLine($"Acc X = {resSelfTest.AccelerometerAverage.X} vs >0.005 & <0.015");
+    Console.WriteLine($"Acc Y = {resSelfTest.AccelerometerAverage.Y} vs >0.005 & <0.015");
+    Console.WriteLine($"Acc Z = {resSelfTest.AccelerometerAverage.Z} vs >0.005 & <0.015");
     Console.WriteLine("Running Gyroscope and Accelerometer calibration");
     mpu9250.CalibrateGyroscopeAccelerometer();
     Console.WriteLine("Calibration results:");

--- a/src/devices/Nrf24l01/samples/Program.cs
+++ b/src/devices/Nrf24l01/samples/Program.cs
@@ -8,13 +8,13 @@ using System.Threading;
 using Iot.Device.Nrf24l01;
 
 // SPI0 CS0
-SpiConnectionSettings senderSettings = new (0, 0)
+SpiConnectionSettings senderSettings = new(0, 0)
 {
     ClockFrequency = Nrf24l01.SpiClockFrequency,
     Mode = Nrf24l01.SpiMode
 };
 // SPI1 CS0
-SpiConnectionSettings receiverSettings = new (1, 2)
+SpiConnectionSettings receiverSettings = new(1, 2)
 {
     ClockFrequency = Nrf24l01.SpiClockFrequency,
     Mode = Nrf24l01.SpiMode
@@ -23,8 +23,8 @@ using SpiDevice senderDevice = SpiDevice.Create(senderSettings);
 using SpiDevice receiverDevice = SpiDevice.Create(receiverSettings);
 
 // SPI Device, CE Pin, IRQ Pin, Receive Packet Size
-using Nrf24l01 sender = new (senderDevice, 23, 24, 20);
-using Nrf24l01 receiver = new (receiverDevice, 5, 6, 20);
+using Nrf24l01 sender = new(senderDevice, 23, 24, 20);
+using Nrf24l01 receiver = new(receiverDevice, 5, 6, 20);
 // Set sender send address, receiver pipe0 address (Optional)
 byte[] receiverAddress = Encoding.UTF8.GetBytes("NRF24");
 sender.Address = receiverAddress;

--- a/src/devices/OneWire/OneWireDevice.cs
+++ b/src/devices/OneWire/OneWireDevice.cs
@@ -27,7 +27,7 @@ namespace Iot.Device.OneWire
         /// </summary>
         /// <param name="family">Family id used to filter devices.</param>
         /// <returns>A list of devices found.</returns>
-        public static IEnumerable<(string busId, string devId)> EnumerateDeviceIds(DeviceFamily family = DeviceFamily.Any)
+        public static IEnumerable<(string BusId, string DevId)> EnumerateDeviceIds(DeviceFamily family = DeviceFamily.Any)
         {
             foreach (var busId in OneWireBus.EnumerateBusIdsInternal())
             {

--- a/src/devices/OneWire/samples/Program.cs
+++ b/src/devices/OneWire/samples/Program.cs
@@ -22,16 +22,16 @@ else
     // More advanced way, with rescanning the bus and iterating devices per 1-wire bus
     foreach (string busId in OneWireBus.EnumerateBusIds())
     {
-        OneWireBus bus = new (busId);
+        OneWireBus bus = new(busId);
         Console.WriteLine($"Found bus '{bus.BusId}', scanning for devices ...");
         await bus.ScanForDeviceChangesAsync();
         foreach (string devId in bus.EnumerateDeviceIds())
         {
-            OneWireDevice dev = new (busId, devId);
+            OneWireDevice dev = new(busId, devId);
             Console.WriteLine($"Found family '{dev.Family}' device '{dev.DeviceId}' on '{bus.BusId}'");
             if (OneWireThermometerDevice.IsCompatible(busId, devId))
             {
-                OneWireThermometerDevice devTemp = new (busId, devId);
+                OneWireThermometerDevice devTemp = new(busId, devId);
                 Console.WriteLine("Temperature reported by device: " +
                                     (await devTemp.ReadTemperatureAsync()).DegreesCelsius.ToString("F2") +
                                     "\u00B0C");

--- a/src/devices/Pca95x4/samples/Program.cs
+++ b/src/devices/Pca95x4/samples/Program.cs
@@ -18,7 +18,7 @@ CheckInputRegisterPolarityInversion(pca95x4);
 
 Pca95x4 GetPca95x4Device()
 {
-    I2cConnectionSettings i2cConnectionSettings = new (1, s_deviceAddress);
+    I2cConnectionSettings i2cConnectionSettings = new(1, s_deviceAddress);
     I2cDevice i2cDevice = I2cDevice.Create(i2cConnectionSettings);
     return new Pca95x4(i2cDevice);
 }

--- a/src/devices/Pca9685/Pca9685.cs
+++ b/src/devices/Pca9685/Pca9685.cs
@@ -311,7 +311,7 @@ namespace Iot.Device.Pwm
             _device.Write(bytes);
         }
 
-        private static (ushort on, ushort off) DutyCycleToOnOff(double dutyCycle)
+        private static (ushort On, ushort Off) DutyCycleToOnOff(double dutyCycle)
         {
             Debug.Assert(dutyCycle >= 0.0 && dutyCycle <= 1.0, "Duty cycle must be between 0 and 1");
 

--- a/src/devices/Pca9685/samples/Program.cs
+++ b/src/devices/Pca9685/samples/Program.cs
@@ -32,8 +32,6 @@ Console.WriteLine($"PWM Frequency: {pca9685.PwmFrequency}Hz");
 Console.WriteLine();
 PrintHelp();
 
-#pragma warning disable SA1011
-
 while (true)
 {
     string[]? command = Console.ReadLine()?.ToLower()?.Split(' ');

--- a/src/devices/Pca9685/samples/Program.cs
+++ b/src/devices/Pca9685/samples/Program.cs
@@ -22,10 +22,10 @@ var busId = 1;
 var selectedI2cAddress = 0b000000; // A5 A4 A3 A2 A1 A0
 var deviceAddress = Pca9685.I2cAddressBase + selectedI2cAddress;
 
-I2cConnectionSettings settings = new (busId, deviceAddress);
+I2cConnectionSettings settings = new(busId, deviceAddress);
 using I2cDevice device = I2cDevice.Create(settings);
 
-using Pca9685 pca9685 = new (device);
+using Pca9685 pca9685 = new(device);
 Console.WriteLine(
     $"PCA9685 is ready on I2C bus {device.ConnectionSettings.BusId} with address {device.ConnectionSettings.DeviceAddress}");
 Console.WriteLine($"PWM Frequency: {pca9685.PwmFrequency}Hz");

--- a/src/devices/Pcx857x/tests/Pcx857xTest.cs
+++ b/src/devices/Pcx857x/tests/Pcx857xTest.cs
@@ -76,7 +76,6 @@ namespace Iot.Device.Pcx857x.Tests
         public class Pcx857xChipMock
         {
             private int _ports;
-#pragma warning disable SA1011
             private byte[] _registers;
             private byte[]? _lastReadBuffer;
             private byte[]? _lastWriteBuffer;

--- a/src/devices/Pn5180/Pn5180.cs
+++ b/src/devices/Pn5180/Pn5180.cs
@@ -128,7 +128,7 @@ namespace Iot.Device.Pn5180
         /// Get the Product, Firmware and EEPROM versions of the PN8150
         /// </summary>
         /// <returns>A tuple with the Product, Firmware and EEPROM versions</returns>
-        public (Version? product, Version? firmware, Version? eeprom) GetVersions()
+        public (Version? Product, Version? Firmware, Version? Eeprom) GetVersions()
         {
             Span<byte> versionAnswer = stackalloc byte[6];
 
@@ -432,7 +432,7 @@ namespace Iot.Device.Pn5180
         /// If the full byte is valid then the value of the valid bit is 0
         /// </summary>
         /// <returns>A tuple whit the number of bytes to read and the number of valid bits in the last byte. If all bits are valid, then the value of valid bits is 0</returns>
-        public (int bytes, int validBits) GetNumberOfBytesReceivedAndValidBits()
+        public (int Bytes, int ValidBits) GetNumberOfBytesReceivedAndValidBits()
         {
             try
             {

--- a/src/devices/Pn5180/samples/Program.cs
+++ b/src/devices/Pn5180/samples/Program.cs
@@ -84,7 +84,7 @@ Pn5180 HardwareSpi()
     SpiDevice spi = SpiDevice.Create(new SpiConnectionSettings(0, 1) { ClockFrequency = Pn5180.MaximumSpiClockFrequency, Mode = Pn5180.DefaultSpiMode, DataFlow = DataFlow.MsbFirst });
 
     // Reset the device
-    using GpioController gpioController = new ();
+    using GpioController gpioController = new();
     gpioController.OpenPin(4, PinMode.Output);
     gpioController.Write(4, PinValue.Low);
     Thread.Sleep(10);
@@ -115,7 +115,7 @@ Pn5180 Ft4222()
 
     Ft4222Spi ftSpi = new Ft4222Spi(new SpiConnectionSettings(0, 1) { ClockFrequency = Pn5180.MaximumSpiClockFrequency, Mode = Pn5180.DefaultSpiMode, DataFlow = DataFlow.MsbFirst });
 
-    using GpioController gpioController = new (PinNumberingScheme.Board, new Ft4222Gpio());
+    using GpioController gpioController = new(PinNumberingScheme.Board, new Ft4222Gpio());
 
     // Reset the device
     gpioController.OpenPin(0, PinMode.Output);

--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -17,8 +17,6 @@ using Iot.Device.Pn532.RfConfiguration;
 using Iot.Device.Rfid;
 using IoT.Device.Pn532;
 
-#pragma warning disable SA1011
-
 namespace Iot.Device.Pn532
 {
     /// <summary>

--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -853,7 +853,7 @@ namespace Iot.Device.Pn532
         /// <summary>
         /// Set the PN532 as a target, so as a card
         /// </summary>
-        public (TargetModeInitialized? modeInialized, byte[]? initiator) InitAsTarget(TargetModeInitialization mode,
+        public (TargetModeInitialized? ModeInialized, byte[]? Initiator) InitAsTarget(TargetModeInitialization mode,
             TargetMifareParameters mifare, TargetFeliCaParameters feliCa, TargetPiccParameters picc)
         {
             // First make sure we have the right mode in the parameters for the PICC only case

--- a/src/devices/Pn532/samples/Program.cs
+++ b/src/devices/Pn532/samples/Program.cs
@@ -102,7 +102,7 @@ void ReadMiFare(Pn532 pn532)
             Console.WriteLine($", ATS: {BitConverter.ToString(decrypted.Ats)}");
         }
 
-        MifareCard mifareCard = new (pn532, decrypted.TargetNumber)
+        MifareCard mifareCard = new(pn532, decrypted.TargetNumber)
         {
             BlockNumber = 0, Command = MifareCardCommand.AuthenticationA
         };

--- a/src/devices/Pn532/samples/Program.cs
+++ b/src/devices/Pn532/samples/Program.cs
@@ -11,8 +11,6 @@ using Iot.Device.Card.Mifare;
 using Iot.Device.Pn532;
 using Iot.Device.Pn532.ListPassive;
 
-#pragma warning disable SA1011
-
 string device = "/dev/ttyS0";
 using Pn532 pn532 = new Pn532(device);
 if (args.Length > 0)

--- a/src/devices/RGBLedMatrix/samples/Program.cs
+++ b/src/devices/RGBLedMatrix/samples/Program.cs
@@ -22,18 +22,18 @@ string weatherKey = "Please request a key from openweathermap.org";
 
 CityData[] citiesData = new CityData[]
 {
-    new ("New York", "US", "America/New_York"),
-    new ("Redmond", "US", "America/Los_Angeles"),
-    new ("Toronto", "CA", "America/Toronto"),
-    new ("Mexico", "MX", "America/Mexico_City"),
-    new ("Madrid", "ES", "Europe/Madrid"),
-    new ("London", "UK", "Europe/London"),
-    new ("Paris", "FR", "Europe/Paris"),
-    new ("Rome", "IT", "Europe/Rome"),
-    new ("Moscow", "RU", "Europe/Moscow"),
-    new ("Casablanca", "MA", "Africa/Casablanca"),
-    new ("Cairo", "EG", "Africa/Cairo"),
-    new ("Riyadh", "SA", "Asia/Riyadh")
+    new("New York", "US", "America/New_York"),
+    new("Redmond", "US", "America/Los_Angeles"),
+    new("Toronto", "CA", "America/Toronto"),
+    new("Mexico", "MX", "America/Mexico_City"),
+    new("Madrid", "ES", "Europe/Madrid"),
+    new("London", "UK", "Europe/London"),
+    new("Paris", "FR", "Europe/Paris"),
+    new("Rome", "IT", "Europe/Rome"),
+    new("Moscow", "RU", "Europe/Moscow"),
+    new("Casablanca", "MA", "Africa/Casablanca"),
+    new("Cairo", "EG", "Africa/Cairo"),
+    new("Riyadh", "SA", "Asia/Riyadh")
 };
 
 Console.WriteLine($"Hello Matrix World!");

--- a/src/devices/RadioReceiver/samples/Program.cs
+++ b/src/devices/RadioReceiver/samples/Program.cs
@@ -6,7 +6,7 @@ using System.Device.I2c;
 using Iot.Device.RadioReceiver;
 using UnitsNet;
 
-I2cConnectionSettings settings = new (1, Tea5767.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Tea5767.DefaultI2cAddress);
 using I2cDevice device = I2cDevice.Create(settings);
 
 using Tea5767 radio = new Tea5767(device, FrequencyRange.Other, Frequency.FromMegahertz(103.3));

--- a/src/devices/RadioTransmitter/samples/Program.cs
+++ b/src/devices/RadioTransmitter/samples/Program.cs
@@ -5,9 +5,9 @@ using System;
 using System.Device.I2c;
 using Iot.Device.RadioTransmitter;
 
-I2cConnectionSettings settings = new (1, Kt0803.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Kt0803.DefaultI2cAddress);
 using I2cDevice device = I2cDevice.Create(settings);
 
-using Kt0803 radio = new (device, 106.6, Region.China);
+using Kt0803 radio = new(device, 106.6, Region.China);
 Console.WriteLine($"The radio is running on FM {radio.Frequency.ToString("0.0")}MHz");
 Console.ReadKey();

--- a/src/devices/Rtc/samples/Program.cs
+++ b/src/devices/Rtc/samples/Program.cs
@@ -4,10 +4,10 @@ using System.Threading;
 using Iot.Device.Rtc;
 
 // This project contains DS1307, DS3231, PCF8563
-I2cConnectionSettings settings = new (1, Ds3231.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Ds3231.DefaultI2cAddress);
 I2cDevice device = I2cDevice.Create(settings);
 
-using Ds3231 rtc = new (device);
+using Ds3231 rtc = new(device);
 // set time
 rtc.DateTime = DateTime.Now;
 

--- a/src/devices/Seesaw/samples/Seesaw.Sample.BlinkingLights.cs
+++ b/src/devices/Seesaw/samples/Seesaw.Sample.BlinkingLights.cs
@@ -21,7 +21,7 @@ const int initialSleep = 100;
 int sleep = initialSleep;
 Volume? volume = null;
 
-TimeEnvelope[] envelopes = new TimeEnvelope[] { new (1000), new (1000), new (4000) };
+TimeEnvelope[] envelopes = new TimeEnvelope[] { new(1000), new(1000), new(4000) };
 
 Console.WriteLine("Hello World!");
 

--- a/src/devices/Seesaw/samples/Seesaw.Sample.Capabilities.cs
+++ b/src/devices/Seesaw/samples/Seesaw.Sample.Capabilities.cs
@@ -10,7 +10,7 @@ const byte AdafruitSeesawBreakoutI2cAddress = 0x49;
 const byte AdafruitSeesawBreakoutI2cBus = 0x1;
 
 using I2cDevice i2cDevice = I2cDevice.Create(new I2cConnectionSettings(AdafruitSeesawBreakoutI2cBus, AdafruitSeesawBreakoutI2cAddress));
-using Seesaw ssDevice = new (i2cDevice);
+using Seesaw ssDevice = new(i2cDevice);
 Console.WriteLine();
 Console.WriteLine($"Seesaw Version: {ssDevice.Version}");
 Console.WriteLine();

--- a/src/devices/Seesaw/samples/Seesaw.Sample.SoilSensor.cs
+++ b/src/devices/Seesaw/samples/Seesaw.Sample.SoilSensor.cs
@@ -10,7 +10,7 @@ const byte AdafruitSeesawSoilSensorI2cAddress = 0x36;
 const byte AdafruitSeesawSoilSensorI2cBus = 0x1;
 
 using I2cDevice i2cDevice = I2cDevice.Create(new I2cConnectionSettings(AdafruitSeesawSoilSensorI2cBus, AdafruitSeesawSoilSensorI2cAddress));
-using Seesaw ssDevice = new (i2cDevice);
+using Seesaw ssDevice = new(i2cDevice);
 while (true)
 {
     Console.WriteLine($"Temperature: {ssDevice.GetTemperature()}'C");

--- a/src/devices/Seesaw/samples/Volume.cs
+++ b/src/devices/Seesaw/samples/Volume.cs
@@ -29,7 +29,7 @@ internal class Volume
     private void Init() =>
         _lastValue = GetVolumeValue();
 
-    public (bool update, int value) GetSleepForVolume(int sleep)
+    public (bool Update, int Value) GetSleepForVolume(int sleep)
     {
         var value = GetVolumeValue();
         if (value > _lastValue - 2 && value < _lastValue + 2)

--- a/src/devices/SenseHat/SenseHatAccelerometerAndGyroscope.cs
+++ b/src/devices/SenseHat/SenseHatAccelerometerAndGyroscope.cs
@@ -32,7 +32,7 @@ namespace Iot.Device.SenseHat
 
         private static I2cDevice CreateDefaultI2cDevice()
         {
-            I2cConnectionSettings settings = new (1, I2cAddress);
+            I2cConnectionSettings settings = new(1, I2cAddress);
             return I2cDevice.Create(settings);
         }
     }

--- a/src/devices/SenseHat/SenseHatJoystick.cs
+++ b/src/devices/SenseHat/SenseHatJoystick.cs
@@ -69,7 +69,7 @@ namespace Iot.Device.SenseHat
 
         private static I2cDevice CreateDefaultI2cDevice()
         {
-            I2cConnectionSettings settings = new (1, I2cAddress);
+            I2cConnectionSettings settings = new(1, I2cAddress);
             return I2cDevice.Create(settings);
         }
 

--- a/src/devices/SenseHat/SenseHatLedMatrix.cs
+++ b/src/devices/SenseHat/SenseHatLedMatrix.cs
@@ -65,7 +65,7 @@ namespace Iot.Device.SenseHat
         /// <param name="index">Index</param>
         /// <returns>Tuple of X and Y coordinates</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static (int x, int y) IndexToPosition(int index)
+        public static (int X, int Y) IndexToPosition(int index)
         {
             if (index < 0 || index >= NumberOfPixelsPerRow * NumberOfPixelsPerRow)
             {

--- a/src/devices/SenseHat/SenseHatLedMatrixI2c.cs
+++ b/src/devices/SenseHat/SenseHatLedMatrixI2c.cs
@@ -134,7 +134,7 @@ namespace Iot.Device.SenseHat
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static (byte r, byte g, byte b) DestructColor(Color color)
+        private static (byte R, byte G, byte B) DestructColor(Color color)
         {
             // 5-bit (shift by 3) look much closer to native driver (SysFs implementation)
             // but this driver is directly reflecting the registers so we will leave the
@@ -150,7 +150,7 @@ namespace Iot.Device.SenseHat
 
         private static I2cDevice CreateDefaultI2cDevice()
         {
-            I2cConnectionSettings settings = new (1, I2cAddress);
+            I2cConnectionSettings settings = new(1, I2cAddress);
             return I2cDevice.Create(settings);
         }
 

--- a/src/devices/SenseHat/SenseHatPressureAndTemperature.cs
+++ b/src/devices/SenseHat/SenseHatPressureAndTemperature.cs
@@ -26,7 +26,7 @@ namespace Iot.Device.SenseHat
 
         private static I2cDevice CreateDefaultI2cDevice()
         {
-            I2cConnectionSettings settings = new (1, I2cAddress);
+            I2cConnectionSettings settings = new(1, I2cAddress);
             return I2cDevice.Create(settings);
         }
     }

--- a/src/devices/SenseHat/SenseHatTemperatureAndHumidity.cs
+++ b/src/devices/SenseHat/SenseHatTemperatureAndHumidity.cs
@@ -26,7 +26,7 @@ namespace Iot.Device.SenseHat
 
         private static I2cDevice CreateDefaultI2cDevice()
         {
-            I2cConnectionSettings settings = new (1, I2cAddress);
+            I2cConnectionSettings settings = new(1, I2cAddress);
             return I2cDevice.Create(settings);
         }
     }

--- a/src/devices/SenseHat/samples/AccelerometerAndGyroscope.Sample.cs
+++ b/src/devices/SenseHat/samples/AccelerometerAndGyroscope.Sample.cs
@@ -14,7 +14,7 @@ namespace Iot.Device.SenseHat.Samples
     {
         public static void Run()
         {
-            using SenseHatAccelerometerAndGyroscope ag = new ();
+            using SenseHatAccelerometerAndGyroscope ag = new();
             while (true)
             {
                 Console.WriteLine($"Acceleration={ag.Acceleration}");

--- a/src/devices/SenseHat/samples/Joystick.Sample.cs
+++ b/src/devices/SenseHat/samples/Joystick.Sample.cs
@@ -14,7 +14,7 @@ namespace Iot.Device.SenseHat.Samples
     {
         public static void Run()
         {
-            using SenseHatJoystick j = new ();
+            using SenseHatJoystick j = new();
             while (true)
             {
                 j.Read();

--- a/src/devices/SenseHat/samples/LedMatrix.Sample.cs
+++ b/src/devices/SenseHat/samples/LedMatrix.Sample.cs
@@ -17,7 +17,7 @@ namespace Iot.Device.SenseHat.Samples
             // another implementation which can be used is: SenseHatLedMatrixSysFs
             // I2C implementation does not require installing anything
             // SysFs implementation is faster and has arguably better colors
-            using SenseHatLedMatrixI2c ledMatrix = new ();
+            using SenseHatLedMatrixI2c ledMatrix = new();
             WriteDemo(ledMatrix);
 
             // Uncomment to see demo of SetPixel/Fill

--- a/src/devices/SenseHat/samples/Magnetometer.Sample.cs
+++ b/src/devices/SenseHat/samples/Magnetometer.Sample.cs
@@ -15,8 +15,8 @@ namespace Iot.Device.SenseHat.Samples
     {
         public static void Run()
         {
-            using SenseHatMagnetometer magnetometer = new ();
-            using SenseHatLedMatrixI2c ledMatrix = new ();
+            using SenseHatMagnetometer magnetometer = new();
+            using SenseHatLedMatrixI2c ledMatrix = new();
             Console.WriteLine("Move SenseHat around in every direction until dot on the LED matrix stabilizes when not moving.");
             ledMatrix.Fill();
             Stopwatch sw = Stopwatch.StartNew();

--- a/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
+++ b/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
@@ -19,7 +19,7 @@ namespace Iot.Device.SenseHat.Samples
             // set this to the current sea level pressure in the area for correct altitude readings
             var defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
 
-            using SenseHatPressureAndTemperature pt = new ();
+            using SenseHatPressureAndTemperature pt = new();
             while (true)
             {
                 var tempValue = pt.Temperature;

--- a/src/devices/SenseHat/samples/Program.cs
+++ b/src/devices/SenseHat/samples/Program.cs
@@ -11,7 +11,7 @@ using UnitsNet;
 // set this to the current sea level pressure in the area for correct altitude readings
 var defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
 
-using SenseHat sh = new ();
+using SenseHat sh = new();
 int n = 0;
 int x = 3, y = 3;
 

--- a/src/devices/SenseHat/samples/TemperatureAndHumidity.Sample.cs
+++ b/src/devices/SenseHat/samples/TemperatureAndHumidity.Sample.cs
@@ -16,7 +16,7 @@ namespace Iot.Device.SenseHat.Samples
     {
         public static void Run()
         {
-            using SenseHatTemperatureAndHumidity th = new ();
+            using SenseHatTemperatureAndHumidity th = new();
             while (true)
             {
                 var tempValue = th.Temperature;

--- a/src/devices/ShiftRegister/samples/Program.cs
+++ b/src/devices/ShiftRegister/samples/Program.cs
@@ -10,10 +10,10 @@ using Iot.Device.Multiplexing;
 using ShiftRegister sr = new ShiftRegister(ShiftRegisterPinMapping.Complete, 8);
 
 // Uncomment this code to use SPI (and comment the line above)
-// SpiConnectionSettings settings = new (0, 0);
+// SpiConnectionSettings settings = new(0, 0);
 // using var spiDevice = SpiDevice.Create(settings);
 // var sr = new Sn74hc595(spiDevice, Sn74hc595.PinMapping.Standard);
-CancellationTokenSource cancellationSource = new ();
+CancellationTokenSource cancellationSource = new();
 Console.CancelKeyPress += (s, e) =>
 {
     e.Cancel = true;

--- a/src/devices/Sht3x/samples/Program.cs
+++ b/src/devices/Sht3x/samples/Program.cs
@@ -8,9 +8,9 @@ using Iot.Device.Common;
 using Iot.Device.Sht3x;
 using UnitsNet;
 
-I2cConnectionSettings settings = new (1, (byte)I2cAddress.AddrLow);
+I2cConnectionSettings settings = new(1, (byte)I2cAddress.AddrLow);
 using I2cDevice device = I2cDevice.Create(settings);
-using Sht3x sensor = new (device);
+using Sht3x sensor = new(device);
 while (true)
 {
     Temperature tempValue = sensor.Temperature;

--- a/src/devices/Shtc3/samples/Program.cs
+++ b/src/devices/Shtc3/samples/Program.cs
@@ -8,9 +8,9 @@ using Iot.Device.Common;
 using Iot.Device.Shtc3;
 using UnitsNet;
 
-I2cConnectionSettings settings = new (1, Iot.Device.Shtc3.Shtc3.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Iot.Device.Shtc3.Shtc3.DefaultI2cAddress);
 using I2cDevice device = I2cDevice.Create(settings);
-using Shtc3 sensor = new (device);
+using Shtc3 sensor = new(device);
 Console.WriteLine($"Sensor Id: {sensor.Id}");
 while (true)
 {

--- a/src/devices/Si7021/samples/Program.cs
+++ b/src/devices/Si7021/samples/Program.cs
@@ -8,9 +8,9 @@ using Iot.Device.Common;
 using Iot.Device.Si7021;
 using UnitsNet;
 
-I2cConnectionSettings settings = new (1, Si7021.DefaultI2cAddress);
+I2cConnectionSettings settings = new(1, Si7021.DefaultI2cAddress);
 using I2cDevice device = I2cDevice.Create(settings);
-using Si7021 sensor = new (device, Resolution.Resolution1);
+using Si7021 sensor = new(device, Resolution.Resolution1);
 while (true)
 {
     var tempValue = sensor.Temperature;

--- a/src/devices/Sn74hc595/samples/Program.cs
+++ b/src/devices/Sn74hc595/samples/Program.cs
@@ -7,11 +7,11 @@ using System.Device.Spi;
 using System.Threading;
 using Iot.Device.Multiplexing;
 
-using Sn74hc595 sr = new (Sn74hc595PinMapping.Complete);
-// SpiConnectionSettings settings = new (0, 0);
+using Sn74hc595 sr = new(Sn74hc595PinMapping.Complete);
+// SpiConnectionSettings settings = new(0, 0);
 // using var spiDevice = SpiDevice.Create(settings);
 // var sr = new Sn74hc595(spiDevice, Sn74hc595.PinMapping.Standard);
-CancellationTokenSource cancellationSource = new ();
+CancellationTokenSource cancellationSource = new();
 Console.CancelKeyPress += (s, e) =>
 {
     e.Cancel = true;

--- a/src/devices/SocketCan/samples/Program.cs
+++ b/src/devices/SocketCan/samples/Program.cs
@@ -12,7 +12,7 @@ CanId id = new CanId()
     Standard = 0x1A // arbitrary id
 };
 
-Dictionary<string, Action> samples = new ()
+Dictionary<string, Action> samples = new()
 {
     { "send", SendExample },
     { "receive", ReceiveAllExample },
@@ -69,7 +69,7 @@ void ReceiveAllExample()
 {
     Console.WriteLine("Listening for any id");
 
-    using CanRaw can = new ();
+    using CanRaw can = new();
     byte[] buffer = new byte[8];
 
     while (true)
@@ -96,7 +96,7 @@ void ReceiveOnAddressExample()
 {
     Console.WriteLine($"Listening for id = 0x{id.Value:X2}");
 
-    using CanRaw can = new ();
+    using CanRaw can = new();
     byte[] buffer = new byte[8];
     can.Filter(id);
 

--- a/src/devices/SoftPwm/SoftwarePwmChannel.cs
+++ b/src/devices/SoftPwm/SoftwarePwmChannel.cs
@@ -98,7 +98,7 @@ namespace System.Device.Pwm.Drivers
             _frequency = frequency;
             _dutyCycle = dutyCycle;
             _shouldDispose = shouldDispose || controller is null;
-            _controller = controller ?? new ();
+            _controller = controller ?? new();
 
             UpdatePulseWidthParameters();
 

--- a/src/devices/SoftPwm/samples/Program.cs
+++ b/src/devices/SoftPwm/samples/Program.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 Console.WriteLine("Hello PWM!");
 
-using SoftwarePwmChannel pwmChannel = new (17, 200, 0);
+using SoftwarePwmChannel pwmChannel = new(17, 200, 0);
 pwmChannel.Start();
 for (double fill = 0.0; fill <= 1.0; fill += 0.01)
 {

--- a/src/devices/Ssd1351/Ssd1351.cs
+++ b/src/devices/Ssd1351/Ssd1351.cs
@@ -82,7 +82,7 @@ namespace Iot.Device.Ssd1351
         ///         BBBBBGGG GGGRRRRR
         ///         43210543 21043210
         /// </returns>
-        private (byte, byte) Color565(Color color)
+        private (byte Low, byte High) Color565(Color color)
         {
             // get the top 5 MSB of the blue or red value
             UInt16 retval = (UInt16)((_colorSequence == ColorSequence.BGR ? color.B : color.R) >> 3);

--- a/src/devices/Ssd1351/Ssd1351Commands.cs
+++ b/src/devices/Ssd1351/Ssd1351Commands.cs
@@ -417,7 +417,6 @@ namespace Iot.Device.Ssd1351
             SendCommand(Ssd1351Command.SetGPIO, (byte)(((int)pin1Mode << 2) + pin0Mode));
         }
 
-#pragma warning disable SA1011
         /// <summary>
         /// This command sets the gray levels GS0 -> GS63.
         /// </summary>

--- a/src/devices/Ssd1351/samples/Program.cs
+++ b/src/devices/Ssd1351/samples/Program.cs
@@ -11,10 +11,10 @@ using Iot.Device.Ssd1351;
 const int pinID_DC = 23;
 const int pinID_Reset = 24;
 
-using Bitmap dotnetBM = new (128, 128);
+using Bitmap dotnetBM = new(128, 128);
 using Graphics g = Graphics.FromImage(dotnetBM);
 using SpiDevice displaySPI = SpiDevice.Create(new SpiConnectionSettings(0, 0) { Mode = SpiMode.Mode3, DataBitLength = 8, ClockFrequency = 12_000_000 /* 12MHz */ });
-using Ssd1351 ssd1351 = new (displaySPI, pinID_DC, pinID_Reset);
+using Ssd1351 ssd1351 = new(displaySPI, pinID_DC, pinID_Reset);
 ssd1351.ResetDisplayAsync().Wait();
 InitDisplayForAdafruit(ssd1351);
 

--- a/src/devices/Ssd13xx/Ssd1306.cs
+++ b/src/devices/Ssd13xx/Ssd1306.cs
@@ -42,7 +42,6 @@ namespace Iot.Device.Ssd13xx
         /// <param name="command">The command to send to the display controller.</param>
         private void SendCommand(ICommand command)
         {
-#pragma warning disable SA1011
             byte[]? commandBytes = command?.GetBytes();
 
             if (commandBytes is not { Length: >0 })

--- a/src/devices/Ssd13xx/Ssd1327.cs
+++ b/src/devices/Ssd13xx/Ssd1327.cs
@@ -89,7 +89,6 @@ namespace Iot.Device.Ssd13xx
 
         private void SendCommand(ICommand command)
         {
-#pragma warning disable SA1011
             byte[]? commandBytes = command?.GetBytes();
 
             if (commandBytes is not { Length: >0 })

--- a/src/devices/Ssd13xx/samples/Program.cs
+++ b/src/devices/Ssd13xx/samples/Program.cs
@@ -43,7 +43,7 @@ I2cDevice GetI2CDevice()
 {
     Console.WriteLine("Using I2C protocol");
 
-    I2cConnectionSettings connectionSettings = new (1, 0x3C);
+    I2cConnectionSettings connectionSettings = new(1, 0x3C);
     return I2cDevice.Create(connectionSettings);
 }
 

--- a/src/devices/Ssd13xx/samples/Ssd1306Extensions.cs
+++ b/src/devices/Ssd13xx/samples/Ssd1306Extensions.cs
@@ -22,7 +22,7 @@ namespace Iot.Device.Ssd13xx.Samples
         {
             Int16 width = 128;
             Int16 pages = 4;
-            List<byte> buffer = new ();
+            List<byte> buffer = new();
 
             for (int page = 0; page < pages; page++)
             {

--- a/src/devices/Tcs3472x/samples/Program.cs
+++ b/src/devices/Tcs3472x/samples/Program.cs
@@ -7,9 +7,9 @@ using System.Threading;
 using Iot.Device.Tcs3472x;
 
 Console.WriteLine("Hello TCS3472x!");
-I2cConnectionSettings i2cSettings = new (1, Tcs3472x.DefaultI2cAddress);
+I2cConnectionSettings i2cSettings = new(1, Tcs3472x.DefaultI2cAddress);
 using I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);
-using Tcs3472x tcs3472X = new (i2cDevice);
+using Tcs3472x tcs3472X = new(i2cDevice);
 while (!Console.KeyAvailable)
 {
     Console.WriteLine($"ID: {tcs3472X.ChipId} Gain: {tcs3472X.Gain} Time to wait: {tcs3472X.IsClearInterrupt}");

--- a/src/devices/Tm1637/samples/Program.cs
+++ b/src/devices/Tm1637/samples/Program.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using Iot.Device.Tm1637;
 
 Console.WriteLine("Hello Tm1637!");
-using Tm1637 tm1637 = new (20, 21);
+using Tm1637 tm1637 = new(20, 21);
 tm1637.Brightness = 7;
 tm1637.ScreenOn = true;
 tm1637.ClearDisplay();

--- a/src/devices/UFireIse/samples/Program.cs
+++ b/src/devices/UFireIse/samples/Program.cs
@@ -6,8 +6,6 @@ using System.Device.I2c;
 using Iot.Device.UFire;
 using UnitsNet;
 
-#pragma warning disable SA1011
-
 const int BusId = 1;
 
 PrintHelp();

--- a/src/devices/UFireIse/samples/Program.cs
+++ b/src/devices/UFireIse/samples/Program.cs
@@ -12,7 +12,7 @@ const int BusId = 1;
 
 PrintHelp();
 
-I2cConnectionSettings settings = new (BusId, UFireIse.I2cAddress);
+I2cConnectionSettings settings = new(BusId, UFireIse.I2cAddress);
 using I2cDevice device = I2cDevice.Create(settings);
 Console.WriteLine(
         $"UFire_ISE is ready on I2C bus {device.ConnectionSettings.BusId} with address {device.ConnectionSettings.DeviceAddress}");
@@ -58,7 +58,7 @@ void Basic(I2cDevice device)
 
 void Orp(I2cDevice device)
 {
-    using UFireOrp uFireOrp = new (device);
+    using UFireOrp uFireOrp = new(device);
     if (uFireOrp.TryMeasureOxidationReductionPotential(out ElectricPotential orp))
     {
         Console.WriteLine("Eh:" + orp.Millivolts);

--- a/src/devices/Vl53L0X/samples/Program.cs
+++ b/src/devices/Vl53L0X/samples/Program.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using Iot.Device.Vl53L0X;
 
 Console.WriteLine("Hello VL53L0X!");
-using Vl53L0X vL53L0X = new (I2cDevice.Create(new I2cConnectionSettings(1, Vl53L0X.DefaultI2cAddress)));
+using Vl53L0X vL53L0X = new(I2cDevice.Create(new I2cConnectionSettings(1, Vl53L0X.DefaultI2cAddress)));
 Console.WriteLine($"Rev: {vL53L0X.Information.Revision}, Prod: {vL53L0X.Information.ProductId}, Mod: {vL53L0X.Information.ModuleId}");
 Console.WriteLine($"Offset in µm: {vL53L0X.Information.OffsetMicrometers}, Signal rate fixed 400 µm: {vL53L0X.Information.SignalRateMeasuementFixed400Micrometers}");
 vL53L0X.MeasurementMode = MeasurementMode.Continuous;

--- a/src/devices/Ws28xx/samples/Program.cs
+++ b/src/devices/Ws28xx/samples/Program.cs
@@ -12,7 +12,7 @@ using Iot.Device.Ws28xx;
 const int Count = 8;
 Console.Clear();
 
-SpiConnectionSettings settings = new (0, 0)
+SpiConnectionSettings settings = new(0, 0)
 {
     ClockFrequency = 2_400_000,
     Mode = SpiMode.Mode0,

--- a/tools/DevicesApiTester/Commands/Gpio/GpioButtonWait.cs
+++ b/tools/DevicesApiTester/Commands/Gpio/GpioButtonWait.cs
@@ -44,7 +44,7 @@ namespace DeviceApiTester.Commands.Gpio
             }
 
             using GpioController controller = CreateGpioController();
-            using CancellationTokenSource cancellationTokenSource = new ();
+            using CancellationTokenSource cancellationTokenSource = new();
             Console.WriteLine($"Listening for button presses on GPIO {Enum.GetName(typeof(PinNumberingScheme), Scheme)} pin {ButtonPin} . . .");
 
             // This example runs until Ctrl+C (or Ctrl+Break) is pressed, so register a local function handler.

--- a/tools/device-listing/Program.cs
+++ b/tools/device-listing/Program.cs
@@ -46,7 +46,7 @@ string[] categoriesToDisplay = new string[]
     "protocol"
 };
 
-Dictionary<string, string?> categoriesDescriptions = new ()
+Dictionary<string, string?> categoriesDescriptions = new()
 {
     { "adc", "Analog/Digital converters" },
     { "accelerometer", "Accelerometers" },
@@ -114,7 +114,7 @@ if (repoRoot is null)
 
 string devicesPath = Path.Combine(repoRoot, "src", "devices");
 
-List<DeviceInfo> devices = new ();
+List<DeviceInfo> devices = new();
 
 foreach (string directory in Directory.EnumerateDirectories(devicesPath))
 {


### PR DESCRIPTION
- https://www.nuget.org/packages/StyleCop.Analyzers
- version 1.2.0-beta.261
- Removed all instances of pragma SA1011

StyleCop Errors fixed:

- [SA1000](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md): The keyword 'new' should not be followed by a space
- [SA1142](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md): Refer to tuple fields by name
- [SA1316](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md): Tuple element names should use correct casing
- [SA1414](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md): Tuple types in signatures should have element names

I believe SA1316 is breaking.