### PR TITLE
Modernize switch statements

### DIFF
--- a/samples/led-matrix-weather/Program.Drawings.cs
+++ b/samples/led-matrix-weather/Program.Drawings.cs
@@ -85,41 +85,30 @@ namespace LedMatrixWeather
         private static Vector3 OpenWeatherIcon(Vector2 uv, string icon, float time)
         {
             uv -= new Vector2(0.5f, 0.5f);
-
-            switch (icon)
+            return icon switch
             {
-                case "01d":
-                case "01d.org":
-                    return IconSunny(uv, time);
-                case "01n":
-                    return IconMoon(uv, time);
-                case "02d":
-                    return IconPartiallySunny(uv, time);
-                case "02n": // partially cloudy at night
-                    return IconMoon(uv, time);
-                case "03d": // clouds day
-                case "03n": // clouds night
-                case "04d": // overcast clouds
-                case "04n":
-                case "11d": // with thunder
-                case "11n":
-                case "13d": // with snow
-                case "13n":
-                case "50d": // no clue what the picture represents but kinda looks like a cloud
-                case "50n":
-                    return IconClouds(uv, time);
-                case "09d":
-                case "09n":
-                case "10d": // with a bit of the sun
-                case "10n":
-                    return IconRain(uv, time);
-                default:
-                {
-                    // Don't know the icon
-                    // We're in Seattle so let's assume rain
-                    return IconRain(uv, time);
-                }
-            }
+                "01d" or "01d.org" => IconSunny(uv, time),
+                "01n" => IconMoon(uv, time),
+                "02d" => IconPartiallySunny(uv, time),
+                // partially cloudy at night
+                "02n" => IconMoon(uv, time),
+                "03d" or // clouds day
+                "03n" or // clouds night
+                "04d" or // overcast clouds
+                "04n" or
+                "11d" or // with thunder
+                "11n" or
+                "13d" or // with snow
+                "13n" or
+                "50d" or // no clue what the picture represents but kinda looks like a cloud
+                "50n" => IconClouds(uv, time),
+                "09d" or "09n" or
+                "10d" or // with a bit of the sun
+                "10n" => IconRain(uv, time),
+                // Don't know the icon
+                // We're in Seattle so let's assume rain
+                _ => IconRain(uv, time),
+            };
         }
 
         private static Vector3 IconSunny(Vector2 uv, float time)

--- a/samples/led-matrix-weather/Program.cs
+++ b/samples/led-matrix-weather/Program.cs
@@ -72,17 +72,12 @@ namespace LedMatrixWeather
             {
                 if (!Console.IsOutputRedirected)
                 {
-                    while (s_scenario is object)
+                    while (s_scenario is object && Console.ReadKey(intercept: true).Key != ConsoleKey.Q)
                     {
-                        switch (Console.ReadKey(intercept: true).Key)
-                        {
-                            case ConsoleKey.Q:
-                            {
-                                s_scenario = null;
-                                break;
-                            }
-                        }
+                        Thread.Sleep(10);
                     }
+
+                    s_scenario = null;
                 }
 
                 drawing.Wait();

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -72,25 +72,14 @@ namespace System.Device.Gpio.Drivers
 
         internal static RaspberryPi3LinuxDriver? CreateInternalRaspberryPi3LinuxDriver(out RaspberryBoardInfo boardInfo)
         {
-            RaspberryBoardInfo identification = RaspberryBoardInfo.LoadBoardInfo();
-            RaspberryPi3LinuxDriver? linuxDriver;
-            boardInfo = identification;
-            switch (identification.BoardModel)
+            boardInfo = RaspberryBoardInfo.LoadBoardInfo();
+            return boardInfo.BoardModel switch
             {
-                case RaspberryBoardInfo.Model.RaspberryPi3B:
-                case RaspberryBoardInfo.Model.RaspberryPi3BPlus:
-                case RaspberryBoardInfo.Model.RaspberryPi4:
-                    linuxDriver = new RaspberryPi3LinuxDriver();
-                    break;
-                case RaspberryBoardInfo.Model.RaspberryPiComputeModule3:
-                    linuxDriver = new RaspberryPiCm3Driver();
-                    break;
-                default:
-                    linuxDriver = null;
-                    break;
-            }
-
-            return linuxDriver;
+                RaspberryBoardInfo.Model.RaspberryPi3B or RaspberryBoardInfo.Model.RaspberryPi3BPlus or
+                RaspberryBoardInfo.Model.RaspberryPi4 => new RaspberryPi3LinuxDriver(),
+                RaspberryBoardInfo.Model.RaspberryPiComputeModule3 => new RaspberryPiCm3Driver(),
+                _ => null,
+            };
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
@@ -142,19 +142,11 @@ namespace System.Device.Gpio.Drivers
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         /// <param name="mode">The mode to check.</param>
         /// <returns>The status if the pin supports the mode.</returns>
-        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode)
+        protected internal override bool IsPinModeSupported(int pinNumber, PinMode mode) => mode switch
         {
-            switch (mode)
-            {
-                case PinMode.Input:
-                case PinMode.InputPullDown:
-                case PinMode.InputPullUp:
-                case PinMode.Output:
-                    return true;
-                default:
-                    return false;
-            }
-        }
+            PinMode.Input or PinMode.InputPullDown or PinMode.InputPullUp or PinMode.Output => true,
+            _ => false,
+        };
 
         /// <summary>
         /// Opens a pin in order for it to be ready to use.
@@ -339,20 +331,14 @@ namespace System.Device.Gpio.Drivers
              * to this register.
              */
             int shift = (pinNumber & 0xf) << 1;
-            uint pull = 0;
             uint bits = 0;
-            switch (mode)
+            uint pull = mode switch
             {
-                case PinMode.Input:
-                    pull = 0;
-                    break;
-                case PinMode.InputPullUp:
-                    pull = 1;
-                    break;
-                case PinMode.InputPullDown:
-                    pull = 2;
-                    break;
-            }
+                PinMode.Input => 0,
+                PinMode.InputPullUp => 1,
+                PinMode.InputPullDown => 2,
+                _ => 0,
+            };
 
             var gpioReg = _registerViewPointer;
             bits = (gpioReg->GPPUPPDN[(pinNumber >> 4)]);

--- a/src/System.Device.Gpio/System/Device/Gpio/ExceptionHelper.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/ExceptionHelper.cs
@@ -28,60 +28,24 @@ namespace System.Device.Gpio
             return new ArgumentException(GetResourceString(resource, -1, -1));
         }
 
-        private static string GetResourceString(ExceptionResource resource, int errorCode, int pin)
+        private static string GetResourceString(ExceptionResource resource, int errorCode, int pin) => resource switch
         {
-            string message = string.Empty;
-            switch (resource)
-            {
-                case ExceptionResource.NoChipIteratorFound:
-                    message = $"Unable to find a chip iterator, error code: {errorCode}";
-                    break;
-                case ExceptionResource.NoChipFound:
-                    message = $"Unable to find a chip, error code: {errorCode}";
-                    break;
-                case ExceptionResource.PinModeReadError:
-                    message = $"Error while reading pin mode for pin: {pin}";
-                    break;
-                case ExceptionResource.OpenPinError:
-                    message = $"Pin {pin} not available, error: {errorCode}";
-                    break;
-                case ExceptionResource.ReadPinError:
-                    message = $"Error while reading value from pin: {pin}, error: {errorCode}";
-                    break;
-                case ExceptionResource.PinNotOpenedError:
-                    message = $"Can not access pin {pin} that is not open.";
-                    break;
-                case ExceptionResource.SetPinModeError:
-                    message = $"Error setting pin mode, for pin: {pin}, error: {errorCode}";
-                    break;
-                case ExceptionResource.ConvertPinNumberingSchemaError:
-                    message = $"This driver is generic so it cannot perform conversions between pin numbering schemes.";
-                    break;
-                case ExceptionResource.RequestEventError:
-                    message = $"Error while requesting event listener for pin {pin}, error code: {errorCode}";
-                    break;
-                case ExceptionResource.InvalidEventType:
-                    message = $"Invalid or not supported event type requested";
-                    break;
-                case ExceptionResource.EventWaitError:
-                    message = $"Error while waiting for event, error code {errorCode}, pin: {pin}";
-                    break;
-                case ExceptionResource.EventReadError:
-                    message = $"Error while reading pin event result, error code {errorCode}";
-                    break;
-                case ExceptionResource.NotListeningForEventError:
-                    message = $"Attempted to remove a callback for a pin that is not listening for events.";
-                    break;
-                case ExceptionResource.LibGpiodNotInstalled:
-                    message = $"Libgpiod driver not installed. More information on: https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/";
-                    break;
-                default:
-                    Debug.Fail($"The ExceptionResource enum value: {resource} is not part of the switch. Add the appropriate case and exception message.");
-                    break;
-            }
-
-            return message;
-        }
+            ExceptionResource.NoChipIteratorFound => $"Unable to find a chip iterator, error code: {errorCode}",
+            ExceptionResource.NoChipFound => $"Unable to find a chip, error code: {errorCode}",
+            ExceptionResource.PinModeReadError => $"Error while reading pin mode for pin: {pin}",
+            ExceptionResource.OpenPinError => $"Pin {pin} not available, error: {errorCode}",
+            ExceptionResource.ReadPinError => $"Error while reading value from pin: {pin}, error: {errorCode}",
+            ExceptionResource.PinNotOpenedError => $"Can not access pin {pin} that is not open.",
+            ExceptionResource.SetPinModeError => $"Error setting pin mode, for pin: {pin}, error: {errorCode}",
+            ExceptionResource.ConvertPinNumberingSchemaError => $"This driver is generic so it cannot perform conversions between pin numbering schemes.",
+            ExceptionResource.RequestEventError => $"Error while requesting event listener for pin {pin}, error code: {errorCode}",
+            ExceptionResource.InvalidEventType => $"Invalid or not supported event type requested",
+            ExceptionResource.EventWaitError => $"Error while waiting for event, error code {errorCode}, pin: {pin}",
+            ExceptionResource.EventReadError => $"Error while reading pin event result, error code {errorCode}",
+            ExceptionResource.NotListeningForEventError => $"Attempted to remove a callback for a pin that is not listening for events.",
+            ExceptionResource.LibGpiodNotInstalled => $"Libgpiod driver not installed. More information on: https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/",
+            _ => throw new Exception($"The ExceptionResource enum value: {resource} is not part of the switch. Add the appropriate case and exception message."),
+        };
     }
 
     internal enum ExceptionResource

