### PR TITLE
Change Ft4222 to work with multiple I2C devices (I2cBus prototype)

### DIFF
--- a/src/devices/Ft4222/Ft4222I2c.cs
+++ b/src/devices/Ft4222/Ft4222I2c.cs
@@ -12,64 +12,17 @@ namespace Iot.Device.Ft4222
     /// <summary>
     /// FT4222 I2C Device
     /// </summary>
-    public class Ft4222I2c : I2cDevice
+    internal class Ft4222I2c : I2cDevice
     {
-        private const uint I2cMasterFrequencyKbps = 400;
-
+        private Ft4222I2cBus _i2cBus;
+        private int _deviceAddress;
         private I2cConnectionSettings _settings;
-        private SafeFtHandle _ftHandle;
 
-        /// <summary>
-        /// Store the FTDI Device Information
-        /// </summary>
-        public DeviceInformation DeviceInformation { get; private set; }
-
-        /// <summary>
-        /// Create a FT4222 I2C Device
-        /// </summary>
-        /// <param name="settings">I2C Connection Settings</param>
-        public Ft4222I2c(I2cConnectionSettings settings)
+        internal Ft4222I2c(Ft4222I2cBus i2cBus, int deviceAddress)
         {
-            _settings = settings;
-            // Check device
-            var devInfos = FtCommon.GetDevices();
-            if (devInfos.Count == 0)
-            {
-                throw new IOException("No FTDI device available");
-            }
-
-            // Select the one from bus Id
-            // FT4222 propose depending on the mode multiple interfaces. Only the A is available for I2C or where there is none as it's the only interface
-            var devInfo = devInfos.Where(m => m.Description == "FT4222 A" || m.Description == "FT4222").ToArray();
-            if ((devInfo.Length == 0) || (devInfo.Length < _settings.BusId))
-            {
-                throw new IOException($"Can't find a device to open I2C on index {_settings.BusId}");
-            }
-
-            DeviceInformation = devInfo[_settings.BusId];
-            // Open device
-            var ftStatus = FtFunction.FT_OpenEx(DeviceInformation.LocId, FtOpenType.OpenByLocation, out _ftHandle);
-
-            if (ftStatus != FtStatus.Ok)
-            {
-                throw new IOException($"Failed to open device {DeviceInformation.Description}, status: {ftStatus}");
-            }
-
-            // Set the clock
-            FtClockRate ft4222Clock = FtClockRate.Clock24MHz;
-
-            ftStatus = FtFunction.FT4222_SetClock(_ftHandle, ft4222Clock);
-            if (ftStatus != FtStatus.Ok)
-            {
-                throw new IOException($"Failed set clock rate {ft4222Clock} on device: {DeviceInformation.Description}, status: {ftStatus}");
-            }
-
-            // Set the device as I2C Master
-            ftStatus = FtFunction.FT4222_I2CMaster_Init(_ftHandle, I2cMasterFrequencyKbps);
-            if (ftStatus != FtStatus.Ok)
-            {
-                throw new IOException($"Failed to initialize I2C Master mode on device: {DeviceInformation.Description}, status: {ftStatus}");
-            }
+            _i2cBus = i2cBus;
+            _deviceAddress = deviceAddress;
+            _settings = new I2cConnectionSettings((int)i2cBus.DeviceInformation.LocId, deviceAddress);
         }
 
         /// <inheritdoc/>
@@ -78,12 +31,7 @@ namespace Iot.Device.Ft4222
         /// <inheritdoc/>
         public override void Read(Span<byte> buffer)
         {
-            ushort byteRead;
-            var ftStatus = FtFunction.FT4222_I2CMaster_Read(_ftHandle, (ushort)_settings.DeviceAddress, in MemoryMarshal.GetReference(buffer), (ushort)buffer.Length, out byteRead);
-            if (ftStatus != FtStatus.Ok)
-            {
-                throw new IOException($"{nameof(Read)} failed to read, error: {ftStatus}");
-            }
+            _i2cBus.Read(_deviceAddress, buffer);
         }
 
         /// <inheritdoc/>
@@ -97,12 +45,7 @@ namespace Iot.Device.Ft4222
         /// <inheritdoc/>
         public override void Write(ReadOnlySpan<byte> buffer)
         {
-            ushort byteSent;
-            var ftStatus = FtFunction.FT4222_I2CMaster_Write(_ftHandle, (ushort)_settings.DeviceAddress, in MemoryMarshal.GetReference(buffer), (ushort)buffer.Length, out byteSent);
-            if (ftStatus != FtStatus.Ok)
-            {
-                throw new IOException($"{nameof(Write)} failed to write, error: {ftStatus}");
-            }
+            _i2cBus.Write(_deviceAddress, buffer);
         }
 
         /// <inheritdoc/>
@@ -118,14 +61,15 @@ namespace Iot.Device.Ft4222
         /// <inheritdoc/>
         public override void WriteRead(ReadOnlySpan<byte> writeBuffer, Span<byte> readBuffer)
         {
-            Write(writeBuffer);
-            Read(readBuffer);
+            _i2cBus.WriteRead(_deviceAddress, writeBuffer, readBuffer);
         }
 
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
-            _ftHandle.Dispose();
+            _i2cBus?.RemoveDevice(_deviceAddress);
+            _i2cBus = null!;
+            _settings = null!;
             base.Dispose(disposing);
         }
     }

