### PR TITLE
Fixing DHT InputPullUp to Input only

### DIFF
--- a/src/devices/Dhtxx/DhtBase.cs
+++ b/src/devices/Dhtxx/DhtBase.cs
@@ -162,7 +162,7 @@ namespace Iot.Device.DHTxx
             // wait 20 - 40 microseconds
             DelayHelper.DelayMicroseconds(30, true);
 
-            _controller.SetPinMode(_pin, PinMode.InputPullUp);
+            _controller.SetPinMode(_pin, PinMode.Input);
 
             // DHT corresponding signal - LOW - about 80 microseconds
             count = _loopCount;

--- a/src/devices/Dhtxx/DhtBase.cs
+++ b/src/devices/Dhtxx/DhtBase.cs
@@ -145,6 +145,7 @@ namespace Iot.Device.DHTxx
 
             byte readVal = 0;
             uint count;
+            var pinMode = _controller.IsPinModeSupported(_pin, PinMode.InputPullUp) ? PinMode.InputPullUp : PinMode.Input;
 
             // keep data line HIGH
             _controller.SetPinMode(_pin, PinMode.Output);
@@ -162,7 +163,7 @@ namespace Iot.Device.DHTxx
             // wait 20 - 40 microseconds
             DelayHelper.DelayMicroseconds(30, true);
 
-            _controller.SetPinMode(_pin, PinMode.Input);
+            _controller.SetPinMode(_pin, pinMode);
 
             // DHT corresponding signal - LOW - about 80 microseconds
             count = _loopCount;


### PR DESCRIPTION
Changing InputPullUp to Input only
Rational:
- The InputPullUp is not supported on all platforms
- The InputPullUp is not required if the hardware includes a pull up
  - Most hardware come with the pull up already build in
  - Our recommendation from the sample is to use a physical resistor pull up. See https://github.com/dotnet/iot/tree/master/src/devices/Dhtxx/samples
  - In general, it's better to have real physical hardware pull up as you're sure it's always there

Should fix as well #1270