--- a/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
@@ -127,66 +127,23 @@ namespace System.Device.Gpio
         /// See http://www.raspberrypi-spy.co.uk/2012/09/checking-your-raspberry-pi-board-version/ for information.
         /// </summary>
         /// <returns></returns>
-        private Model GetBoardModel()
+        private Model GetBoardModel() => (Firmware & 0xFFFF) switch
         {
-            var firmware = Firmware;
-            switch (firmware & 0xFFFF)
-            {
-                case 0x2:
-                case 0x3:
-                    return Model.RaspberryPiBRev1;
-
-                case 0x4:
-                case 0x5:
-                case 0x6:
-                case 0xd:
-                case 0xe:
-                case 0xf:
-                    return Model.RaspberryPiBRev2;
-
-                case 0x7:
-                case 0x8:
-                case 0x9:
-                    return Model.RaspberryPiA;
-
-                case 0x10:
-                    return Model.RaspberryPiBPlus;
-
-                case 0x11:
-                    return Model.RaspberryPiComputeModule;
-
-                case 0x12:
-                    return Model.RaspberryPiAPlus;
-
-                case 0x1040:
-                case 0x1041:
-                    return Model.RaspberryPi2B;
-
-                case 0x0092:
-                case 0x0093:
-                    return Model.RaspberryPiZero;
-
-                case 0x00C1:
-                    return Model.RaspberryPiZeroW;
-
-                case 0x2082:
-                    return Model.RaspberryPi3B;
-
-                case 0x20D3:
-                    return Model.RaspberryPi3BPlus;
-
-                case 0x20A0:
-                case 0x2100:
-                    return Model.RaspberryPiComputeModule3;
-
-                case 0x3112:
-                case 0x3111:
-                    return Model.RaspberryPi4;
-
-                default:
-                    return Model.Unknown;
-            }
-        }
+            0x2 or 0x3 => Model.RaspberryPiBRev1,
+            0x4 or 0x5 or 0x6 or 0xd or 0xe or 0xf => Model.RaspberryPiBRev2,
+            0x7 or 0x8 or 0x9 => Model.RaspberryPiA,
+            0x10 => Model.RaspberryPiBPlus,
+            0x11 => Model.RaspberryPiComputeModule,
+            0x12 => Model.RaspberryPiAPlus,
+            0x1040 or 0x1041 => Model.RaspberryPi2B,
+            0x0092 or 0x0093 => Model.RaspberryPiZero,
+            0x00C1 => Model.RaspberryPiZeroW,
+            0x2082 => Model.RaspberryPi3B,
+            0x20D3 => Model.RaspberryPi3BPlus,
+            0x20A0 or 0x2100 => Model.RaspberryPiComputeModule3,
+            0x3112 or 0x3111 => Model.RaspberryPi4,
+            _ => Model.Unknown,
+        };
 
         /// <summary>
         /// Gets the processor name.

--- a/src/devices/BrickPi3/Movement/Motor.cs
+++ b/src/devices/BrickPi3/Movement/Motor.cs
@@ -110,19 +110,11 @@ namespace Iot.Device.BrickPi3.Movement
                 var motorstatus = _brick.GetMotorStatus((byte)Port);
                 switch (polarity)
                 {
-                    case Polarity.Backward:
-                        if (motorstatus.Speed > 0)
-                        {
-                            _brick.SetMotorPower((byte)Port, -Speed);
-                        }
-
+                    case Polarity.Backward when motorstatus.Speed > 0:
+                        _brick.SetMotorPower((byte)Port, -Speed);
                         break;
-                    case Polarity.Forward:
-                        if (motorstatus.Speed < 0)
-                        {
-                            _brick.SetMotorPower((byte)Port, -Speed);
-                        }
-
+                    case Polarity.Forward when motorstatus.Speed < 0:
+                        _brick.SetMotorPower((byte)Port, -Speed);
                         break;
                     case Polarity.OppositeDirection:
                         _brick.SetMotorPower((byte)Port, -Speed);

--- a/src/devices/BrickPi3/Sensors/EV3ColorSensor.cs
+++ b/src/devices/BrickPi3/Sensors/EV3ColorSensor.cs
@@ -203,45 +203,23 @@ namespace Iot.Device.BrickPi3.Sensors
         /// Get the raw value
         /// </summary>
         /// <returns></returns>
-        public int ReadRaw()
+        public int ReadRaw() => _colorMode switch
         {
-            int val = 0;
-            switch (_colorMode)
-            {
-                case ColorSensorMode.Color:
-                case ColorSensorMode.Reflection:
-                case ColorSensorMode.Ambient:
-                    val = (int)ReadColor();
-                    break;
-                case ColorSensorMode.Green:
-                case ColorSensorMode.Blue:
-                    val = CalculateRawAverage();
-                    break;
-            }
-
-            return val;
-        }
+            ColorSensorMode.Color or ColorSensorMode.Reflection or ColorSensorMode.Ambient
+                => (int)ReadColor(),
+            ColorSensorMode.Green or ColorSensorMode.Blue => CalculateRawAverage(),
+            _ => 0,
+        };
 
         /// <summary>
         /// Read the intensity of the reflected or ambient light in percent. In color mode the color index is returned
         /// </summary>
-        public int Read()
+        public int Read() => _colorMode switch
         {
-            int val = 0;
-            switch (_colorMode)
-            {
-                case ColorSensorMode.Color:
-                case ColorSensorMode.Reflection:
-                case ColorSensorMode.Ambient:
-                    val = (int)ReadColor();
-                    break;
-                default:
-                    val = CalculateRawAverageAsPct();
-                    break;
-            }
-
-            return val;
-        }
+            ColorSensorMode.Color or ColorSensorMode.Reflection or ColorSensorMode.Ambient
+                => (int)ReadColor(),
+            _ => CalculateRawAverageAsPct(),
+        };
 
         private int CalculateRawAverage()
         {
@@ -263,12 +241,9 @@ namespace Iot.Device.BrickPi3.Sensors
             }
         }
 
-        private int CalculateRawAverageAsPct()
-        {
-            // Need to find out what is the ADC resolution
-            // 1023 is probably the correct one
-            return (CalculateRawAverage() * 100) / 1023;
-        }
+        // Need to find out what is the ADC resolution
+        // 1023 is probably the correct one
+        private int CalculateRawAverageAsPct() => (CalculateRawAverage() * 100) / 1023;
 
         /// <summary>
         /// Read the test value
@@ -291,26 +266,14 @@ namespace Iot.Device.BrickPi3.Sensors
         /// Get the color as a string
         /// </summary>
         /// <returns></returns>
-        public string ReadAsString()
+        public string ReadAsString() => _colorMode switch
         {
-            string s = string.Empty;
-            switch (_colorMode)
-            {
-                case ColorSensorMode.Color:
-                    s = ReadColor().ToString();
-                    break;
-                case ColorSensorMode.Reflection:
-                case ColorSensorMode.Green:
-                case ColorSensorMode.Blue:
-                    s = Read().ToString();
-                    break;
-                case ColorSensorMode.Ambient:
-                    s = Read().ToString();
-                    break;
-            }
-
-            return s;
-        }
+            ColorSensorMode.Color => ReadColor().ToString(),
+            ColorSensorMode.Reflection or ColorSensorMode.Green or ColorSensorMode.Blue
+                => Read().ToString(),
+            ColorSensorMode.Ambient => Read().ToString(),
+            _ => string.Empty,
+        };
 
         /// <summary>
         /// Reads the color.