--- a/src/devices/Ft4222/Ft4222I2cBus.cs
+++ b/src/devices/Ft4222/Ft4222I2cBus.cs
@@ -1,0 +1,170 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Device.I2c;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Iot.Device.Ft4222
+{
+    /// <summary>
+    /// FT4222 I2C Device
+    /// </summary>
+    public class Ft4222I2cBus : IDisposable
+    {
+        private const uint I2cMasterFrequencyKbps = 400;
+
+        private SafeFtHandle _ftHandle;
+        private HashSet<int> _usedAddresses = new HashSet<int>();
+
+        /// <summary>
+        /// Store the FTDI Device Information
+        /// </summary>
+        public DeviceInformation DeviceInformation { get; private set; }
+
+        /// <summary>
+        /// Create a FT4222 I2C Device
+        /// </summary>
+        /// <param name="deviceInformation">Device information. Use FtCommon.GetDevices to get it.</param>
+        public Ft4222I2cBus(DeviceInformation deviceInformation)
+        {
+            switch (deviceInformation.Type)
+            {
+                case FtDevice.Ft4222HMode0or2With2Interfaces:
+                case FtDevice.Ft4222HMode1or2With4Interfaces:
+                case FtDevice.Ft4222HMode3With1Interface:
+                    break;
+                default: throw new ArgumentException($"Unknown device type: {deviceInformation.Type}");
+            }
+
+            DeviceInformation = deviceInformation;
+            // Open device
+            var ftStatus = FtFunction.FT_OpenEx(DeviceInformation.LocId, FtOpenType.OpenByLocation, out _ftHandle);
+
+            if (ftStatus != FtStatus.Ok)
+            {
+                throw new IOException($"Failed to open device {DeviceInformation.Description}, status: {ftStatus}");
+            }
+
+            // Set the clock
+            FtClockRate ft4222Clock = FtClockRate.Clock24MHz;
+
+            ftStatus = FtFunction.FT4222_SetClock(_ftHandle, ft4222Clock);
+            if (ftStatus != FtStatus.Ok)
+            {
+                throw new IOException($"Failed set clock rate {ft4222Clock} on device: {DeviceInformation.Description}, status: {ftStatus}");
+            }
+
+            // Set the device as I2C Master
+            ftStatus = FtFunction.FT4222_I2CMaster_Init(_ftHandle, I2cMasterFrequencyKbps);
+            if (ftStatus != FtStatus.Ok)
+            {
+                throw new IOException($"Failed to initialize I2C Master mode on device: {DeviceInformation.Description}, status: {ftStatus}");
+            }
+        }
+
+        /// <summary>
+        /// Reads data from the specified device.
+        /// </summary>
+        /// <param name="deviceAddress">Device address to read from.</param>
+        /// <param name="buffer">Buffer to read data to.</param>
+        public void Read(int deviceAddress, Span<byte> buffer)
+        {
+            if (deviceAddress < 0 || deviceAddress > ushort.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(deviceAddress));
+            }
+
+            if (buffer.Length > ushort.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(buffer), $"Buffer is too large. Maximum length is {ushort.MaxValue}.");
+            }
+
+            ushort bytesRead;
+            var ftStatus = FtFunction.FT4222_I2CMaster_Read(_ftHandle, (ushort)deviceAddress, in MemoryMarshal.GetReference(buffer), (ushort)buffer.Length, out bytesRead);
+            if (ftStatus != FtStatus.Ok)
+            {
+                throw new IOException($"{nameof(Read)} failed to read, error: {ftStatus}");
+            }
+
+            if (bytesRead != buffer.Length)
+            {
+                throw new IOException($"Number of bytes read ({bytesRead}) doesn't match length of the buffer ({buffer.Length}).");
+            }
+        }
+
+        /// <summary>
+        /// Writes data to the specified device.
+        /// </summary>
+        /// <param name="deviceAddress">Device address to write to.</param>
+        /// <param name="buffer">Buffer to write.</param>
+        public void Write(int deviceAddress, ReadOnlySpan<byte> buffer)
+        {
+            if (deviceAddress < 0 || deviceAddress > ushort.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(deviceAddress));
+            }
+
+            if (buffer.Length > ushort.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(buffer), $"Buffer is too large. Maximum length is {ushort.MaxValue}.");
+            }
+
+            ushort bytesSent;
+            var ftStatus = FtFunction.FT4222_I2CMaster_Write(_ftHandle, (ushort)deviceAddress, in MemoryMarshal.GetReference(buffer), (ushort)buffer.Length, out bytesSent);
+            if (ftStatus != FtStatus.Ok)
+            {
+                throw new IOException($"{nameof(Write)} failed to write, error: {ftStatus}");
+            }
+        }
+
+        /// <summary>
+        /// Reads and writes data to the specified device.
+        /// </summary>
+        /// <param name="deviceAddress">Device address to read and write.</param>
+        /// <param name="writeBuffer">Buffer to write.</param>
+        /// <param name="readBuffer">Buffer to read data to.</param>
+        public void WriteRead(int deviceAddress, ReadOnlySpan<byte> writeBuffer, Span<byte> readBuffer)
+        {
+            Write(deviceAddress, writeBuffer);
+            Read(deviceAddress, readBuffer);
+        }
+
+        /// <summary>
+        /// Creates I2C device.
+        /// </summary>
+        /// <param name="deviceAddress">Device address related with the device to create.</param>
+        /// <returns>I2cDevice instance.</returns>
+        public I2cDevice CreateDevice(int deviceAddress)
+        {
+            if (!_usedAddresses.Add(deviceAddress))
+            {
+                throw new ArgumentException($"Device with address 0x{deviceAddress,0X2} is already open.", nameof(deviceAddress));
+            }
+
+            return new Ft4222I2c(this, deviceAddress);
+        }
+
+        /// <summary>
+        /// Removes I2C device.
+        /// </summary>
+        /// <param name="deviceAddress">Device address to create</param>
+        public void RemoveDevice(int deviceAddress)
+        {
+            if (!_usedAddresses.Remove(deviceAddress))
+            {
+                throw new ArgumentException($"Device with address 0x{deviceAddress,0X2} was not open.", nameof(deviceAddress));
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _ftHandle?.Dispose();
+            _ftHandle = null!;
+        }
+    }
+}

