### PR TITLE
A GPIO has to be writeable even in drive mode input

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
@@ -46,7 +46,7 @@ namespace System.Device.Gpio.Tests
         }
 
         [Fact]
-        public void WriteInputPinThrows()
+        public void WriteInputPinDoesNotThrow()
         {
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, It.IsAny<PinMode>())).Returns(true);
@@ -55,7 +55,7 @@ namespace System.Device.Gpio.Tests
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
 
             ctrl.OpenPin(1, PinMode.Input);
-            Assert.Throws<InvalidOperationException>(() => ctrl.Write(1, PinValue.High));
+            ctrl.Write(1, PinValue.High);
         }
 
         [Fact]

--- a/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
@@ -51,7 +51,6 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, It.IsAny<PinMode>())).Returns(true);
             _mockedGpioDriver.Setup(x => x.SetPinModeEx(1, It.IsAny<PinMode>()));
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Input);
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
 
             ctrl.OpenPin(1, PinMode.Input);
@@ -63,7 +62,6 @@ namespace System.Device.Gpio.Tests
         {
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
             _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
@@ -105,7 +103,6 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.SetPinModeEx(1, PinMode.Output));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
             _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
             _mockedGpioDriver.Setup(x => x.ReadEx(1)).Returns(PinValue.High);
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
@@ -123,7 +120,6 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
             ctrl.OpenPin(1, PinMode.Output);
             ctrl.Write(1, PinValue.High);
@@ -179,8 +175,6 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(2));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(2, PinMode.Output)).Returns(true);
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(2)).Returns(PinMode.Output);
             _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
             _mockedGpioDriver.Setup(x => x.WriteEx(2, PinValue.Low));
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -112,12 +112,12 @@ namespace System.Device.Gpio.Tests
         }
 
         [Fact]
-        public void ThrowsIfWritingOnInputPin()
+        public void AllowWritingOnInputPin()
         {
             using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
             {
                 controller.OpenPin(InputPin, PinMode.Input);
-                Assert.Throws<InvalidOperationException>(() => controller.Write(InputPin, PinValue.High));
+                controller.Write(InputPin, PinValue.High);
             }
         }
 

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -228,11 +228,6 @@ namespace System.Device.Gpio
             }
 
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
-            if (_driver.GetPinMode(logicalPinNumber) != PinMode.Output)
-            {
-                throw new InvalidOperationException($"Can not write to pin {logicalPinNumber} because it is not set to Output mode.");
-            }
-
             _driver.Write(logicalPinNumber, value);
         }
 


### PR DESCRIPTION
...because one wants to set the value used when switching to output mode.

Detailed explanation:

CPU's GPIO pins are set to input mode upon system start. Via pull-up or pull-down resistor the state can be determined on schematic/electronic side.
If the pin is used as an output, the software can set the mode to output. But before it has to be possible to set the output state to ensure that the output state is where it should be upon switching from input to output state.

A simplified schematic of GPIO internals:

```text
                           Vcc
                          /
                   ------X2 high / low switch
                  /       \
                 /         GND
                /
GPIO pin ------ X1 input / output switch or output activate switch (input will still be there)
                \
                 ------- Input logic
```

So before switching X1 we should define in which state X2 is.

I had the case with an Apollo Lake CPU where:

```csharp
_gpioController.SetDriveMode(1, PinMode.Output)
_gpioController.Write(1, PinValue.Low)
```
Lead to a short high peak in the output that I have to avoid. That's why I had to switch to use `Windows.Devices.Gpio` via the NuGet `Microsoft.Windows.SDK.Contracts`, which allows to write before setting to output.