--- a/src/devices/BrickPi3/Sensors/EV3GyroSensor.cs
+++ b/src/devices/BrickPi3/Sensors/EV3GyroSensor.cs
@@ -94,10 +94,7 @@ namespace Iot.Device.BrickPi3.Sensors
         /// </summary>
         public int Value
         {
-            get
-            {
-                return ReadRaw();
-            }
+            get => ReadRaw();
             internal set
             {
                 if (value != _value)
@@ -124,10 +121,7 @@ namespace Iot.Device.BrickPi3.Sensors
         /// </summary>
         public int PeriodRefresh
         {
-            get
-            {
-                return _periodRefresh;
-            }
+            get => _periodRefresh;
             set
             {
                 _periodRefresh = value;
@@ -156,11 +150,7 @@ namespace Iot.Device.BrickPi3.Sensors
         /// <value>The mode.</value>
         public GyroMode Mode
         {
-            get
-            {
-                return _gmode;
-            }
-
+            get => _gmode;
             set
             {
                 if (_gmode != value)
@@ -180,21 +170,12 @@ namespace Iot.Device.BrickPi3.Sensors
         /// Reads the sensor value as a string.
         /// </summary>
         /// <returns>The value as a string</returns>
-        public string ReadAsString()
+        public string ReadAsString() => _gmode switch
         {
-            string s = string.Empty;
-            switch (_gmode)
-            {
-                case GyroMode.Angle:
-                    s = Read().ToString() + " degree";
-                    break;
-                case GyroMode.AngularVelocity:
-                    s = Read().ToString() + " deg/sec";
-                    break;
-            }
-
-            return s;
-        }
+            GyroMode.Angle => $"{Read().ToString()} degree",
+            GyroMode.AngularVelocity => $"{Read().ToString()} deg/sec",
+            _ => string.Empty,
+        };
 
         /// <summary>
         /// Reset the sensor
@@ -265,43 +246,28 @@ namespace Iot.Device.BrickPi3.Sensors
         /// Gets sensor name
         /// </summary>
         /// <returns>Sensor name</returns>
-        public string GetSensorName()
-        {
-            return "EV3 Gyro";
-        }
+        public string GetSensorName() => "EV3 Gyro";
 
         /// <summary>
         /// Moves to next mode
         /// </summary>
-        public void SelectNextMode()
-        {
-            Mode = Mode.Next();
-        }
+        public void SelectNextMode() => Mode = Mode.Next();
 
         /// <summary>
         /// Moves to previous mode
         /// </summary>
-        public void SelectPreviousMode()
-        {
-            Mode = Mode.Previous();
-        }
+        public void SelectPreviousMode() => Mode = Mode.Previous();
 
         /// <summary>
         /// Number of modes supported
         /// </summary>
         /// <returns>Number of modes</returns>
-        public int NumberOfModes()
-        {
-            return Enum.GetNames(typeof(GyroMode)).Length;
-        }
+        public int NumberOfModes() => Enum.GetNames(typeof(GyroMode)).Length;
 
         /// <summary>
         /// Selected mode
         /// </summary>
         /// <returns>String representing selected mode</returns>
-        public string SelectedMode()
-        {
-            return Mode.ToString();
-        }
+        public string SelectedMode() => Mode.ToString();
     }
 }

--- a/src/devices/BrickPi3/Sensors/EV3IRSensor.cs
+++ b/src/devices/BrickPi3/Sensors/EV3IRSensor.cs
@@ -141,11 +141,7 @@ namespace Iot.Device.BrickPi3.Sensors
         /// </summary>
         public int PeriodRefresh
         {
-            get
-            {
-                return _periodRefresh;
-            }
-
+            get => _periodRefresh;
             set
             {
                 _periodRefresh = value;
@@ -161,11 +157,7 @@ namespace Iot.Device.BrickPi3.Sensors
         /// </summary>
         public int Value
         {
-            get
-            {
-                return ReadRaw();
-            }
-
+            get => ReadRaw();
             internal set
             {
                 if (value != _value)
@@ -202,11 +194,7 @@ namespace Iot.Device.BrickPi3.Sensors
         /// <value>The mode.</value>
         public IRMode Mode
         {
-            get
-            {
-                return _mode;
-            }
-
+            get => _mode;
             set
             {
                 if (_mode != value)
@@ -221,47 +209,25 @@ namespace Iot.Device.BrickPi3.Sensors
         /// Reads the sensor value as a string.
         /// </summary>
         /// <returns>The value as a string</returns>
-        public string ReadAsString()
+        public string ReadAsString() => _mode switch
         {
-            string s = string.Empty;
-            switch (_mode)
-            {
-                case IRMode.Proximity:
-                    s = ReadDistance() + " cm";
-                    break;
-                case IRMode.Remote:
-                    s = ReadRemoteCommand() + " on channel " + Channel;
-                    break;
-                case IRMode.Seek:
-                    s = "Location: " + ReadBeaconLocation() + " Distance: TBD cm";
-                    break;
-            }
-
-            return s;
-        }
+            IRMode.Proximity => $"{ReadDistance()} cm",
+            IRMode.Remote => $"{ReadRemoteCommand()} on channel {Channel}",
+            IRMode.Seek => $"Location: {ReadBeaconLocation()} Distance: TBD cm",
+            _ => string.Empty,
+        };
 
         /// <summary>
         /// Read the sensor value. The returned value depends on the mode. Distance in proximity mode.
         /// Remote command number in remote mode. Beacon location in seek mode.
         /// </summary>
-        public int Read()
+        public int Read() => Mode switch
         {
-            int value = 0;
-            switch (Mode)
-            {
-                case IRMode.Proximity:
-                    value = ReadDistance();
-                    break;
-                case IRMode.Remote:
-                    value = ReadRemoteCommand();
-                    break;
-                case IRMode.Seek:
-                    value = ReadBeaconLocation();
-                    break;
-            }
-
-            return value;
-        }
+            IRMode.Proximity => ReadDistance(),
+            IRMode.Remote => ReadRemoteCommand(),
+            IRMode.Seek => ReadBeaconLocation(),
+            _ => 0,
+        };
 
         /// <summary>
         /// Read the sensor value
@@ -276,21 +242,13 @@ namespace Iot.Device.BrickPi3.Sensors
                 // SEEK = 8x8 bites, 4 x for each of the four channels, heading and distance
                 // PROXIMITY = 1x8 bites
                 // REMOTE = 4x8, button pressed per channel
-                int value = int.MaxValue;
-                switch (_mode)
+                int value = _mode switch
                 {
-                    case IRMode.Proximity:
-                        value = ret[0];
-                        break;
-                    case IRMode.Seek:
-                        value = ret[0] + (ret[2] << 8) + (ret[4] << 16) + (ret[6] << 24);
-                        break;
-                    case IRMode.Remote:
-                        value = ret[0] + (ret[1] << 8) + (ret[2] << 16) + (ret[3] << 24);
-                        break;
-                    default:
-                        break;
-                }
+                    IRMode.Proximity => ret[0],
+                    IRMode.Seek => ret[0] + (ret[2] << 8) + (ret[4] << 16) + (ret[6] << 24),
+                    IRMode.Remote => ret[0] + (ret[1] << 8) + (ret[2] << 16) + (ret[3] << 24),
+                    _ => int.MaxValue,
+                };
 
                 return value;
             }
@@ -383,43 +341,28 @@ namespace Iot.Device.BrickPi3.Sensors
         /// Gets sensor name
         /// </summary>
         /// <returns>Sensor name</returns>
-        public string GetSensorName()
-        {
-            return "EV3 IR";
-        }
+        public string GetSensorName() => "EV3 IR";
 
         /// <summary>
         /// Moves to next mode
         /// </summary>
-        public void SelectNextMode()
-        {
-            Mode = Mode.Next();
-        }
+        public void SelectNextMode() => Mode = Mode.Next();
 
         /// <summary>
         /// Moves to previous mode
         /// </summary>
-        public void SelectPreviousMode()
-        {
-            Mode = Mode.Previous();
-        }
+        public void SelectPreviousMode() => Mode = Mode.Previous();
 
         /// <summary>
         /// Number of modes supported
         /// </summary>
         /// <returns>Number of modes</returns>
-        public int NumberOfModes()
-        {
-            return Enum.GetNames(typeof(IRMode)).Length;
-        }
+        public int NumberOfModes() => Enum.GetNames(typeof(IRMode)).Length;
 
         /// <summary>
         /// Selected mode
         /// </summary>
         /// <returns>String representing selected mode</returns>
-        public string SelectedMode()
-        {
-            return Mode.ToString();
-        }
+        public string SelectedMode() => Mode.ToString();
     }
 }

--- a/src/devices/BrickPi3/Sensors/EV3UltraSonicSensor.cs
+++ b/src/devices/BrickPi3/Sensors/EV3UltraSonicSensor.cs
@@ -174,24 +174,13 @@ namespace Iot.Device.BrickPi3.Sensors
         /// Reads the sensor value as a string.
         /// </summary>
         /// <returns>The value as a string</returns>
-        public string ReadAsString()
+        public string ReadAsString() => _mode switch
         {
-            string s = string.Empty;
-            switch (_mode)
-            {
-                case UltraSonicMode.Centimeter:
-                    s = Read().ToString() + " cm";
-                    break;
-                case UltraSonicMode.Inch:
-                    s = Read().ToString() + " inch";
-                    break;
-                case UltraSonicMode.Listen:
-                    s = Read().ToString();
-                    break;
-            }
-
-            return s;
-        }
+            UltraSonicMode.Centimeter => $"{Read().ToString()} cm",
+            UltraSonicMode.Inch => $"{Read().ToString()} inch",
+            UltraSonicMode.Listen => Read().ToString(),
+            _ => string.Empty,
+        };
 
         /// <summary>
         /// Read the sensor value. Result depends on the mode
@@ -216,64 +205,46 @@ namespace Iot.Device.BrickPi3.Sensors
         {
             try
             {
-                var ret = _brick.GetSensor((byte)Port);
-                switch (_mode)
+                byte[] ret = _brick.GetSensor((byte)Port);
+                return _mode switch
                 {
-                    case UltraSonicMode.Centimeter:
-                    case UltraSonicMode.Inch:
-                        return (ret[0] + (ret[1] >> 8));
-                    case UltraSonicMode.Listen:
-                        return ret[0];
-                }
+                    UltraSonicMode.Centimeter or UltraSonicMode.Inch => (ret[0] + (ret[1] >> 8)),
+                    UltraSonicMode.Listen => ret[0],
+                    _ => int.MaxValue,
+                };
             }
             catch (Exception ex) when (ex is IOException)
             {
+                return int.MaxValue;
             }
-
-            return int.MaxValue;
         }
 
         /// <summary>
         /// Gets sensor name
         /// </summary>
         /// <returns>Sensor name</returns>
-        public string GetSensorName()
-        {
-            return "EV3 Ultrasonic";
-        }
+        public string GetSensorName() => "EV3 Ultrasonic";
 
         /// <summary>
         /// Moves to next mode
         /// </summary>
-        public void SelectNextMode()
-        {
-            Mode = Mode.Next();
-        }
+        public void SelectNextMode() => Mode = Mode.Next();
 
         /// <summary>
         /// Moves to previous mode
         /// </summary>
-        public void SelectPreviousMode()
-        {
-            Mode = Mode.Previous();
-        }
+        public void SelectPreviousMode() => Mode = Mode.Previous();
 
         /// <summary>
         /// Number of modes supported
         /// </summary>
         /// <returns>Number of modes</returns>
-        public int NumberOfModes()
-        {
-            return Enum.GetNames(typeof(UltraSonicMode)).Length;
-        }
+        public int NumberOfModes() => Enum.GetNames(typeof(UltraSonicMode)).Length;
 
         /// <summary>
         /// Selected mode
         /// </summary>
         /// <returns>String representing selected mode</returns>
-        public string SelectedMode()
-        {
-            return Mode.ToString();
-        }
+        public string SelectedMode() => Mode.ToString();
     }
 }

--- a/src/devices/BrickPi3/Sensors/NXTColorSensor.cs
+++ b/src/devices/BrickPi3/Sensors/NXTColorSensor.cs
@@ -161,10 +161,7 @@ namespace Iot.Device.BrickPi3.Sensors
             _timer = null!;
         }
 
-        private void OnPropertyChanged(string name)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-        }
+        private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 
         /// <summary>
         /// To notify a property has changed. The minimum time can be set up
