### PR TITLE
Add a generic logging infrastructure

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -16,6 +16,14 @@
   </ToolsetDependencies>
   <!-- ProductDependencies -->
   <ProductDependencies>
+    <Dependency Name="Microsoft.Extensions.Logging" Version="5.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>bfc49945c0bedeffe01bb5d6f3c217dad207d0d8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>bfc49945c0bedeffe01bb5d6f3c217dad207d0d8</Sha>
+    </Dependency>
     <Dependency Name="System.Drawing.Common" Version="5.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5111aa12cdeb8e8703d475193f78c1848f58f6c6</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,6 +13,7 @@
     <SystemMemoryPackageVersion>4.5.4</SystemMemoryPackageVersion>
     <SystemRuntimeInteropServicesWindowsRuntimePackageVersion>4.3.0</SystemRuntimeInteropServicesWindowsRuntimePackageVersion>
     <UnitsNetPackageVersion>4.77.0</UnitsNetPackageVersion>
+    <MicrosoftExtensionsVersion>5.0.0</MicrosoftExtensionsVersion>
     <SixLaborsImageSharpPackageVersion>1.0.2</SixLaborsImageSharpPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,8 @@
     <SystemMemoryPackageVersion>4.5.4</SystemMemoryPackageVersion>
     <SystemRuntimeInteropServicesWindowsRuntimePackageVersion>4.3.0</SystemRuntimeInteropServicesWindowsRuntimePackageVersion>
     <UnitsNetPackageVersion>4.77.0</UnitsNetPackageVersion>
-    <MicrosoftExtensionsVersion>5.0.0</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>5.0.0</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>5.0.0</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <SixLaborsImageSharpPackageVersion>1.0.2</SixLaborsImageSharpPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <PackageReference Include="System.Management" Version="$(SystemManagementPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="SixLabors.ImageSharp" Version="$(SixLaborsImageSharpPackageVersion)" />
   </ItemGroup>
 

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -29,7 +29,7 @@
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <PackageReference Include="System.Management" Version="$(SystemManagementPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
     <PackageReference Include="SixLabors.ImageSharp" Version="$(SixLaborsImageSharpPackageVersion)" />
   </ItemGroup>
 

