### PR TITLE
Update Ssd13xx sample

### DIFF
--- a/src/devices/Ssd13xx/samples/Program.cs
+++ b/src/devices/Ssd13xx/samples/Program.cs
@@ -14,6 +14,7 @@ using SixLabors.Fonts;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Drawing.Processing;
 using Iot.Device.Ssd13xx;
 using Iot.Device.Ssd13xx.Commands;
 using Iot.Device.Ssd13xx.Samples;
@@ -188,7 +189,7 @@ void DisplayImages(Ssd1306 ssd1306)
     Console.WriteLine("Display Images");
     foreach (var image_name in Directory.GetFiles("images", "*.bmp").OrderBy(f => f))
     {
-        using Image<Gray16> image = Image.Load<Gray16>(image_name);
+        using Image<L16> image = Image.Load<L16>(image_name);
         ssd1306.DisplayImage(image);
         Thread.Sleep(1000);
     }
@@ -206,12 +207,16 @@ void DisplayClock(Ssd1306 ssd1306)
     {
         using (Image<Rgba32> image = new Image<Rgba32>(128, 32))
         {
-            image.Mutate(ctx => ctx
-                .Fill(Rgba32.Black)
-                .DrawText(DateTime.Now.ToString("HH:mm:ss"), fontsys, Rgba32.White,
-                    new SixLabors.Primitives.PointF(0, y)));
+            if (image.TryGetSinglePixelSpan(out Span<Rgba32> imageSpan))
+            {
+                imageSpan.Fill(Color.Black);
+            }
 
-            using (Image<Gray16> image_t = image.CloneAs<Gray16>())
+            image.Mutate(ctx => ctx
+                .DrawText(DateTime.Now.ToString("HH:mm:ss"), fontsys, Color.White,
+                    new SixLabors.ImageSharp.PointF(0, y)));
+
+            using (Image<L16> image_t = image.CloneAs<L16>())
             {
                 ssd1306.DisplayImage(image_t);
             }

--- a/src/devices/Ssd13xx/samples/Ssd1306Extensions.cs
+++ b/src/devices/Ssd13xx/samples/Ssd1306Extensions.cs
@@ -18,7 +18,7 @@ namespace Iot.Device.Ssd13xx.Samples
         /// </summary>
         /// <param name="s">Ssd1306 object.</param>
         /// <param name="image">Image to display.</param>
-        internal static void DisplayImage(this Ssd1306 s, Image<Gray16> image)
+        internal static void DisplayImage(this Ssd1306 s, Image<L16> image)
         {
             Int16 width = 128;
             Int16 pages = 4;

--- a/src/devices/Ssd13xx/samples/Ssd13xx.Samples.csproj
+++ b/src/devices/Ssd13xx/samples/Ssd13xx.Samples.csproj
@@ -7,10 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0008" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0006" />
-    <PackageReference Include="SixLabors.Shapes.Text" Version="1.0.0-beta0008" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0010" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This sample is stale, and was broken by ImageSharp updates (some time ago). These changes appear to fix it, API-wise. I didn't test it.

Context for updates: 

- https://github.com/SixLabors/ImageSharp/commit/d2d51456b5f934b25625418a4f07836d2aba7357
- https://github.com/SixLabors/ImageSharp/blob/78a584e8482b052d7a9885682299e2f37518d83d/tests/ImageSharp.Tests/Drawing/DrawImageTests.cs#L132