### PR TITLE
Adding support to multi-target device binding projects

### DIFF
--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -14,12 +14,13 @@
     <!--Disabling default items so samples source won't get build by the main library-->
   </PropertyGroup>
   
+  <!-- The following ItemGroup is in charge of getting the source files we will compile on each TFM -->
   <ItemGroup>
-    <_ExcludeFromCompile Include="$(DeviceRoot)**/samples/**/*.cs" />
-    <_ExcludeFromCompile Include="$(DeviceRoot)**/tests/**/*.cs" />
-    <_ExcludeFromCompile Include="$(DeviceRoot)**/obj/**/*.cs" />
-    <_ExcludeFromCompile Include="$(DeviceRoot)/Common/System/Runtime/CompilerServices/IsExternalInit.cs" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
-    <Compile Include="$(DeviceRoot)**/*.cs" Exclude="@(_ExcludeFromCompile)" />
+    <!-- Excluding samples and test projects when getting source files -->
+    <_ExcludeProjectReferences Include="$(DeviceRoot)**/samples/*.csproj" />
+    <_ExcludeProjectReferences Include="$(DeviceRoot)**/tests/*.csproj" />
+
+    <ProjectReference Include="$(DeviceRoot)**/*.csproj" Exclude="@(_ExcludeProjectReferences)" ReferenceOutputAssembly="false" BuildReference="false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,5 +30,27 @@
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <PackageReference Include="System.Management" Version="$(SystemManagementPackageVersion)" />
   </ItemGroup>
+
+  <!-- This target will call into each device binding project to get out the source files for the framework we are building
+  and then it will add the results to the Compile item group. -->
+  <Target Name="GetCompileItemsFromProjects"
+          BeforeTargets="BeforeBuild"
+          DependsOnTargets="PrepareProjectReferences"
+          Condition="'$(TargetFramework)' != ''">
+    <ItemGroup>
+      <_projectsToGetCompileItemsFrom Include="@(_MSBuildProjectReferenceExistent)" Exclude="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="%(_projectsToGetCompileItemsFrom.Identity)"
+             Targets="GetCompileItemsForTargetFramework"
+             Properties="TargetFramework=%(_projectsToGetCompileItemsFrom.NearestTargetFramework)"
+             BuildInParallel="true">
+      <Output ItemName="_CompileItemsFromProjects" TaskParameter="TargetOutputs" />
+    </MSBuild>
+
+    <ItemGroup>
+      <Compile Include="%(_CompileItemsFromProjects.Identity)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -17,8 +17,8 @@
   <!-- The following ItemGroup is in charge of getting the source files we will compile on each TFM -->
   <ItemGroup>
     <!-- Excluding samples and test projects when getting source files -->
-    <_ExcludeProjectReferences Include="$(DeviceRoot)**/samples/*.csproj" />
-    <_ExcludeProjectReferences Include="$(DeviceRoot)**/tests/*.csproj" />
+    <_ExcludeProjectReferences Include="$(DeviceRoot)**/samples/**/*.csproj" />
+    <_ExcludeProjectReferences Include="$(DeviceRoot)**/tests/**/*.csproj" />
 
     <ProjectReference Include="$(DeviceRoot)**/*.csproj" Exclude="@(_ExcludeProjectReferences)" ReferenceOutputAssembly="false" BuildReference="false" />
   </ItemGroup>

--- a/src/devices/Directory.Build.targets
+++ b/src/devices/Directory.Build.targets
@@ -1,3 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+
+  <!-- This target will be called from Iot.Device.Bindings project to each device project in order to get out
+  the full path of the items to be compiled for each  framework. -->
+  <Target Name="GetCompileItemsForTargetFramework"
+          Returns="@(_CompileItemsForFramework)">
+    <ItemGroup>
+      <_CompileItemsForFramework Include="%(Compile.FullPath)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/devices/Directory.Build.targets
+++ b/src/devices/Directory.Build.targets
@@ -5,8 +5,12 @@
   the full path of the items to be compiled for each  framework. -->
   <Target Name="GetCompileItemsForTargetFramework"
           Returns="@(_CompileItemsForFramework)">
+
     <ItemGroup>
-      <_CompileItemsForFramework Include="%(Compile.FullPath)" />
+      <_GeneratedFiles Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
+      <_GeneratedFiles Include="$(GeneratedAssemblyInfoFile)" />
+      <_GeneratedFilesToFullPath Include="@(_GeneratedFiles -> '%(FullPath)')" />
+      <_CompileItemsForFramework Include="%(Compile.FullPath)" Exclude="@(_GeneratedFilesToFullPath)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/devices/Hcsr04/Hcsr04.csproj
+++ b/src/devices/Hcsr04/Hcsr04.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Shtc3/Shtc3.csproj
+++ b/src/devices/Shtc3/Shtc3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>


### PR DESCRIPTION
cc: @richlander @krwq @Ellerbach @pgrawehr 

Even though device bindings have individual project files, we have always shipped them as one single library (Iot.Device.Bindings). The way we are doing that currently is by manually specifying in the Iot.Device.Bindings a static list of files to be compiled and excluding the ones that we don't want to, which won't be easy to scale in the future once we want to start adding bindings that are only supported in higher frameworks (for example, only in net5.0). The changes on this PR will make it so that instead of having one static list defined, the Iot.Device.Bindings project will now dynamically call into each individual device binding project to get out the right compile items for a specific framework, and that way it will now be easy moving forward to add new bindings projects that are supported only in some TFMs. At the moment, we target two TFMs with Iot.Device.Bindings (netcoreapp2.1, net5.0) but that is now able to scale in the future if we want to.