--- a/src/devices/Ft4222/README.md
+++ b/src/devices/Ft4222/README.md
@@ -17,13 +17,13 @@ The version used to build this project is 1.4.2 and you can download it directly
 
 You will need to unzip the file and go to ```LibFT4222-v1.4.2\imports\LibFT4222\lib\amd64```, copy ```LibFT4222-64.dll``` to ```LibFT4222.dll``` into your path or in the same directory as the executable you are launching.
 
-Alternatively, you can register your dll globally. Copy ```LibFT4222-64.dll``` to ```LibFT4222.dll``` and then run from the directory where your ```LibFT4222.dll``` is located the following command in administrator mode: ```regsvr32.exe LibFT4222.dll```
+Alternatively, you can register your dll globally by adding its location to the PATH.
 
 ### Running it on a Windows 32 bit version
 
 You will need to unzip the file and go to ```LibFT4222-v1.4.2\imports\LibFT4222\lib\i386```, copy ```LibFT4222.dll``` to your path or in the same directory as the executable you are launching.
 
-Alternatively, you can register your dll globally. Run from the directory where your ```LibFT4222.dll``` is located the following command in administrator mode: ```regsvr32.exe LibFT4222.dll```
+Alternatively, you can register your dll globally by adding its location to the PATH.
 
 ## Linux Requirements
 
