### PR TITLE
only throw exception if glyph data not found

### DIFF
--- a/src/devices/Common/Iot/Device/Graphics/BdfFont.cs
+++ b/src/devices/Common/Iot/Device/Graphics/BdfFont.cs
@@ -131,8 +131,10 @@ namespace Iot.Device.Graphics
             {
                 charData = GlyphUshortData.AsSpan().Slice(index, Height);
             }
-
-            throw new InvalidDataException("Couldn't get the glyph data");
+            else
+            {
+                throw new InvalidDataException("Couldn't get the glyph data");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1344
- Problem: All calls to BdfFontGet.GetCharData() will throw an exception, regardless of whether the font was loaded properly or not.
- Fix: only throw an exception if the glyph data cannot be located