@@ -177,11 +174,7 @@ namespace Iot.Device.BrickPi3.Sensors
         /// </summary>
         public int PeriodRefresh
         {
-            get
-            {
-                return _periodRefresh;
-            }
-
+            get => _periodRefresh;
             set
             {
                 _periodRefresh = value;
@@ -194,11 +187,7 @@ namespace Iot.Device.BrickPi3.Sensors
         /// </summary>
         public int Value
         {
-            get
-            {
-                return ReadRaw();
-            }
-
+            get => ReadRaw();
             internal set
             {
                 if (value != _value)
@@ -234,11 +223,7 @@ namespace Iot.Device.BrickPi3.Sensors
         /// </summary>
         public ColorSensorMode ColorMode
         {
-            get
-            {
-                return _colorMode;
-            }
-
+            get => _colorMode;
             set
             {
                 if (value != _colorMode)
@@ -258,10 +243,7 @@ namespace Iot.Device.BrickPi3.Sensors
         /// Gets sensor name
         /// </summary>
         /// <returns>Sensor name</returns>
-        public string GetSensorName()
-        {
-            return "NXT Color Sensor";
-        }
+        public string GetSensorName() => "NXT Color Sensor";
 
         private void GetRawValues()
         {
@@ -282,51 +264,25 @@ namespace Iot.Device.BrickPi3.Sensors
         /// Reads raw value from the sensor
         /// </summary>
         /// <returns>Value read from the sensor</returns>
-        public int ReadRaw()
+        public int ReadRaw() => _colorMode switch
         {
-            int val = 0;
-            switch (_colorMode)
-            {
-                case ColorSensorMode.Color:
-                    val = (int)ReadColor();
-                    break;
-                case ColorSensorMode.Reflection:
-                case ColorSensorMode.Green:
-                case ColorSensorMode.Blue:
-                    val = CalculateRawAverage();
-                    break;
-                case ColorSensorMode.Ambient:
-                    val = CalculateRawAverage();
-                    break;
-            }
-
-            return val;
-        }
+                ColorSensorMode.Color => (int)ReadColor(),
+                ColorSensorMode.Reflection or ColorSensorMode.Green or ColorSensorMode.Blue
+                    => CalculateRawAverage(),
+                ColorSensorMode.Ambient => CalculateRawAverage(),
+                _ => 0,
+        };
 
         /// <summary>
         /// Read the intensity of the reflected or ambient light in percent. In color mode the color index is returned
         /// </summary>
-        public int Read()
+        public int Read() => _colorMode switch
         {
-            int val = 0;
-            switch (_colorMode)
-            {
-                case ColorSensorMode.Ambient:
-                    val = CalculateRawAverageAsPct();
-                    break;
-                case ColorSensorMode.Color:
-                    val = (int)ReadColor();
-                    break;
-                case ColorSensorMode.Reflection:
-                    val = CalculateRawAverageAsPct();
-                    break;
-                default:
-                    val = CalculateRawAverageAsPct();
-                    break;
-            }
-
-            return val;
-        }
+            ColorSensorMode.Ambient => CalculateRawAverageAsPct(),
+            ColorSensorMode.Color => (int)ReadColor(),
+            ColorSensorMode.Reflection => CalculateRawAverageAsPct(),
+            _ => CalculateRawAverageAsPct(),
+        };
 
         private int CalculateRawAverage()
         {
@@ -348,37 +304,22 @@ namespace Iot.Device.BrickPi3.Sensors
             }
         }
 
-        private int CalculateRawAverageAsPct()
-        {
-            // Need to find out what is the ADC resolution
-            // 1023 is probably the correct one
-            return (CalculateRawAverage() * 100) / 1023;
-        }
+        // Need to find out what is the ADC resolution
+        // 1023 is probably the correct one
+        private int CalculateRawAverageAsPct() => (CalculateRawAverage() * 100) / 1023;
 
         /// <summary>
         /// Reads value from sensor represented as string
         /// </summary>
         /// <returns>Sensor value as string</returns>
-        public string ReadAsString()
+        public string ReadAsString() => _colorMode switch
         {
-            string s = string.Empty;
-            switch (_colorMode)
-            {
-                case ColorSensorMode.Color:
-                    s = ReadColor().ToString();
-                    break;
-                case ColorSensorMode.Reflection:
-                case ColorSensorMode.Green:
-                case ColorSensorMode.Blue:
-                    s = Read().ToString();
-                    break;
-                case ColorSensorMode.Ambient:
-                    s = Read().ToString();
-                    break;
-            }
-
-            return s;
-        }
+            ColorSensorMode.Color => ReadColor().ToString(),
+            ColorSensorMode.Reflection or ColorSensorMode.Green or ColorSensorMode.Blue
+                => Read().ToString(),
+            ColorSensorMode.Ambient => Read().ToString(),
+            _ => string.Empty,
+        };
 
         /// <summary>
         /// Reads the color.
@@ -415,35 +356,23 @@ namespace Iot.Device.BrickPi3.Sensors
         /// <summary>
         /// Moves to next mode
         /// </summary>
-        public void SelectNextMode()
-        {
-            _colorMode = ColorMode.Next();
-        }
+        public void SelectNextMode() => _colorMode = ColorMode.Next();
 
         /// <summary>
         /// Moves to previous mode
         /// </summary>
-        public void SelectPreviousMode()
-        {
-            _colorMode = ColorMode.Previous();
-        }
+        public void SelectPreviousMode() => _colorMode = ColorMode.Previous();
 
         /// <summary>
         /// Number of modes supported
         /// </summary>
         /// <returns>Number of modes</returns>
-        public int NumberOfModes()
-        {
-            return Enum.GetNames(typeof(ColorSensorMode)).Length;
-        }
+        public int NumberOfModes() => Enum.GetNames(typeof(ColorSensorMode)).Length;
 
         /// <summary>
         /// Selected mode
         /// </summary>
         /// <returns>String representing selected mode</returns>
-        public string SelectedMode()
-        {
-            return ColorMode.ToString();
-        }
+        public string SelectedMode() => ColorMode.ToString();
     }
 }

--- a/src/devices/GrovePi/GrovePi.cs
+++ b/src/devices/GrovePi/GrovePi.cs
@@ -118,26 +118,18 @@ namespace Iot.Device.GrovePiDevice
         /// <returns></returns>
         public byte[]? ReadCommand(GrovePiCommand command, GrovePort pin)
         {
-            int numberBytesToRead = 0;
-            switch (command)
+            int numberBytesToRead = command switch
             {
-                case GrovePiCommand.DigitalRead:
-                    numberBytesToRead = 1;
-                    break;
-                case GrovePiCommand.AnalogRead:
-                case GrovePiCommand.UltrasonicRead:
-                case GrovePiCommand.LetBarGet:
-                    numberBytesToRead = 3;
-                    break;
-                case GrovePiCommand.Version:
-                    numberBytesToRead = 4;
-                    break;
-                case GrovePiCommand.DhtTemp:
-                    numberBytesToRead = 9;
-                    break;
-                // No other commands are for read
-                default:
-                    return null;
+                GrovePiCommand.DigitalRead => 1,
+                GrovePiCommand.AnalogRead or GrovePiCommand.UltrasonicRead or GrovePiCommand.LetBarGet => 3,
+                GrovePiCommand.Version => 4,
+                GrovePiCommand.DhtTemp => 9,
+                _ => 0,
+            };
+
+            if (numberBytesToRead == 0)
+            {
+                return null;
             }
 
             byte[] outArray = new byte[numberBytesToRead];

--- a/src/devices/Mcp23xxx/Mcp23xxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23xxx.cs
@@ -289,18 +289,12 @@ namespace Iot.Device.Mcp23xxx
         /// <returns>Value of intterupt pin</returns>
         protected PinValue InternalReadInterrupt(Port port)
         {
-            int pinNumber;
-            switch (port)
+            int pinNumber = port switch
             {
-                case Port.PortA:
-                    pinNumber = _interruptA;
-                    break;
-                case Port.PortB:
-                    pinNumber = _interruptB;
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(port));
-            }
+                Port.PortA => _interruptA,
+                Port.PortB => _interruptB,
+                _ => throw new ArgumentOutOfRangeException(nameof(port)),
+            };
 
             if (pinNumber == -1 || _controller is null)
             {

--- a/src/devices/Mcp23xxx/samples/Program.cs
+++ b/src/devices/Mcp23xxx/samples/Program.cs
@@ -27,46 +27,28 @@ if (mcp23xxx is Mcp23x1x mcp23x1x)
 // Uncomment sample to run
 // ReadBits(controllerUsingMcp);
 // Program methods
-Mcp23xxx GetMcp23xxxDevice(Mcp23xxxDevice mcp23xxxDevice)
+Mcp23xxx GetMcp23xxxDevice(Mcp23xxxDevice mcp23xxxDevice) => mcp23xxxDevice switch
 {
-    I2cConnectionSettings i2cConnectionSettings = new(1, s_deviceAddress);
-    I2cDevice i2cDevice = I2cDevice.Create(i2cConnectionSettings);
-
-    // I2C.
-    switch (mcp23xxxDevice)
-    {
-        case Mcp23xxxDevice.Mcp23008:
-            return new Mcp23008(i2cDevice);
-        case Mcp23xxxDevice.Mcp23009:
-            return new Mcp23009(i2cDevice);
-        case Mcp23xxxDevice.Mcp23017:
-            return new Mcp23017(i2cDevice);
-        case Mcp23xxxDevice.Mcp23018:
-            return new Mcp23018(i2cDevice);
-    }
-
-    SpiConnectionSettings spiConnectionSettings = new(0, 0)
-    {
-        ClockFrequency = 1000000, Mode = SpiMode.Mode0
-    };
-
-    SpiDevice spiDevice = SpiDevice.Create(spiConnectionSettings);
-
+    // I2C
+    Mcp23xxxDevice.Mcp23008 => new Mcp23008(NewI2c()),
+    Mcp23xxxDevice.Mcp23009 => new Mcp23009(NewI2c()),
+    Mcp23xxxDevice.Mcp23017 => new Mcp23017(NewI2c()),
+    Mcp23xxxDevice.Mcp23018 => new Mcp23018(NewI2c()),
     // SPI.
-    switch (mcp23xxxDevice)
-    {
-        case Mcp23xxxDevice.Mcp23S08:
-            return new Mcp23s08(spiDevice, s_deviceAddress);
-        case Mcp23xxxDevice.Mcp23S09:
-            return new Mcp23s09(spiDevice);
-        case Mcp23xxxDevice.Mcp23S17:
-            return new Mcp23s17(spiDevice, s_deviceAddress);
-        case Mcp23xxxDevice.Mcp23S18:
-            return new Mcp23s18(spiDevice);
-    }
+    Mcp23xxxDevice.Mcp23S08 => new Mcp23s08(NewSpi(), s_deviceAddress),
+    Mcp23xxxDevice.Mcp23S09 => new Mcp23s09(NewSpi()),
+    Mcp23xxxDevice.Mcp23S17 => new Mcp23s17(NewSpi(), s_deviceAddress),
+    Mcp23xxxDevice.Mcp23S18 => new Mcp23s18(NewSpi()),
+    _ => throw new Exception($"Invalid Mcp23xxxDevice: {nameof(mcp23xxxDevice)}"),
 
-    throw new Exception($"Invalid Mcp23xxxDevice: {nameof(mcp23xxxDevice)}");
-}
+};
+
+I2cDevice NewI2c() => I2cDevice.Create(new(1, s_deviceAddress));
+
+SpiDevice NewSpi() => SpiDevice.Create(new(0, 0)
+{
+    ClockFrequency = 1000000, Mode = SpiMode.Mode0
+});
 
 void ReadSwitchesWriteLeds(Mcp23x1x mcp23x1x)
 {

--- a/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxDn.cs
+++ b/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxDn.cs
@@ -62,8 +62,8 @@ namespace Iot.Device.Mcp25xxx.Register.MessageTransmit
         /// <returns>The Tx Buffer Number based on the register address.</returns>
         public static byte GetTxBufferNumber(Address address) => address switch
         {
-            Address.TxB0D0 or Address.TxB0D1 or Address.TxB0D2 or Address.TxB0D3 or Address.TxB0D4 or Address.TxB0D5 or Address.TxB0D6 or Address.TxB0D7 => 0,
-            Address.TxB1D0 or Address.TxB1D1 or Address.TxB1D2 or Address.TxB1D3 or Address.TxB1D4 or Address.TxB1D5 or Address.TxB1D6 or Address.TxB1D7 => 1,
+            >= Address.TxB0D0 and <= Address.TxB0D7 => 0,
+            >= Address.TxB1D0 and <= Address.TxB1D7 => 1,
             _ => throw new ArgumentException($"Invalid address value {address}.", nameof(address)),
         };
 

--- a/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxDn.cs
+++ b/src/devices/Mcp25xxx/Register/MessageTransmit/TxBxDn.cs
@@ -60,32 +60,12 @@ namespace Iot.Device.Mcp25xxx.Register.MessageTransmit
         /// </summary>
         /// <param name="address">The address to look up Tx Buffer Number.</param>
         /// <returns>The Tx Buffer Number based on the register address.</returns>
-        public static byte GetTxBufferNumber(Address address)
+        public static byte GetTxBufferNumber(Address address) => address switch
         {
-            switch (address)
-            {
-                case Address.TxB0D0:
-                case Address.TxB0D1:
-                case Address.TxB0D2:
-                case Address.TxB0D3:
-                case Address.TxB0D4:
-                case Address.TxB0D5:
-                case Address.TxB0D6:
-                case Address.TxB0D7:
-                    return 0;
-                case Address.TxB1D0:
-                case Address.TxB1D1:
-                case Address.TxB1D2:
-                case Address.TxB1D3:
-                case Address.TxB1D4:
-                case Address.TxB1D5:
-                case Address.TxB1D6:
-                case Address.TxB1D7:
-                    return 1;
-                default:
-                    throw new ArgumentException($"Invalid address value {address}.", nameof(address));
-            }
-        }
+            Address.TxB0D0 or Address.TxB0D1 or Address.TxB0D2 or Address.TxB0D3 or Address.TxB0D4 or Address.TxB0D5 or Address.TxB0D6 or Address.TxB0D7 => 0,
+            Address.TxB1D0 or Address.TxB1D1 or Address.TxB1D2 or Address.TxB1D3 or Address.TxB1D4 or Address.TxB1D5 or Address.TxB1D6 or Address.TxB1D7 => 1,
+            _ => throw new ArgumentException($"Invalid address value {address}.", nameof(address)),
+        };
 
         /// <summary>
         /// Gets the address of the register.

--- a/src/devices/Mcp3428/Helpers.cs
+++ b/src/devices/Mcp3428/Helpers.cs
@@ -44,48 +44,21 @@ namespace Iot.Device.Mcp3428
         public static byte I2CAddressFromPins(PinState adr0, PinState adr1)
         {
             byte addr = 0b1101000; // Base value from doc
-
-            var idx = (byte)adr0 << 4 + (byte)adr1;
-
-            switch (idx)
+            int idx = (byte)adr0 << 4 + (byte)adr1;
+            int value = idx switch
             {
-                case 0:
-                case 0x22:
-                    break;
+                0 or 0x22 => 0,
+                0x02 => 1,
+                0x01 => 2,
+                0x10 => 4,
+                0x12 => 5,
+                0x11 => 6,
+                0x20 => 3,
+                0x21 => 7,
+                _ => throw new ArgumentException("Invalid combination"),
+            };
 
-                case 0x02:
-                    addr += 1;
-                    break;
-
-                case 0x01:
-                    addr += 2;
-                    break;
-
-                case 0x10:
-                    addr += 4;
-                    break;
-
-                case 0x12:
-                    addr += 5;
-                    break;
-
-                case 0x11:
-                    addr += 6;
-                    break;
-
-                case 0x20:
-                    addr += 3;
-                    break;
-
-                case 0x21:
-                    addr += 7;
-                    break;
-
-                default:
-                    throw new ArgumentException("Invalid combination");
-            }
-
-            return addr;
+            return addr += (byte)value;
         }
 
         public static byte SetChannelBits(byte configByte, int channel)