--- a/src/devices/Common/Common.sln
+++ b/src/devices/Common/Common.sln
@@ -1,13 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30717.126
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A15AFC2C-C6D8-496A-B275-DBE044FEA83F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Tests", "tests\Common.Tests.csproj", "{BF1A594E-CEE3-4629-9F95-56D40F7F00E4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common.Tests", "tests\Common.Tests.csproj", "{BF1A594E-CEE3-4629-9F95-56D40F7F00E4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "CommonHelpers.csproj", "{1B521F66-CECB-4FA6-9FC4-FA70F24F8C60}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "CommonHelpers.csproj", "{1B521F66-CECB-4FA6-9FC4-FA70F24F8C60}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{CAED1B3A-81A5-419E-86D9-96F8D9EB2F29}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common.Samples", "samples\Common.Samples.csproj", "{57DBD884-125C-4F60-852C-98086C15A43B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +21,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{BF1A594E-CEE3-4629-9F95-56D40F7F00E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -34,18 +35,6 @@ Global
 		{BF1A594E-CEE3-4629-9F95-56D40F7F00E4}.Release|x64.Build.0 = Release|Any CPU
 		{BF1A594E-CEE3-4629-9F95-56D40F7F00E4}.Release|x86.ActiveCfg = Release|Any CPU
 		{BF1A594E-CEE3-4629-9F95-56D40F7F00E4}.Release|x86.Build.0 = Release|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Debug|x64.Build.0 = Debug|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Debug|x86.Build.0 = Debug|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Release|x64.ActiveCfg = Release|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Release|x64.Build.0 = Release|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Release|x86.ActiveCfg = Release|Any CPU
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473}.Release|x86.Build.0 = Release|Any CPU
 		{1B521F66-CECB-4FA6-9FC4-FA70F24F8C60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1B521F66-CECB-4FA6-9FC4-FA70F24F8C60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1B521F66-CECB-4FA6-9FC4-FA70F24F8C60}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -58,9 +47,27 @@ Global
 		{1B521F66-CECB-4FA6-9FC4-FA70F24F8C60}.Release|x64.Build.0 = Release|Any CPU
 		{1B521F66-CECB-4FA6-9FC4-FA70F24F8C60}.Release|x86.ActiveCfg = Release|Any CPU
 		{1B521F66-CECB-4FA6-9FC4-FA70F24F8C60}.Release|x86.Build.0 = Release|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Debug|x64.Build.0 = Debug|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Debug|x86.Build.0 = Debug|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Release|x64.ActiveCfg = Release|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Release|x64.Build.0 = Release|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Release|x86.ActiveCfg = Release|Any CPU
+		{57DBD884-125C-4F60-852C-98086C15A43B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{BF1A594E-CEE3-4629-9F95-56D40F7F00E4} = {A15AFC2C-C6D8-496A-B275-DBE044FEA83F}
-		{FC8AD588-F544-48D2-BEC0-2FDCF56E3473} = {A34B9682-EF69-4618-BB14-C36510C1ACAC}
+		{57DBD884-125C-4F60-852C-98086C15A43B} = {CAED1B3A-81A5-419E-86D9-96F8D9EB2F29}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {55F88A01-0608-4CD9-A295-DF0B06AE7399}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/Common/CommonHelpers.csproj
+++ b/src/devices/Common/CommonHelpers.csproj
@@ -16,6 +16,7 @@
     <Compile Include="System/Device/Gpio/*.cs" />
     <Compile Include="System/Device/Analog/*.cs" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Common/Iot/Device/Common/LogDispatcher.cs
+++ b/src/devices/Common/Iot/Device/Common/LogDispatcher.cs
@@ -12,23 +12,13 @@ namespace Iot.Device.Common
     /// </summary>
     public static class LogDispatcher
     {
-        private static object _lock;
-
-        static LogDispatcher()
-        {
-            LoggerFactory = null;
-            _lock = new object();
-        }
+        private static object _lock = new object();
 
         /// <summary>
         /// The default logger factory for the whole assembly.
         /// If this is null (the default), logging is disabled
         /// </summary>
-        public static ILoggerFactory? LoggerFactory
-        {
-            get;
-            set;
-        }
+        public static ILoggerFactory? LoggerFactory { get; set; } = null;
 
         /// <summary>
         /// Gets a logger with the given name

--- a/src/devices/Common/Iot/Device/Common/LogDispatcher.cs
+++ b/src/devices/Common/Iot/Device/Common/LogDispatcher.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Iot.Device.Common
+{
+    /// <summary>
+    /// This class contains static members that provide log support.
+    /// </summary>
+    public static class LogDispatcher
+    {
+        private static object _lock;
+
+        static LogDispatcher()
+        {
+            LoggerFactory = null;
+            _lock = new object();
+        }
+
+        /// <summary>
+        /// The default logger factory for the whole assembly.
+        /// If this is null (the default), logging is disabled
+        /// </summary>
+        public static ILoggerFactory? LoggerFactory
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets a logger with the given name
+        /// </summary>
+        /// <param name="loggerName">Name of the logger</param>
+        /// <returns>A reference to a <see cref="ILogger"/>.</returns>
+        public static ILogger GetLogger(string loggerName)
+        {
+            if (LoggerFactory == null)
+            {
+                return new NullLogger();
+            }
+
+            return LoggerFactory.CreateLogger(loggerName);
+        }
+
+        /// <summary>
+        /// Gets a logger with the name of the current class
+        /// </summary>
+        /// <param name="currentClass">The class whose logger shall be retrieved</param>
+        /// <returns>A <see cref="ILogger"/> instance</returns>
+        public static ILogger GetCurrentClassLogger(this object currentClass)
+        {
+            string? name = currentClass.GetType().FullName;
+
+            // This is true if the method is used from an incomplete (generic) type
+            if (name == null)
+            {
+                name = currentClass.GetType().Name;
+            }
+
+            return GetLogger(name);
+        }
+
+        private class NullLogger : ILogger
+        {
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return false;
+            }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return new ScopeDisposable();
+            }
+        }
+
+        /// <summary>
+        /// This doesn't really do anything
+        /// </summary>
+        internal sealed class ScopeDisposable : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/devices/Common/Iot/Device/Common/SimpleConsoleLogger.cs
+++ b/src/devices/Common/Iot/Device/Common/SimpleConsoleLogger.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Iot.Device.Common
+{
+    /// <summary>
+    /// A simple console logger - logs all incoming log messages to the console
+    /// </summary>
+    public class SimpleConsoleLogger : ILogger
+    {
+        /// <summary>
+        /// Creates console output with color support
+        /// </summary>
+        public SimpleConsoleLogger(string loggerName)
+        {
+            LoggerName = loggerName;
+            MinLogLevel = LogLevel.Information;
+        }
+
+        /// <summary>
+        /// Specifies the minimum log level that is printed. Default is <see cref="LogLevel.Information"/>
+        /// </summary>
+        public LogLevel MinLogLevel
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Name of the logger
+        /// </summary>
+        public string LoggerName { get; }
+
+        /// <inheritdoc />
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            var previousColor = Console.ForegroundColor;
+            switch (logLevel)
+            {
+                case LogLevel.Error:
+                case LogLevel.Critical:
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    break;
+                case LogLevel.Warning:
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    break;
+                case LogLevel.Information:
+                    Console.ForegroundColor = ConsoleColor.Blue;
+                    break;
+            }
+
+            string msg = formatter(state, exception);
+            Console.WriteLine($"{logLevel} - {msg}");
+            Console.ForegroundColor = previousColor;
+        }
+
+        /// <inheritdoc />
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return logLevel >= MinLogLevel;
+        }
+
+        /// <inheritdoc />
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return new LogDispatcher.ScopeDisposable();
+        }
+    }
+}

--- a/src/devices/Common/Iot/Device/Common/SimpleConsoleLoggerFactory.cs
+++ b/src/devices/Common/Iot/Device/Common/SimpleConsoleLoggerFactory.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Iot.Device.Common
+{
+    /// <summary>
+    /// Provides a very simple console logger that does not require a reference to Microsoft.Extensions.Logging.dll
+    /// </summary>
+    public class SimpleConsoleLoggerFactory : ILoggerFactory
+    {
+        /// <summary>
+        /// The console logger is built-in here
+        /// </summary>
+        /// <param name="provider">Argument is ignored</param>
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        /// <inheritdoc/>
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new SimpleConsoleLogger(categoryName);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/devices/Common/README.md
+++ b/src/devices/Common/README.md
@@ -22,7 +22,7 @@ The `LogDispatcher` class contains static methods to enable a binding to provide
 
 Logging is disabled by default. To enable logging to the console in an application, you can use this code: 
 
-```
+```csharp
 using var loggerFactory = new LoggerFactory();
 loggerFactory.AddProvider(new ConsoleLoggerProvider((s, level) => true, false));
 
@@ -33,7 +33,8 @@ LogDispatcher.LoggerFactory = loggerFactory;
 Other loggers are available in the `Microsoft.Extensions.Logging` Nuget-package. Some help is (here)[https://docs.microsoft.com/en-us/dotnet/core/extensions/logging#non-host-console-app]. Alternatively, you can also connect the log output to your favorite logging framework, such as NLog, Log4Net and others.
 
 To enable a binding to use logging, you can call `GetCurrentClassLogger()` in the constructor to get a logger that automatically identifies the class.
-```
+
+```csharp
     private ILogger _logger;
 
     public MyTestComponent()
@@ -43,7 +44,8 @@ To enable a binding to use logging, you can call `GetCurrentClassLogger()` in th
 ```
 
 Then, logging can be performed using the methods on the obtained `ILogger` interface.
-```
+
+```csharp
 _logger.LogInformation("An informative message");
 _logger.LogError("An error situation");
 _logger.LogWarning(new PlatformNotSupportedException("Something is not supported"), "With exception context");

--- a/src/devices/Common/README.md
+++ b/src/devices/Common/README.md
@@ -23,8 +23,11 @@ The `LogDispatcher` class contains static methods to enable a binding to provide
 Logging is disabled by default. To enable logging to the console in an application, you can use this code: 
 
 ```csharp
-using var loggerFactory = new LoggerFactory();
-loggerFactory.AddProvider(new ConsoleLoggerProvider((s, level) => true, false));
+using var loggerFactory = LoggerFactory.Create(builder =>
+{
+	builder
+		.AddConsole();
+});
 
 // Statically register our factory. Note that this must be done before instantiation of any class that wants to use logging.
 LogDispatcher.LoggerFactory = loggerFactory;

--- a/src/devices/Common/README.md
+++ b/src/devices/Common/README.md
@@ -1,0 +1,51 @@
+# Common classes
+
+This contains a set of classes that can be used accross different sensors and bindings.
+
+## Weather helpers
+
+The `WeatherHelper` class contains a set of static functions to calculate meteorological data based on different input sets.
+
+Some of the functions include:
+
+- CalculateDewPoint: Calculates the [dew point](https://en.wikipedia.org/wiki/Dew_point), given a measured temperature and relative humidity. Simply put, the dew point indicates at what temperature water will condense if temperature drops.
+- CalculateAltitude: (Different overloads) Calculate observer altitude given current pressure and temperature
+- CalculateBarometricPressure: Calculate the sea-level equivalent of the current pressure, given the observers altitude. Used to make pressure readings from different locations comparable.
+
+## Number Helper
+
+The `NumberHelper` class contains a few methods to convert BCD numbers (binary coded decimal, uses 4 bits for each decimal digit) to binary and vice-versa.
+
+## Logging 
+
+The `LogDispatcher` class contains static methods to enable a binding to provide log output. This can be helpful for debugging or analysis.
+
+Logging is disabled by default. To enable logging to the console in an application, you can use this code: 
+
+```
+using var loggerFactory = new LoggerFactory();
+loggerFactory.AddProvider(new ConsoleLoggerProvider((s, level) => true, false));
+
+// Statically register our factory. Note that this must be done before instantiation of any class that wants to use logging.
+LogDispatcher.LoggerFactory = loggerFactory;
+```
+
+Other loggers are available in the `Microsoft.Extensions.Logging` Nuget-package. Some help is (here)[https://docs.microsoft.com/en-us/dotnet/core/extensions/logging#non-host-console-app]. Alternatively, you can also connect the log output to your favorite logging framework, such as NLog, Log4Net and others.
+
+To enable a binding to use logging, you can call `GetCurrentClassLogger()` in the constructor to get a logger that automatically identifies the class.
+```
+    private ILogger _logger;
+
+    public MyTestComponent()
+    {
+        _logger = this.GetCurrentClassLogger();
+    }
+```
+
+Then, logging can be performed using the methods on the obtained `ILogger` interface.
+```
+_logger.LogInformation("An informative message");
+_logger.LogError("An error situation");
+_logger.LogWarning(new PlatformNotSupportedException("Something is not supported"), "With exception context");
+```
+

--- a/src/devices/Common/samples/Common.Samples.csproj
+++ b/src/devices/Common/samples/Common.Samples.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../CommonHelpers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/devices/Common/samples/Common.Samples.csproj
+++ b/src/devices/Common/samples/Common.Samples.csproj
@@ -6,12 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="../CommonHelpers.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Common/samples/Common.Samples.csproj
+++ b/src/devices/Common/samples/Common.Samples.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Common/samples/MyTestComponent.cs
+++ b/src/devices/Common/samples/MyTestComponent.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Iot.Device.Common.Samples
+{
+    internal class MyTestComponent
+    {
+        private ILogger _logger;
+
+        public MyTestComponent()
+        {
+            _logger = this.GetCurrentClassLogger();
+        }
+
+        public void DoSomeLogging()
+        {
+            _logger.LogInformation("An informative message");
+            _logger.LogError("An error situation");
+            _logger.LogWarning(new PlatformNotSupportedException("Something is not supported"), "With exception context");
+        }
+    }
+}

--- a/src/devices/Common/samples/Program.cs
+++ b/src/devices/Common/samples/Program.cs
@@ -8,6 +8,7 @@ using Iot.Device.Common.Samples;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
 
 namespace Common.Samples.Test
 {
@@ -28,8 +29,11 @@ namespace Common.Samples.Test
         /// </summary>
         private static void LogWithStandardProvider()
         {
-            using var loggerFactory = new LoggerFactory();
-            loggerFactory.AddProvider(new ConsoleLoggerProvider((s, level) => true, false));
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .AddConsole();
+            });
 
             // Statically register our factory. Note that this must be done before instantiation of any class that wants to use logging.
             LogDispatcher.LoggerFactory = loggerFactory;

--- a/src/devices/Common/samples/Program.cs
+++ b/src/devices/Common/samples/Program.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using Iot.Device.Common;
+using Iot.Device.Common.Samples;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+
+namespace Common.Samples.Test
+{
+    internal static class Program
+    {
+        public static int Main(string[] args)
+        {
+            LogWithStandardProvider();
+
+            LogWithSimpleProvider();
+
+            return 0;
+        }
+
+        /// <summary>
+        /// This example shows how to enable logging to the console by using the implementations in
+        /// Microsoft.Extensions.Logging.dll and Microsoft.Extensions.Logging.Console.dll. Both packages need to be referenced.
+        /// </summary>
+        private static void LogWithStandardProvider()
+        {
+            using var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(new ConsoleLoggerProvider((s, level) => true, false));
+
+            // Statically register our factory. Note that this must be done before instantiation of any class that wants to use logging.
+            LogDispatcher.LoggerFactory = loggerFactory;
+
+            var testee = new MyTestComponent();
+
+            testee.DoSomeLogging();
+            LogDispatcher.LoggerFactory = null;
+        }
+
+        /// <summary>
+        /// This example shows how to use logging with a very simple console logger that does not need any extra references.
+        /// </summary>
+        private static void LogWithSimpleProvider()
+        {
+            LogDispatcher.LoggerFactory = new SimpleConsoleLoggerFactory();
+
+            var testee = new MyTestComponent();
+
+            testee.DoSomeLogging();
+            LogDispatcher.LoggerFactory = null;
+        }
+    }
+}

--- a/src/devices/Common/tests/Common.Tests.csproj
+++ b/src/devices/Common/tests/Common.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Moq" Version="4.14.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Common/tests/Common.Tests.csproj
+++ b/src/devices/Common/tests/Common.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="Moq" Version="4.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Common/tests/LoggingTests.cs
+++ b/src/devices/Common/tests/LoggingTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Moq;
+
+namespace Iot.Device.Common.Tests
+{
+    public sealed class LoggingTests : IDisposable
+    {
+        public void Dispose()
+        {
+            LogDispatcher.LoggerFactory = null;
+        }
+
+        [Fact]
+        public void ConsoleLoggerCausesNoException()
+        {
+            var logger = new SimpleConsoleLogger("Test");
+            logger.LogWarning("A test message");
+        }
+
+        [Fact]
+        public void NotHavingALoggerRegisteredDoesNotCauseAnException()
+        {
+            LogDispatcher.LoggerFactory = null;
+            var logger = this.GetCurrentClassLogger();
+            logger.LogDebug("This isn't logged");
+        }
+
+        [Fact]
+        public void LoggingWorks()
+        {
+            var loggerFactoryMock = new Mock<ILoggerFactory>(MockBehavior.Strict);
+            var loggerMock = new Mock<ILogger>(MockBehavior.Loose);
+            loggerFactoryMock.Setup(x => x.CreateLogger("Iot.Device.Common.Tests." + nameof(LoggingTests))).Returns(loggerMock.Object);
+            // Unfortunately, this doesn't work, because the exact method being called is Log<FormattedLogValues>(), but that class isn't public
+            // loggerMock.Setup(x => x.Log(LogLevel.Information, new EventId(), "This test works (maybe)", null, It.IsAny<Func<string, Exception, string>>()));
+
+            // assign the factory
+            LogDispatcher.LoggerFactory = loggerFactoryMock.Object;
+            var logger = this.GetCurrentClassLogger();
+            Assert.Equal(loggerMock.Object, logger);
+            logger.LogInformation("This test works (maybe)");
+
+            loggerFactoryMock.VerifyAll();
+            loggerMock.VerifyAll();
+        }
+    }
+}

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -17,6 +17,5 @@
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <PackageReference Include="SixLabors.ImageSharp" Version="$(SixLaborsImageSharpPackageVersion)" />
     <ProjectReference Include="$(SystemDeviceModelPath)" Condition="'$(MSBuildProjectName)' != '$(SystemDeviceModelProjectName)'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
 </Project>

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -17,5 +17,6 @@
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <PackageReference Include="SixLabors.ImageSharp" Version="$(SixLaborsImageSharpPackageVersion)" />
     <ProjectReference Include="$(SystemDeviceModelPath)" Condition="'$(MSBuildProjectName)' != '$(SystemDeviceModelProjectName)'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Allows to have a common base for logging
within all bindings.

Simple console logger provided as well, but
in a larger application, you might want to
forward the logs to some logging framework
such as NLog.

Note: Some bindings that use their own logging
right now should be updated afterwards.