@@ -78,9 +78,9 @@ Form the ```I2cConnectionSettings``` class that you are passing, the ```BusId```
 The example below shows how to create the I2C device and pass it to a BNO055 sensor. This sensor is the one which has been used to stress test the implementation.
 
 ```csharp
-var winFtdiI2C = new Ft4222I2c(new I2cConnectionSettings(0, Bno055Sensor.DefaultI2cAddress));
-
-Bno055Sensor bno055Sensor = new Bno055Sensor(winFtdiI2C);
+using Ft4222I2cBus ftI2c = new(FtCommon.GetDevices()[0]);
+using I2cDevice i2cDevice = ftI2c.CreateDevice(Bno055Sensor.DefaultI2cAddress);
+Bno055Sensor bno055Sensor = new(i2cDevice);
 
 Console.WriteLine($"Id: {bno055Sensor.Info.ChipId}, AccId: {bno055Sensor.Info.AcceleratorId}, GyroId: {bno055Sensor.Info.GyroscopeId}, MagId: {bno055Sensor.Info.MagnetometerId}");
 Console.WriteLine($"Firmware version: {bno055Sensor.Info.FirmwareVersion}, Bootloader: {bno055Sensor.Info.BootloaderVersion}");

--- a/src/devices/Ft4222/README.md
+++ b/src/devices/Ft4222/README.md
@@ -71,21 +71,24 @@ Console.WriteLine($"Dll version: {dll}");
 
 ### I2C
 
-```Ft4222I2c``` is the I2C driver which you can pass later to any device requiring I2C or directly use it to send I2C commands. The I2C implementation is fully compatible with ```System.Device.I2c.I2cDevice```.
+```Ft4222I2cBus``` is the I2C bus driver which allows you to create I2C needed for any device or use it directly to send I2C commands. The created I2C device is implementing ```System.Device.I2c.I2cDevice```.
 
-Form the ```I2cConnectionSettings``` class that you are passing, the ```BusId``` is the FTDI device index you want to use. 
-
-The example below shows how to create the I2C device and pass it to a BNO055 sensor. This sensor is the one which has been used to stress test the implementation.
+The example below shows how to create the I2C devices and pass them to a BNO055 sensor and BME280 sensors.
 
 ```csharp
 using Ft4222I2cBus ftI2c = new(FtCommon.GetDevices()[0]);
-using I2cDevice i2cDevice = ftI2c.CreateDevice(Bno055Sensor.DefaultI2cAddress);
-Bno055Sensor bno055Sensor = new(i2cDevice);
+using Bno055Sensor bno055 = new(ftI2c.CreateDevice(Bno055Sensor.DefaultI2cAddress));
+using Bme280 bme280 = new(ftI2c.CreateDevice(Bme280.DefaultI2cAddress));
+bme280.SetPowerMode(Bmx280PowerMode.Normal);
 