@@ -106,23 +79,13 @@ namespace Iot.Device.Mcp3428
 
         public static byte SetResolutionBits(byte configByte, AdcResolution resolution) => (byte)((configByte & ~Helpers.Masks.ResolutionMask) | (byte)resolution);
 
-        public static int UpdateFrequency(AdcResolution res)
+        public static int UpdateFrequency(AdcResolution res) => res switch
         {
-            switch (res)
-            {
-                case AdcResolution.Bit12:
-                    return 240;
-
-                case AdcResolution.Bit14:
-                    return 60;
-
-                case AdcResolution.Bit16:
-                    return 15;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(res), res, null);
-            }
-        }
+            AdcResolution.Bit12 => 240,
+            AdcResolution.Bit14 => 60,
+            AdcResolution.Bit16 => 15,
+            _ => throw new ArgumentOutOfRangeException(nameof(res), res, null),
+        };
 
         // From datasheet 5.2
         public static class Masks

--- a/src/devices/Mpu9250/Mpu6500.cs
+++ b/src/devices/Mpu9250/Mpu6500.cs
@@ -250,24 +250,14 @@ namespace Iot.Device.Imu
         {
             get
             {
-                float val = 0;
-                switch (GyroscopeRange)
+                float val = GyroscopeRange switch
                 {
-                    case GyroscopeRange.Range0250Dps:
-                        val = 250.0f;
-                        break;
-                    case GyroscopeRange.Range0500Dps:
-                        val = 500.0f;
-                        break;
-                    case GyroscopeRange.Range1000Dps:
-                        val = 1000.0f;
-                        break;
-                    case GyroscopeRange.Range2000Dps:
-                        val = 2000.0f;
-                        break;
-                    default:
-                        break;
-                }
+                    GyroscopeRange.Range0250Dps => 250.0f,
+                    GyroscopeRange.Range0500Dps => 500.0f,
+                    GyroscopeRange.Range1000Dps => 1000.0f,
+                    GyroscopeRange.Range2000Dps => 2000.0f,
+                    _ => 0,
+                };
 
                 val /= Adc;
                 // the sample rate diver only apply for the non FS modes

--- a/src/devices/Mpu9250/Mpu9250.cs
+++ b/src/devices/Mpu9250/Mpu9250.cs
@@ -121,34 +121,18 @@ namespace Iot.Device.Imu
             return new Vector3(magn.Y, magn.X, -magn.Z);
         }
 
-        private TimeSpan GetTimeout()
+        // TODO: find what is the value in the documentation, it should be pretty fast
+        // But taking the same value as for the slowest one so th 8Hz one
+        private TimeSpan GetTimeout() => _ak8963.MeasurementMode switch
         {
-            TimeSpan timeout = TimeSpan.Zero;
-            switch (_ak8963.MeasurementMode)
-            {
-                // TODO: find what is the value in the documentation, it should be pretty fast
-                // But taking the same value as for the slowest one so th 8Hz one
-                case MeasurementMode.SingleMeasurement:
-                case MeasurementMode.ExternalTriggedMeasurement:
-                case MeasurementMode.SelfTest:
-                case MeasurementMode.ContinuousMeasurement8Hz:
-                    // 8Hz measurement period plus 2 milliseconds
-                    timeout = TimeSpan.FromMilliseconds(127);
-                    break;
-                case MeasurementMode.ContinuousMeasurement100Hz:
-                    // 100Hz measurement period plus 2 milliseconds
-                    // When switching to this mode, the first read can be longer than 10 ms. Tests shows up to 100 ms
-                    timeout = _firstContinuousRead ? TimeSpan.FromMilliseconds(100) : TimeSpan.FromMilliseconds(12);
-                    break;
-                // Those cases are not measurement and should be 0 then
-                case MeasurementMode.FuseRomAccess:
-                case MeasurementMode.PowerDown:
-                default:
-                    break;
-            }
-
-            return timeout;
-        }
+            // 8Hz measurement period plus 2 milliseconds
+            MeasurementMode.SingleMeasurement or MeasurementMode.ExternalTriggedMeasurement or MeasurementMode.SelfTest or MeasurementMode.ContinuousMeasurement8Hz
+                => TimeSpan.FromMilliseconds(127),
+            // 100Hz measurement period plus 2 milliseconds
+            // When switching to this mode, the first read can be longer than 10 ms. Tests shows up to 100 ms
+            MeasurementMode.ContinuousMeasurement100Hz => _firstContinuousRead ? TimeSpan.FromMilliseconds(100) : TimeSpan.FromMilliseconds(12),
+            _ => TimeSpan.Zero,
+        };
 
         /// <summary>
         /// Select the magnetometer measurement mode

