### PR TITLE
WIP: GpioController: LibGpiodDriver: Add methods to handle pins by name

### DIFF
--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
@@ -51,6 +51,14 @@ internal partial class Interop
         internal static extern SafeLineHandle gpiod_chip_get_line(SafeChipHandle chip, int offset);
 
         /// <summary>
+        /// Find a GPIO line by its name.
+        /// </summary>
+        /// <param name="name">The name of the GPIO line</param>
+        /// <returns>Handle to the GPIO line or <see langword="null" /> if the line could not be found or an error occurred.</returns>
+        [DllImport(LibgpiodLibrary, SetLastError = true)]
+        internal static extern SafeLineHandle gpiod_line_find(string name);
+
+        /// <summary>
         /// Reserve a single line, set the direction to input.
         /// </summary>
         /// <param name="line">GPIO line handle</param>

--- a/src/System.Device.Gpio/System/Device/Gpio/ExceptionHelper.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/ExceptionHelper.cs
@@ -8,27 +8,27 @@ namespace System.Device.Gpio
 {
     internal static class ExceptionHelper
     {
-        public static IOException GetIOException(ExceptionResource resource, int errorCode = -1, int pin = -1)
+        public static IOException GetIOException(ExceptionResource resource, int errorCode = -1, string pin = "-1")
         {
             return new IOException(GetResourceString(resource, errorCode, pin));
         }
 
-        public static InvalidOperationException GetInvalidOperationException(ExceptionResource resource, int pin = -1)
+        public static InvalidOperationException GetInvalidOperationException(ExceptionResource resource, string pin = "-1")
         {
             return new InvalidOperationException(GetResourceString(resource, -1, pin));
         }
 
         public static PlatformNotSupportedException GetPlatformNotSupportedException(ExceptionResource resource)
         {
-            return new PlatformNotSupportedException(GetResourceString(resource, -1, -1));
+            return new PlatformNotSupportedException(GetResourceString(resource, -1, "-1"));
         }
 
         public static ArgumentException GetArgumentException(ExceptionResource resource)
         {
-            return new ArgumentException(GetResourceString(resource, -1, -1));
+            return new ArgumentException(GetResourceString(resource, -1, "-1"));
         }
 
-        private static string GetResourceString(ExceptionResource resource, int errorCode, int pin) => resource switch
+        private static string GetResourceString(ExceptionResource resource, int errorCode, string pin) => resource switch
         {
             ExceptionResource.NoChipIteratorFound => $"Unable to find a chip iterator, error code: {errorCode}",
             ExceptionResource.NoChipFound => $"Unable to find a chip, error code: {errorCode}",
@@ -44,6 +44,7 @@ namespace System.Device.Gpio
             ExceptionResource.EventReadError => $"Error while reading pin event result, error code {errorCode}",
             ExceptionResource.NotListeningForEventError => $"Attempted to remove a callback for a pin that is not listening for events.",
             ExceptionResource.LibGpiodNotInstalled => $"Libgpiod driver not installed. More information on: https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/",
+            ExceptionResource.PinNameNotSupported => $"Open pin by name is supported only on Libgpiod driver",
             _ => throw new Exception($"The ExceptionResource enum value: {resource} is not part of the switch. Add the appropriate case and exception message."),
         };
     }
@@ -64,5 +65,6 @@ namespace System.Device.Gpio
         EventReadError,
         NotListeningForEventError,
         LibGpiodNotInstalled,
+        PinNameNotSupported
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
@@ -31,10 +31,24 @@ namespace System.Device.Gpio
         protected internal abstract void OpenPin(int pinNumber);
 
         /// <summary>
+        /// Opens a pin in order for it to be ready to use.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        protected internal virtual void OpenPin(string pinName) =>
+            throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.PinNameNotSupported);
+
+        /// <summary>
         /// Closes an open pin.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         protected internal abstract void ClosePin(int pinNumber);
+
+        /// <summary>
+        /// Closes an open pin.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        protected internal virtual void ClosePin(string pinName) =>
+            throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.PinNameNotSupported);
 
         /// <summary>
         /// Sets the mode to a pin.
@@ -44,11 +58,27 @@ namespace System.Device.Gpio
         protected internal abstract void SetPinMode(int pinNumber, PinMode mode);
 
         /// <summary>