-Console.WriteLine($"Id: {bno055Sensor.Info.ChipId}, AccId: {bno055Sensor.Info.AcceleratorId}, GyroId: {bno055Sensor.Info.GyroscopeId}, MagId: {bno055Sensor.Info.MagnetometerId}");
-Console.WriteLine($"Firmware version: {bno055Sensor.Info.FirmwareVersion}, Bootloader: {bno055Sensor.Info.BootloaderVersion}");
-Console.WriteLine($"Temperature source: {bno055Sensor.TemperatureSource}, Operation mode: {bno055Sensor.OperationMode}, Units: {bno055Sensor.Units}");
-Console.WriteLine($"Powermode: {bno055Sensor.PowerMode}");
+Console.WriteLine($"Id: {bno055.Info.ChipId}, AccId: {bno055.Info.AcceleratorId}, GyroId: {bno055.Info.GyroscopeId}, MagId: {bno055.Info.MagnetometerId}");
+Console.WriteLine($"Firmware version: {bno055.Info.FirmwareVersion}, Bootloader: {bno055.Info.BootloaderVersion}");
+Console.WriteLine($"Temperature source: {bno055.TemperatureSource}, Operation mode: {bno055.OperationMode}, Units: {bno055.Units}");
+
+if (bme280.TryReadTemperature(out Temperature temperature))
+{
+    Console.WriteLine($"Temperature: {temperature}");
+}
 ```
 
 ### SPI

--- a/src/devices/Ft4222/samples/Ft4222.sample.csproj
+++ b/src/devices/Ft4222/samples/Ft4222.sample.csproj
@@ -6,9 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Ft4222.csproj" />
     <ProjectReference Include="..\..\Bno055\Bno055.csproj" />
+    <ProjectReference Include="..\..\Bmxx80\Bmxx80.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Ft4222/samples/Program.cs
+++ b/src/devices/Ft4222/samples/Program.cs
@@ -9,6 +9,9 @@ using System.Threading;
 using System.Collections.Generic;
 using Iot.Device.Bno055;
 using Iot.Device.Ft4222;
+using Iot.Device.Bmxx80;
+using Iot.Device.Bmxx80.PowerMode;
+using UnitsNet;
 
 Console.WriteLine("Hello I2C, SPI and GPIO FTFI! FT4222");
 Console.WriteLine("Select the test you want to run:");
@@ -66,13 +69,18 @@ if (key.KeyChar == '4')
 void TestI2c(DeviceInformation device)
 {
     using Ft4222I2cBus ftI2c = new(device);
-    using I2cDevice i2cDevice = ftI2c.CreateDevice(Bno055Sensor.DefaultI2cAddress);
-    Bno055Sensor bno055Sensor = new(i2cDevice);
+    using Bno055Sensor bno055 = new(ftI2c.CreateDevice(Bno055Sensor.DefaultI2cAddress));
+    using Bme280 bme280 = new(ftI2c.CreateDevice(Bme280.DefaultI2cAddress));
+    bme280.SetPowerMode(Bmx280PowerMode.Normal);
 
-    Console.WriteLine($"Id: {bno055Sensor.Info.ChipId}, AccId: {bno055Sensor.Info.AcceleratorId}, GyroId: {bno055Sensor.Info.GyroscopeId}, MagId: {bno055Sensor.Info.MagnetometerId}");
-    Console.WriteLine($"Firmware version: {bno055Sensor.Info.FirmwareVersion}, Bootloader: {bno055Sensor.Info.BootloaderVersion}");
-    Console.WriteLine($"Temperature source: {bno055Sensor.TemperatureSource}, Operation mode: {bno055Sensor.OperationMode}, Units: {bno055Sensor.Units}");
-    Console.WriteLine($"Powermode: {bno055Sensor.PowerMode}");
+    Console.WriteLine($"Id: {bno055.Info.ChipId}, AccId: {bno055.Info.AcceleratorId}, GyroId: {bno055.Info.GyroscopeId}, MagId: {bno055.Info.MagnetometerId}");
+    Console.WriteLine($"Firmware version: {bno055.Info.FirmwareVersion}, Bootloader: {bno055.Info.BootloaderVersion}");
+    Console.WriteLine($"Temperature source: {bno055.TemperatureSource}, Operation mode: {bno055.OperationMode}, Units: {bno055.Units}");
+
+    if (bme280.TryReadTemperature(out Temperature temperature))
+    {
+        Console.WriteLine($"Temperature: {temperature}");
+    }
 }
 
 void TestSpi()

--- a/src/devices/Ft4222/samples/Program.cs
+++ b/src/devices/Ft4222/samples/Program.cs
@@ -31,13 +31,21 @@ foreach (DeviceInformation device in devices)
     Console.WriteLine($"Device type: {device.Type}");
 }
 
+if (devices.Count == 0)
+{
+    Console.WriteLine("No devices to connected to run tests.");
+    return;
+}
+
+DeviceInformation firstDevice = devices[0];
+
 var (chip, dll) = FtCommon.GetVersions();
 Console.WriteLine($"Chip version: {chip}");
 Console.WriteLine($"Dll version: {dll}");
 
 if (key.KeyChar == '1')
 {
-    TestI2c();
+    TestI2c(firstDevice);
 }
 
 if (key.KeyChar == '2')
@@ -55,11 +63,11 @@ if (key.KeyChar == '4')
     TestEvents();
 }
 
-void TestI2c()
+void TestI2c(DeviceInformation device)
 {
-    using Ft4222I2c ftI2c = new(new I2cConnectionSettings(0, Bno055Sensor.DefaultI2cAddress));
-
-    Bno055Sensor bno055Sensor = new(ftI2c);
+    using Ft4222I2cBus ftI2c = new(device);
+    using I2cDevice i2cDevice = ftI2c.CreateDevice(Bno055Sensor.DefaultI2cAddress);
+    Bno055Sensor bno055Sensor = new(i2cDevice);
 
     Console.WriteLine($"Id: {bno055Sensor.Info.ChipId}, AccId: {bno055Sensor.Info.AcceleratorId}, GyroId: {bno055Sensor.Info.GyroscopeId}, MagId: {bno055Sensor.Info.MagnetometerId}");
     Console.WriteLine($"Firmware version: {bno055Sensor.Info.FirmwareVersion}, Bootloader: {bno055Sensor.Info.BootloaderVersion}");

--- a/src/devices/Ft4222/samples/Program.cs
+++ b/src/devices/Ft4222/samples/Program.cs
@@ -33,7 +33,7 @@ foreach (DeviceInformation device in devices)
 
 if (devices.Count == 0)
 {
-    Console.WriteLine("No devices to connected to run tests.");
+    Console.WriteLine("No devices connected to run tests.");
     return;
 }
 


### PR DESCRIPTION
Testing idea of I2C bus from: https://github.com/dotnet/iot/issues/1335

also fixing Ft4222 to work with multiple devices. What I just learned is that SenseHat is using same I2cDevice address for both Joystick and LED matrix but it uses 2 devices.