--- a/src/devices/Nrf24l01/Nrf24l01.cs
+++ b/src/devices/Nrf24l01/Nrf24l01.cs
@@ -555,19 +555,12 @@ namespace Iot.Device.Nrf24l01
 
             Span<byte> readData = WriteRead(Command.NRF_R_REGISTER, Register.NRF_CONFIG, 1);
 
-            byte setting;
-            switch (mode)
+            byte setting = mode switch
             {
-                case PowerMode.UP:
-                    setting = (byte)(readData[0] | (1 << 1));
-                    break;
-                case PowerMode.DOWN:
-                    setting = (byte)(readData[0] & ~(1 << 1));
-                    break;
-                default:
-                    setting = (byte)(readData[0] | (1 << 1));
-                    break;
-            }
+                PowerMode.UP => setting = (byte)(readData[0] | (1 << 1)),
+                PowerMode.DOWN => setting = (byte)(readData[0] & ~(1 << 1)),
+                _ => setting = (byte)(readData[0] | (1 << 1)),
+            };
 
             Write(Command.NRF_W_REGISTER, Register.NRF_CONFIG, setting);
 
@@ -598,19 +591,12 @@ namespace Iot.Device.Nrf24l01
 
             Span<byte> readData = WriteRead(Command.NRF_R_REGISTER, Register.NRF_CONFIG, 1);
 
-            byte setting;
-            switch (mode)
+            byte setting = mode switch
             {
-                case WorkingMode.Receive:
-                    setting = (byte)(readData[0] | 1);
-                    break;
-                case WorkingMode.Transmit:
-                    setting = (byte)(readData[0] & ~1);
-                    break;
-                default:
-                    setting = (byte)(readData[0] | 1);
-                    break;
-            }
+                WorkingMode.Receive => (byte)(readData[0] | 1),
+                WorkingMode.Transmit => (byte)(readData[0] & ~1),
+                _ => (byte)(readData[0] | 1),
+            };
 
             Write(Command.NRF_W_REGISTER, Register.NRF_CONFIG, setting);
 

--- a/src/devices/PiJuice/Models/BatteryExtendedProfile.cs
+++ b/src/devices/PiJuice/Models/BatteryExtendedProfile.cs
@@ -4,46 +4,19 @@
 
 using UnitsNet;
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// Battery extended profile
     /// </summary>
-    public class BatteryExtendedProfile
-    {
-        /// <summary>
-        /// Battery chemistry
-        /// </summary>
-        public BatteryChemistry BatteryChemistry { get; set; }
-
-        /// <summary>
-        /// Open Circuit Voltage at 10% charge as millivolts
-        /// </summary>
-        public ElectricPotential OpenCircuitVoltage10Percent { get; set; }
-
-        /// <summary>
-        /// Open Circuit Voltage at 50% charge as millivolts
-        /// </summary>
-        public ElectricPotential OpenCircuitVoltage50Percent { get; set; }
-
-        /// <summary>
-        /// Open Circuit Voltage at 90% charge as millivolts
-        /// </summary>
-        public ElectricPotential OpenCircuitVoltage90Percent { get; set; }
-
-        /// <summary>
-        /// Internal battery resistance at 10% charge as milliohm
-        /// </summary>
-        public ElectricResistance InternalResistance10Percent { get; set; }
-
-        /// <summary>
-        /// Internal battery resistance at 50% charge as milliohm
-        /// </summary>
-        public ElectricResistance InternalResistance50Percent { get; set; }
-
-        /// <summary>
-        /// Internal battery resistance at 90% charge as milliohm
-        /// </summary>
-        public ElectricResistance InternalResistance90Percent { get; set; }
-    }
+    /// <param name="BatteryChemistry">Battery chemistry.</param>
+    /// <param name="OpenCircuitVoltage10Percent">Open Circuit Voltage at 10% charge as millivolts.</param>
+    /// <param name="OpenCircuitVoltage50Percent">Open Circuit Voltage at 50% charge as millivolts.</param>
+    /// <param name="OpenCircuitVoltage90Percent">Open Circuit Voltage at 90% charge as millivolts.</param>
+    /// <param name="InternalResistance10Percent">Internal battery resistance at 10% charge as milliohm.</param>
+    /// <param name="InternalResistance50Percent">Internal battery resistance at 50% charge as milliohm.</param>
+    /// <param name="InternalResistance90Percent">Internal battery resistance at 90% charge as milliohm.</param>
+    public record BatteryExtendedProfile(BatteryChemistry BatteryChemistry, ElectricPotential OpenCircuitVoltage10Percent, ElectricPotential OpenCircuitVoltage50Percent, ElectricPotential OpenCircuitVoltage90Percent, ElectricResistance InternalResistance10Percent, ElectricResistance InternalResistance50Percent, ElectricResistance InternalResistance90Percent);
 }

--- a/src/devices/PiJuice/Models/BatteryProfile.cs
+++ b/src/devices/PiJuice/Models/BatteryProfile.cs
@@ -4,66 +4,23 @@
 
 using UnitsNet;
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// Battery profile
     /// </summary>
-    public class BatteryProfile
-    {
-        /// <summary>
-        /// Charge capacity of battery
-        /// </summary>
-        public ElectricCharge Capacity { get; set; }
-
-        /// <summary>
-        /// [550mA – 2500mA] Constant current that PiJuice battery is charged in current regulation phase of charging process as milliamps
-        /// </summary>
-        public ElectricCurrent ChargeCurrent { get; set; }
-
-        /// <summary>
-        /// [50mA – 400mA] When charging current drops below termination current threshold in voltage regulation phase charging process terminates as milliamps
-        /// </summary>
-        public ElectricCurrent TerminationCurrent { get; set; }
-
-        /// <summary>
-        /// [3500mV – 4440mV] Voltage to which voltage over battery is regulated in voltage regulation phase of charging process as millivolts
-        /// </summary>
-        public ElectricPotential RegulationVoltage { get; set; }
-
-        /// <summary>
-        /// [0mV – 5100mV] Minimum voltage at which battery is fully discharged as millivolts
-        /// </summary>
-        public ElectricPotential CutOffVoltage { get; set; }
-
-        /// <summary>
-        /// Temperature threshold according to JEITA standard below which charging is suspended as celsius
-        /// </summary>
-        public Temperature TemperatureCold { get; set; }
-
-        /// <summary>
-        /// Temperature threshold according to JEITA standard below which charge current is reduced to half of programmed charge current. This threshold should be set above cold temperature as celsius
-        /// </summary>
-        public Temperature TemperatureCool { get; set; }
-
-        /// <summary>
-        /// Temperature threshold according to JEITA standard above which the battery regulation voltage is reduced by 140mV from the programmed regulation voltage. This threshold should be set above cool temperature as celsius
-        /// </summary>
-        public Temperature TemperatureWarm { get; set; }
-
-        /// <summary>
-        /// Temperature threshold according to JEITA standard above which charging is suspended. This threshold should be set above warm temperature as celsius
-        /// </summary>
-        public Temperature TemperatureHot { get; set; }
-
-        /// <summary>
-        /// Thermistor B constant of NTC temperature sensor if it is integrated with battery
-        /// </summary>
-        public int NegativeTemperatureCoefficientB { get; set; }
-
-        /// <summary>
-        /// Nominal thermistor resistance at 25°C of NTC temperature sensor if it is integrated with battery as ohm
-        /// </summary>
-        public ElectricResistance NegativeTemperatureCoefficientResistance { get; set; }
-    }
+    /// <param name="Capacity">Charge capacity of battery.</param>
+    /// <param name="ChargeCurrent">[550mA – 2500mA] Constant current that PiJuice battery is charged in current regulation phase of charging process as milliamps.</param>
+    /// <param name="TerminationCurrent">[50mA – 400mA] When charging current drops below termination current threshold in voltage regulation phase charging process terminates as milliamps.</param>
+    /// <param name="RegulationVoltage">[3500mV – 4440mV] Voltage to which voltage over battery is regulated in voltage regulation phase of charging process as millivolts.</param>
+    /// <param name="CutOffVoltage">[0mV – 5100mV] Minimum voltage at which battery is fully discharged as millivolts.</param>
+    /// <param name="TemperatureCold">Temperature threshold according to JEITA standard below which charging is suspended as celsius.</param>
+    /// <param name="TemperatureCool">Temperature threshold according to JEITA standard below which charge current is reduced to half of programmed charge current. This threshold should be set above cold temperature as celsius.</param>
+    /// <param name="TemperatureWarm">Temperature threshold according to JEITA standard above which the battery regulation voltage is reduced by 140mV from the programmed regulation voltage. This threshold should be set above cool temperature as celsius.</param>
+    /// <param name="TemperatureHot">Temperature threshold according to JEITA standard above which charging is suspended. This threshold should be set above warm temperature as celsius.</param>
+    /// <param name="NegativeTemperatureCoefficientB">Thermistor B constant of NTC temperature sensor if it is integrated with battery.</param>
+    /// <param name="NegativeTemperatureCoefficientResistance">Nominal thermistor resistance at 25°C of NTC temperature sensor if it is integrated with battery as ohm.</param>
+    public record BatteryProfile(ElectricCharge Capacity, ElectricCurrent ChargeCurrent, ElectricCurrent TerminationCurrent, ElectricPotential RegulationVoltage, ElectricPotential CutOffVoltage, Temperature TemperatureCold, Temperature TemperatureCool, Temperature TemperatureWarm, Temperature TemperatureHot, int NegativeTemperatureCoefficientB, ElectricResistance NegativeTemperatureCoefficientResistance);
 }

--- a/src/devices/PiJuice/Models/BatteryProfileStatus.cs
+++ b/src/devices/PiJuice/Models/BatteryProfileStatus.cs
@@ -2,31 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// Battery profile status
     /// </summary>