+        /// Sets the mode to a pin.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        /// <param name="mode">The mode to be set.</param>
+        protected internal virtual void SetPinMode(string pinName, PinMode mode) =>
+            throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.PinNameNotSupported);
+
+        /// <summary>
         /// Gets the mode of a pin.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         /// <returns>The mode of the pin.</returns>
         protected internal abstract PinMode GetPinMode(int pinNumber);
+
+        /// <summary>
+        /// Gets the mode of a pin.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        /// <returns>The mode of the pin.</returns>
+        protected internal virtual PinMode GetPinMode(string pinName) =>
+            throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.PinNameNotSupported);
 
         /// <summary>
         /// Checks if a pin supports a specific mode.
@@ -59,11 +89,28 @@ namespace System.Device.Gpio
         protected internal abstract bool IsPinModeSupported(int pinNumber, PinMode mode);
 
         /// <summary>
+        /// Checks if a pin supports a specific mode.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        /// <param name="mode">The mode to check.</param>
+        /// <returns>The status if the pin supports the mode.</returns>
+        protected internal virtual bool IsPinModeSupported(string pinName, PinMode mode) =>
+            throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.PinNameNotSupported);
+
+        /// <summary>
         /// Reads the current value of a pin.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         /// <returns>The value of the pin.</returns>
         protected internal abstract PinValue Read(int pinNumber);
+
+        /// <summary>
+        /// Reads the current value of a pin.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        /// <returns>The value of the pin.</returns>
+        protected internal virtual PinValue Read(string pinName) =>
+            throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.PinNameNotSupported);
 
         /// <summary>
         /// Writes a value to a pin.
@@ -73,6 +120,14 @@ namespace System.Device.Gpio
         protected internal abstract void Write(int pinNumber, PinValue value);
 
         /// <summary>
+        /// Writes a value to a pin.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        /// <param name="value">The value to be written to the pin.</param>
+        protected internal virtual void Write(string pinName, PinValue value) =>
+            throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.PinNameNotSupported);
+
+        /// <summary>
         /// Blocks execution until an event of type eventType is received or a cancellation is requested.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
@@ -80,6 +135,16 @@ namespace System.Device.Gpio
         /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
         /// <returns>A structure that contains the result of the waiting operation.</returns>
         protected internal abstract WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Blocks execution until an event of type eventType is received or a cancellation is requested.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
+        /// <returns>A structure that contains the result of the waiting operation.</returns>
+        protected internal virtual WaitForEventResult WaitForEvent(string pinName, PinEventTypes eventTypes, CancellationToken cancellationToken) =>
+            throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.PinNameNotSupported);
 
         /// <summary>
         /// Async call until an event of type eventType is received or a cancellation is requested.
@@ -94,6 +159,18 @@ namespace System.Device.Gpio
         }
 
         /// <summary>
+        /// Async call until an event of type eventType is received or a cancellation is requested.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="cancellationToken">The cancellation token of when the operation should stop waiting for an event.</param>
+        /// <returns>A task representing the operation of getting the structure that contains the result of the waiting operation</returns>
+        protected internal virtual ValueTask<WaitForEventResult> WaitForEventAsync(string pinName, PinEventTypes eventTypes, CancellationToken cancellationToken)
+        {
+            return new ValueTask<WaitForEventResult>(Task.Run(() => WaitForEvent(pinName, eventTypes, cancellationToken)));
+        }
+
+        /// <summary>
         /// Adds a handler for a pin value changed event.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
@@ -102,11 +179,28 @@ namespace System.Device.Gpio
         protected internal abstract void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback);
 
         /// <summary>
+        /// Adds a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        /// <param name="eventTypes">The event types to wait for.</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
+        protected internal virtual void AddCallbackForPinValueChangedEvent(string pinName, PinEventTypes eventTypes, PinChangeEventHandler callback) =>
+            throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.PinNameNotSupported);
+
+        /// <summary>
         /// Removes a handler for a pin value changed event.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
         /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
         protected internal abstract void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback);
+
+        /// <summary>
+        /// Removes a handler for a pin value changed event.
+        /// </summary>
+        /// <param name="pinName">The pin name among the lines associated with the driver</param>
+        /// <param name="callback">Delegate that defines the structure for callbacks when a pin value changed event occurs.</param>
+        protected internal virtual void RemoveCallbackForPinValueChangedEvent(string pinName, PinChangeEventHandler callback) =>
+            throw ExceptionHelper.GetPlatformNotSupportedException(ExceptionResource.PinNameNotSupported);
 
         /// <summary>
         /// Disposes this instance, closing all open pins