-    public class BatteryProfileStatus
-    {
-        /// <summary>
-        /// Current battery profile
-        /// </summary>
-        public string BatteryProfile { get; set; }
-
-        /// <summary>
-        /// The source for the battery profile
-        /// </summary>
-        public BatteryProfileSource BatteryProfileSource { get; set; }
-
-        /// <summary>
-        /// Whether the current battery profile is valid
-        /// </summary>
-        public bool BatteryProfileValid { get; set; }
-
-        /// <summary>
-        /// The type of battery profile
-        /// </summary>
-        public BatteryOrigin BatteryOrigin { get; set; }
-    }
+    /// <param name ="BatteryProfile">Current battery profile</param>
+    /// <param name ="BatteryProfileSource">The source for the battery profile</param>
+    /// <param name ="BatteryProfileValid">Whether the current battery profile is valid</param>
+    /// <param name ="BatteryOrigin">The type of battery profile</param>
+    public record BatteryProfileStatus(string BatteryProfile, BatteryProfileSource BatteryProfileSource, bool BatteryProfileValid, BatteryOrigin BatteryOrigin);
 }

--- a/src/devices/PiJuice/Models/ChargingConfig.cs
+++ b/src/devices/PiJuice/Models/ChargingConfig.cs
@@ -2,21 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// Charging configuration
     /// </summary>
-    public class ChargingConfig
-    {
-        /// <summary>
-        /// Whether charging is enabled
-        /// </summary>
-        public bool Enabled { get; set; }
-
-        /// <summary>
-        /// Whether the charging configuration is stored in the non-volatile EEPROM
-        /// </summary>
-        public bool NonVolatile { get; set; }
-    }
+    /// <param name="Enabled">Whether charging is enabled.</param>
+    /// <param name="NonVolatile">Whether the charging configuration is stored in the non-volatile EEPROM.</param>
+    public record ChargingConfig(bool Enabled, bool NonVolatile);
 }

--- a/src/devices/PiJuice/Models/FaultStatus.cs
+++ b/src/devices/PiJuice/Models/FaultStatus.cs
@@ -2,41 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// PiJuice Fault Status
     /// </summary>
-    public class FaultStatus
-    {
-        /// <summary>
-        /// If there was power off triggered by button press
-        /// </summary>
-        public bool ButtonPowerOff { get; set; }
-
-        /// <summary>
-        /// If there was forced power off caused by loss of energy (battery voltage approached cut-off threshold)
-        /// </summary>
-        public bool ForcedPowerOff { get; set; }
-
-        /// <summary>
-        /// If there was forced system switch turn off caused by loss of energy
-        /// </summary>
-        public bool ForcedSystemPowerOff { get; set; }
-
-        /// <summary>
-        /// If watchdog reset happened
-        /// </summary>
-        public bool WatchdogReset { get; set; }
-
-        /// <summary>
-        /// Determines if the battery profile is invalid
-        /// </summary>
-        public bool BatteryProfileInvalid { get; set; }
-
-        /// <summary>
-        /// Battery charging temperature fault
-        /// </summary>
-        public BatteryChargingTemperatureFault BatteryChargingTemperatureFault { get; set; }
-    }
+    /// <param name="ButtonPowerOff">If there was power off triggered by button press.</param>
+    /// <param name="ForcedPowerOff">If there was forced power off caused by loss of energy (battery voltage approached cut-off threshold).</param>
+    /// <param name="ForcedSystemPowerOff">If there was forced system switch turn off caused by loss of energy.</param>
+    /// <param name="WatchdogReset">If watchdog reset happened.</param>
+    /// <param name="BatteryProfileInvalid">Determines if the battery profile is invalid.</param>
+    /// <param name="BatteryChargingTemperatureFault">Battery charging temperature fault.</param>
+    public record FaultStatus(bool ButtonPowerOff, bool ForcedPowerOff, bool ForcedSystemPowerOff, bool WatchdogReset, bool BatteryProfileInvalid, BatteryChargingTemperatureFault BatteryChargingTemperatureFault);
 }

--- a/src/devices/PiJuice/Models/LEDBlink.cs
+++ b/src/devices/PiJuice/Models/LEDBlink.cs
@@ -5,46 +5,19 @@
 using System;
 using System.Drawing;
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// Led blink pattern
     /// </summary>
-    public class LedBlink
-    {
-        /// <summary>
-        /// Led designator
-        /// </summary>
-        public Led Led { get; set; }
-
-        /// <summary>
-        /// Blink indefinite
-        /// </summary>
-        public bool BlinkIndefinite { get; set; }
-
-        /// <summary>
-        /// Number of blinks between [1 - 254]
-        /// </summary>
-        public byte Count { get; set; }
-
-        /// <summary>
-        /// Color for first period of blink
-        /// </summary>
-        public Color ColorFirstPeriod { get; set; }
-
-        /// <summary>
-        /// Duration of first blink period in milliseconds between [10 – 2550]
-        /// </summary>
-        public TimeSpan FirstPeriod { get; set; }
-
-        /// <summary>
-        /// Color for second period of blink
-        /// </summary>
-        public Color ColorSecondPeriod { get; set; }
-
-        /// <summary>
-        /// Duration of second blink period in milliseconds between [10 – 2550]
-        /// </summary>
-        public TimeSpan SecondPeriod { get; set; }
-    }
+    /// <param name="Led">Led designator.</param>
+    /// <param name="BlinkIndefinite">Blink indefinite.</param>
+    /// <param name="Count">Number of blinks between [1 - 254].</param>
+    /// <param name="ColorFirstPeriod">Color for first period of blink.</param>
+    /// <param name="FirstPeriod">Duration of first blink period in milliseconds between [10 – 2550].</param>
+    /// <param name="ColorSecondPeriod">Color for second period of blink.</param>
+    /// <param name="SecondPeriod">Duration of second blink period in milliseconds between [10 – 2550].</param>
+    public record LedBlink(Led Led, bool BlinkIndefinite, byte Count, Color ColorFirstPeriod, TimeSpan FirstPeriod, Color ColorSecondPeriod, TimeSpan SecondPeriod);
 }

--- a/src/devices/PiJuice/Models/LEDConfig.cs
+++ b/src/devices/PiJuice/Models/LEDConfig.cs
@@ -4,31 +4,21 @@
 
 using System.Drawing;
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// Led configuration
     /// </summary>
-    public class LedConfig
-    {
-        /// <summary>
-        /// Led designator
-        /// </summary>
-        public Led Led { get; set; }
-
-        /// <summary>
-        /// Led function type
-        /// </summary>
-        public LedFunction LedFunction { get; set; }
-
-        /// <summary>
-        /// Color for Led
-        /// If LedFunction is ChargeStatus
-        /// Red - parameter defines color component level of red below 15%
-        /// Green - parameter defines color component charge level over 50%
-        /// Blue - parameter defines color component for charging(blink) and fully charged states(constant)
-        /// Red Led and Green Led will show the charge status between 15% - 50%
-        /// </summary>
-        public Color Color { get; set; }
-    }
+    /// <param name="Led">Led designator</param>
+    /// <param name="LedFunction">Led function type</param>
+    /// <param name="Color">Color for Led.
+    /// If LedFunction is ChargeStatus
+    /// Red - parameter defines color component level of red below 15%
+    /// Green - parameter defines color component charge level over 50%
+    /// Blue - parameter defines color component for charging(blink) and fully charged states(constant)
+    /// Red Led and Green Led will show the charge status between 15% - 50%
+    /// </param>
+    public record LedConfig(Led Led, LedFunction LedFunction, Color Color);
 }

--- a/src/devices/PiJuice/Models/PiJuiceInfo.cs
+++ b/src/devices/PiJuice/Models/PiJuiceInfo.cs
@@ -4,12 +4,15 @@
 
 using System;
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// PiJuice info
     /// </summary>
-    public class PiJuiceInfo
+    /// <param name="FirmwareVersion">Firmware version</param>
+    public record PiJuiceInfo(Version FirmwareVersion)
     {
         /// <summary>
         /// Manufacturer information
@@ -20,10 +23,5 @@ namespace Iot.Device.PiJuiceDevice.Models
         /// Board information
         /// </summary>
         public string Board => "PiJuice";
-
-        /// <summary>
-        /// Firmware version
-        /// </summary>
-        public Version FirmwareVersion { get; set; }
     }
 }

--- a/src/devices/PiJuice/Models/PowerInput.cs
+++ b/src/devices/PiJuice/Models/PowerInput.cs
@@ -4,41 +4,18 @@
 
 using UnitsNet;
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// PiJuice power input
     /// </summary>
-    public class PowerInput
-    {
-        /// <summary>
-        /// Selects what power input will have precedence for charging and supplying VSYS output when both are present, PiJuice USB Micro Input, GPIO 5V Input. 5V_GPIO selected by default
-        /// </summary>
-        public PowerInputType Precedence { get; set; }
-
-        /// <summary>
-        /// Enables/disables powering PiJuice from 5V GPIO Input. Enabled by default
-        /// </summary>
-        public bool GpioIn { get; set; }
-
-        /// <summary>
-        /// If enabled PiJuice will automatically power on 5V rail and trigger wake up as soon as power appears at USB Micro Input and there is no battery. Disabled by default
-        /// </summary>
-        public bool NoBatteryTurnOn { get; set; }
-
-        /// <summary>
-        /// Maximum current that PiJuice can take from USB Micro connected power source. 2.5A selected by default
-        /// </summary>
-        public ElectricCurrent UsbMicroCurrentLimit { get; set; }
-
-        /// <summary>
-        /// Minimum voltage at USB Micro power input for Dynamic Power Management Loop. 4.2V set by default
-        /// </summary>
-        public ElectricPotential UsbMicroDynamicPowerManagement { get; set; }
-
-        /// <summary>
-        /// Whether the power input configuration is stored in the non-volatile EEPROM
-        /// </summary>
-        public bool NonVolatile { get; set; }
-    }
+    /// <param name="Precedence">Selects what power input will have precedence for charging and supplying VSYS output when both are present, PiJuice USB Micro Input, GPIO 5V Input. 5V_GPIO selected by default.</param>
+    /// <param name="GpioIn">Enables/disables powering PiJuice from 5V GPIO Input. Enabled by default.</param>
+    /// <param name="NoBatteryTurnOn">If enabled PiJuice will automatically power on 5V rail and trigger wake up as soon as power appears at USB Micro Input and there is no battery. Disabled by default.</param>
+    /// <param name="UsbMicroCurrentLimit">Maximum current that PiJuice can take from USB Micro connected power source. 2.5A selected by default</param>
+    /// <param name="UsbMicroDynamicPowerManagement">Minimum voltage at USB Micro power input for Dynamic Power Management Loop. 4.2V set by default.</param>
+    /// <param name="NonVolatile">Whether the power input configuration is stored in the non-volatile EEPROM.</param>
+    public record PowerInput(PowerInputType Precedence, bool GpioIn, bool NoBatteryTurnOn, ElectricCurrent UsbMicroCurrentLimit, ElectricPotential UsbMicroDynamicPowerManagement, bool NonVolatile);
 }