--- a/src/System.Device.Gpio/System/Device/Gpio/PinValueChangedEventArgs.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinValueChangedEventArgs.cs
@@ -13,10 +13,21 @@ namespace System.Device.Gpio
         /// </summary>
         /// <param name="changeType">The change type that triggered the event.</param>
         /// <param name="pinNumber">The pin number that triggered the event.</param>
-        public PinValueChangedEventArgs(PinEventTypes changeType, int pinNumber)
+        public PinValueChangedEventArgs(PinEventTypes changeType, int? pinNumber)
         {
             ChangeType = changeType;
             PinNumber = pinNumber;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PinValueChangedEventArgs"/> class.
+        /// </summary>
+        /// <param name="changeType">The change type that triggered the event.</param>
+        /// <param name="pinName">The pin name that triggered the event.</param>
+        public PinValueChangedEventArgs(PinEventTypes changeType, string? pinName)
+        {
+            ChangeType = changeType;
+            PinName = pinName;
         }
 
         /// <summary>
@@ -27,6 +38,11 @@ namespace System.Device.Gpio
         /// <summary>
         /// The pin number that triggered the event.
         /// </summary>
-        public int PinNumber { get; }
+        public int? PinNumber { get; }
+
+        /// <summary>
+        /// The pin name that triggered the event.
+        /// </summary>
+        public string? PinName { get; }
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/PinValuePair.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinValuePair.cs
@@ -3,6 +3,8 @@
 
 namespace System.Device.Gpio
 {
+    // TODO: Crete a generic typed for the gpio names case
+
     /// <summary>
     /// Simple wrapper for a pin/value pair.
     /// </summary>


### PR DESCRIPTION
From Linux Kernel docs[1]:

> "Optionally, a GPIO controller may have a "gpio-line-names" property.
> This is an array of strings defining the names of the GPIO lines going
> out of the GPIO controller. This name should be the most meaningful
> producer name for the system, such as a rail name indicating the usage."

`gpiod_line_find` searches for a gpio line that was defined in
`gpio-line-names` and return its handle. This is very useful to avoid
having to search in the datasheets the pin bank/line. The user can
check the labels with the pin names on the PCB and use it instead.

1: https://www.kernel.org/doc/Documentation/devicetree/bindings/gpio/gpio.txt

Example:

The Toradex has a family of computer on modules that are pin compatible. But among the board models, we can have different SoCs. For example the [Apalis Family](https://www.toradex.com/computer-on-modules/apalis-arm-family):

Accesing the `MXM3_3/GPIO2` pin on a [Apalis iMX8QM](https://www.toradex.com/computer-on-modules/apalis-arm-family/nxp-imx-8):

![image](https://user-images.githubusercontent.com/2633321/101286451-5e00d880-37c9-11eb-9afd-6c6451ad92a1.png)

Accessing the `MXM3_3/GPIO2` pin on [Apalis iMX6Q](https://www.toradex.com/pt-br/computer-on-modules/apalis-arm-family/nxp-freescale-imx-6):

![image](https://user-images.githubusercontent.com/2633321/101286740-05323f80-37cb-11eb-85e7-d1c69d8d6c85.png)

The pin in the form factor (hardware) is the same for the two computer on modules but inside the SoC the gpio bank/line numbers changes because of course they are different (arm32v7 for iMX6 and arm64v8 for iMX8 and etc ...).

Using the  `gpio-line-names` the hardware vendor supply a BSP that is also pin-compatible at the software level.

With the changes proposed in this merge request we can write the follow:

```csharp
// Note that libgpiod bank number is not necessary this will be abstracted by the gpiod_line_find
GpioController gpioController = new GpioController();
gpioController.OpenPin("MXM3_3/GPIO2", PinMode.Output);
gpioController.Write("MXM3_3/GPIO2", PinValue.Low);
```

This will work on both Apalis iMX8 and iMX6, we can use a single code base that will work on all hardware compatible with a family of form factor that is compatible.
 
Raspberry Pi also define `gpio-line-names` on their BSP, the pins can also be accessed by their respective names: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm/boot/dts/bcm2837-rpi-3-b.dts#n61