--- a/src/devices/PiJuice/Models/Status.cs
+++ b/src/devices/PiJuice/Models/Status.cs
@@ -2,36 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// PiJuice Status
     /// </summary>
-    public class Status
-    {
-        /// <summary>
-        /// True if there faults or fault events waiting to be read, otherwise False
-        /// </summary>
-        public bool IsFault { get; set; }
-
-        /// <summary>
-        /// True if there are button events, otherwise False
-        /// </summary>
-        public bool IsButton { get; set; }
-
-        /// <summary>
-        /// Current battery status
-        /// </summary>
-        public BatteryState Battery { get; set; }
-
-        /// <summary>
-        /// Current USB Micro power input status
-        /// </summary>
-        public PowerInState PowerInput { get; set; }
-
-        /// <summary>
-        /// Current 5V GPIO power input status
-        /// </summary>
-        public PowerInState PowerInput5VoltInput { get; set; }
-    }
+    /// <param name="IsFault">True if there faults or fault events waiting to be read, otherwise False.</param>
+    /// <param name="IsButton">True if there are button events, otherwise False.</param>
+    /// <param name="Battery">Current battery status.</param>
+    /// <param name="PowerInput">Current USB Micro power input status.</param>
+    /// <param name="PowerInput5VoltInput">Current 5V GPIO power input status.</param>
+    public record Status(bool IsFault, bool IsButton, BatteryState Battery, PowerInState PowerInput, PowerInState PowerInput5VoltInput);
 }

--- a/src/devices/PiJuice/Models/WakeUpOnCharge.cs
+++ b/src/devices/PiJuice/Models/WakeUpOnCharge.cs
@@ -4,21 +4,14 @@
 
 using UnitsNet;
 
+#pragma warning disable CS1591, CS1572, CS1573
+
 namespace Iot.Device.PiJuiceDevice.Models
 {
     /// <summary>
     /// Wake up on charge configuration
     /// </summary>
-    public class WakeUpOnCharge
-    {
-        /// <summary>
-        /// Is the wake up on charge disabled
-        /// </summary>
-        public bool Disabled { get; set; }
-
-        /// <summary>
-        /// Battery charge level percentage between [0 - 100] used to wake up the Raspberry Pi
-        /// </summary>
-        public Ratio WakeUpPercentage { get; set; }
-    }
+    /// <param name="Disabled">Is the wake up on charge disabled.</param>
+    /// <param name="WakeUpPercentage">Battery charge level percentage between [0 - 100] used to wake up the Raspberry Pi.</param>
+    public record WakeUpOnCharge(bool Disabled, Ratio WakeUpPercentage);
 }

--- a/src/devices/PiJuice/PiJuice.cs
+++ b/src/devices/PiJuice/PiJuice.cs
@@ -41,7 +41,7 @@ namespace Iot.Device.PiJuiceDevice
         {
             _i2cDevice = i2cDevice ?? throw new ArgumentNullException(nameof(i2cDevice));
             _shouldDispose = shouldDispose;
-            PiJuiceInfo = new PiJuiceInfo() { FirmwareVersion = GetFirmwareVerion() };
+            PiJuiceInfo = new PiJuiceInfo(GetFirmwareVerion());
         }
 
         /// <inheritdoc/>
@@ -50,7 +50,7 @@ namespace Iot.Device.PiJuiceDevice
             if (_shouldDispose)
             {
                 _i2cDevice?.Dispose();
-                _i2cDevice = null;
+                _i2cDevice = null!;
             }
         }
 

--- a/src/devices/PiJuice/PiJuiceDevice.csproj
+++ b/src/devices/PiJuice/PiJuiceDevice.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-	<EnableDefaultItems>false</EnableDefaultItems>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+	  <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <Compile Include="$(MSBuildThisFileDirectory)/../Common/System/Runtime/CompilerServices/IsExternalInit.cs" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <Compile Include="*.cs" />
     <Compile Remove="samples\**" />
     <Compile Include="Models\*.cs" />

--- a/src/devices/PiJuice/PiJuicePower.cs
+++ b/src/devices/PiJuice/PiJuicePower.cs
@@ -58,11 +58,9 @@ namespace Iot.Device.PiJuiceDevice
             {
                 var response = _piJuice.ReadCommand(PiJuiceCommand.WakeUpOnCharge, 1);
 
-                return new WakeUpOnCharge
-                {
-                    Disabled = response[0] == 0x7F,
-                    WakeUpPercentage = new Ratio((response[0] == 0x7F ? 0 : response[0]), UnitsNet.Units.RatioUnit.Percent)
-                };
+                return new WakeUpOnCharge(
+                    response[0] == 0x7F,
+                    new Ratio((response[0] == 0x7F ? 0 : response[0]), UnitsNet.Units.RatioUnit.Percent));
             }
             set
             {

--- a/src/devices/PiJuice/samples/PiJuiceDevice.sample.cs
+++ b/src/devices/PiJuice/samples/PiJuiceDevice.sample.cs
@@ -16,14 +16,14 @@ namespace PiJuiceDevice.Sample
         public static void Main(string[] args)
         {
             Console.WriteLine("Hello PiJuice!");
-            I2cConnectionSettings i2CConnectionSettings = new I2cConnectionSettings(1, PiJuice.DefaultI2cAddress);
-            PiJuice piJuice = new PiJuice(I2cDevice.Create(i2CConnectionSettings));
+            I2cConnectionSettings i2CConnectionSettings = new(1, PiJuice.DefaultI2cAddress);
+            PiJuice piJuice = new(I2cDevice.Create(i2CConnectionSettings));
             Console.WriteLine($"Manufacturer :{piJuice.PiJuiceInfo.Manufacturer}");
             Console.WriteLine($"Board: {piJuice.PiJuiceInfo.Board}");
             Console.WriteLine($"Firmware version: {piJuice.PiJuiceInfo.FirmwareVersion}");
-            PiJuiceStatus piJuiceStatus = new PiJuiceStatus(piJuice);
-            PiJuicePower piJuicePower = new PiJuicePower(piJuice);
-            PiJuiceConfig piJuiceConfig = new PiJuiceConfig(piJuice);
+            PiJuiceStatus piJuiceStatus = new(piJuice);
+            PiJuicePower piJuicePower = new(piJuice);
+            PiJuiceConfig piJuiceConfig = new(piJuice);
             while (!Console.KeyAvailable)
             {
                 Console.Clear();
@@ -38,11 +38,11 @@ namespace PiJuiceDevice.Sample
                 WakeUpOnCharge wakeUp = piJuicePower.WakeUpOnCharge;
                 Console.WriteLine($"Is wake up on charge disabled: {wakeUp.Disabled}, Wake up at charging percentage: {wakeUp.WakeUpPercentage}%");
                 Console.WriteLine("Set wake up on charge percentage to 60%");
-                piJuicePower.WakeUpOnCharge = new WakeUpOnCharge { Disabled = false, WakeUpPercentage = new Ratio(60, RatioUnit.Percent) };
+                piJuicePower.WakeUpOnCharge = new(false, new Ratio(60, RatioUnit.Percent));
                 Thread.Sleep(5);
                 wakeUp = piJuicePower.WakeUpOnCharge;
                 Console.WriteLine($"Is wake up on charge disabled: {wakeUp.Disabled}, Wake up at charging percentage: {wakeUp.WakeUpPercentage.Value}%");
-                piJuicePower.WakeUpOnCharge = new WakeUpOnCharge { Disabled = true, WakeUpPercentage = new Ratio(0, RatioUnit.Percent) };
+                piJuicePower.WakeUpOnCharge = new(true, new Ratio(0, RatioUnit.Percent));
 
                 Thread.Sleep(2000);
             }

--- a/src/devices/Uln2003/Uln2003.cs
+++ b/src/devices/Uln2003/Uln2003.cs
@@ -94,10 +94,7 @@ namespace Iot.Device.Uln2003
         /// </summary>
         public StepperMode Mode
         {
-            get
-            {
-                return _mode;
-            }
+            get => _mode;
             set
             {
                 _mode = value;

--- a/src/devices/Vl53L0X/Vl53L0X.cs
+++ b/src/devices/Vl53L0X/Vl53L0X.cs
@@ -1049,19 +1049,13 @@ namespace Iot.Device.Vl53L0X
         /// </summary>
         /// <param name="type">The VCSEL period to decode</param>
         /// <returns>The decoded period</returns>
-        private byte GetVcselPulsePeriod(VcselType type)
+        private byte GetVcselPulsePeriod(VcselType type) => type switch
         {
-            switch (type)
-            {
-                case VcselType.VcselPeriodPreRange:
-                    return DecodeVcselPeriod(ReadByte((byte)Registers.PRE_RANGE_CONFIG_VCSEL_PERIOD));
-                case VcselType.VcselPeriodFinalRange:
-                    return DecodeVcselPeriod(ReadByte((byte)Registers.FINAL_RANGE_CONFIG_VCSEL_PERIOD));
-                default:
-                    // Should not arrive
-                    return byte.MaxValue;
-            }
-        }
+            VcselType.VcselPeriodPreRange => DecodeVcselPeriod(ReadByte((byte)Registers.PRE_RANGE_CONFIG_VCSEL_PERIOD)),
+            VcselType.VcselPeriodFinalRange => DecodeVcselPeriod(ReadByte((byte)Registers.FINAL_RANGE_CONFIG_VCSEL_PERIOD)),
+            // Should not arrive
+            _ => byte.MaxValue,
+        };
 
         /// <summary>
         /// Encode VCSEL pulse period register value from period in PCLKs


### PR DESCRIPTION
Switch statements were converted to more terse switch expressions.

Most (or all) of the remaining switch statements are not candidates for switch expressions.

I also converted a number of 1-line methods to method body expressions as well.