### PR TITLE
Adding MFRC522

### DIFF
--- a/src/devices/Card/Mifare/MifareCard.cs
+++ b/src/devices/Card/Mifare/MifareCard.cs
@@ -21,28 +21,32 @@ namespace Iot.Device.Card.Mifare
         private static readonly byte[] Mifare2KBlock64 = new byte[] { 0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
         private static readonly byte[] Mifare2KBlock66 = new byte[] { 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05 };
         private static readonly byte[] Mifare4KBlock64 = new byte[] { 0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
+        private static readonly byte[] StaticDefaultKeyA = new byte[6] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        private static readonly byte[] StaticDefaultKeyB = new byte[6] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+        private static readonly byte[] StaticDefaultFirstBlockNdefKeyA = new byte[6] { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5 };
+        private static readonly byte[] StaticDefaultBlocksNdefKeyA = new byte[6] { 0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7 };
 
         /// <summary>
         /// Default Key A
         /// </summary>
-        public static byte[] DefaultKeyA { get; } = new byte[6] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        public static ReadOnlySpan<byte> DefaultKeyA => StaticDefaultKeyA;
 
         /// <summary>
         /// Default Key B
         /// </summary>
-        public static byte[] DefaultKeyB { get; } = new byte[6] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+        public static ReadOnlySpan<byte> DefaultKeyB => StaticDefaultKeyB;
 
         /// <summary>
         /// Default first block Key A for NDEF card
         /// </summary>
         /// <remarks>See https://www.nxp.com/docs/en/application-note/AN1304.pdf for more information</remarks>
-        public static byte[] DefaultFirstBlockNdefKeyA { get; } = new byte[6] { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5 };
+        public static ReadOnlySpan<byte> DefaultFirstBlockNdefKeyA => StaticDefaultFirstBlockNdefKeyA;
 
         /// <summary>
         /// Default block Key A for NDEF card
         /// </summary>
         /// <remarks>See https://www.nxp.com/docs/en/application-note/AN1304.pdf for more information</remarks>
-        public static byte[] DefaultBlocksNdefKeyA { get; } = new byte[6] { 0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7 };
+        public static ReadOnlySpan<byte> DefaultBlocksNdefKeyA => StaticDefaultBlocksNdefKeyA;
 
         /// <summary>
         /// The tag number detected by the reader, only 1 or 2
@@ -786,7 +790,7 @@ namespace Iot.Device.Card.Mifare
 
             int nbBlocks = GetNumberBlocks();
 
-            byte[] keyFormat = keyB.Length == 0 ? DefaultKeyB : keyB.ToArray();
+            byte[] keyFormat = keyB.Length == 0 ? StaticDefaultKeyB : keyB.ToArray();
             if (keyFormat.Length != 6)
             {
                 throw new ArgumentException($"{nameof(keyB)} can only be empty or 6 bytes length");
@@ -864,7 +868,7 @@ namespace Iot.Device.Card.Mifare
                         Data[7] = 0x07;
                         Data[8] = 0x88;
                         Data[9] = 0x40;
-                        DefaultBlocksNdefKeyA.CopyTo(Data, 6);
+                        StaticDefaultBlocksNdefKeyA.CopyTo(Data, 6);
                         keyFormat.CopyTo(Data, 10);
                         authOk &= WriteDataBlock((byte)block);
                     }
@@ -961,7 +965,7 @@ namespace Iot.Device.Card.Mifare
                 }
                 else
                 {
-                    ret = AuthenticateBlockKeyA(DefaultBlocksNdefKeyA, (byte)(block + inc));
+                    ret = AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, (byte)(block + inc));
                 }
 
                 if (!ret)
@@ -1009,40 +1013,40 @@ namespace Iot.Device.Card.Mifare
 
             // First write the data for the format
             // All block data coming from https://www.nxp.com/docs/en/application-note/AN1304.pdf page 30+
-            var authOk = AuthenticateBlockKeyA(DefaultFirstBlockNdefKeyA, 1);
+            var authOk = AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, 1);
             authOk &= ReadDataBlock(1);
             authOk &= Data.SequenceEqual(Mifare1KBlock1);
-            authOk &= AuthenticateBlockKeyA(DefaultFirstBlockNdefKeyA, 2);
+            authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, 2);
             authOk &= ReadDataBlock(2);
             authOk &= Data.SequenceEqual(Mifare1KBlock2);
 
             if (Capacity == MifareCardCapacity.Mifare2K)
             {
                 byte block = 16 * 4;
-                authOk &= AuthenticateBlockKeyA(DefaultFirstBlockNdefKeyA, block);
+                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
                 authOk &= ReadDataBlock(block);
                 authOk &= Data.SequenceEqual(Mifare2KBlock64);
                 block++;
-                authOk &= AuthenticateBlockKeyA(DefaultFirstBlockNdefKeyA, block);
+                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
                 authOk &= ReadDataBlock(block);
                 authOk &= Data.SequenceEqual(Mifare1KBlock2); // 65 is same as 2
                 block++;
-                authOk &= AuthenticateBlockKeyA(DefaultFirstBlockNdefKeyA, block);
+                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
                 authOk &= ReadDataBlock(block);
                 authOk &= Data.SequenceEqual(Mifare2KBlock66);
             }
             else if (Capacity == MifareCardCapacity.Mifare4K)
             {
                 byte block = 16 * 4;
-                authOk &= AuthenticateBlockKeyA(DefaultFirstBlockNdefKeyA, block);
+                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
                 authOk &= ReadDataBlock(block);
                 authOk &= Data.SequenceEqual(Mifare4KBlock64);
                 block++;
-                authOk &= AuthenticateBlockKeyA(DefaultFirstBlockNdefKeyA, block);
+                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
                 authOk &= ReadDataBlock(block);
                 authOk &= Data.SequenceEqual(Mifare1KBlock2); // 65 is same as 2
                 block++;
-                authOk &= AuthenticateBlockKeyA(DefaultFirstBlockNdefKeyA, block);
+                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
                 authOk &= ReadDataBlock(block);
                 authOk &= Data.SequenceEqual(Mifare1KBlock2); // 66 is same as 2
             }
@@ -1055,11 +1059,11 @@ namespace Iot.Device.Card.Mifare
                 {
                     if ((block == 3) || (block == 67))
                     {
-                        authOk &= AuthenticateBlockKeyA(DefaultFirstBlockNdefKeyA, (byte)block);
+                        authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, (byte)block);
                     }
                     else
                     {
-                        authOk &= AuthenticateBlockKeyA(DefaultBlocksNdefKeyA, (byte)block);
+                        authOk &= AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, (byte)block);
                     }
 
                     if (authOk)
@@ -1157,11 +1161,11 @@ namespace Iot.Device.Card.Mifare
 
             if (KeyB is not object or { Length: not 6 })
             {
-                KeyB = DefaultKeyB;
+                KeyB = StaticDefaultKeyB;
             }
 
             // Read block 4 and check for the data, it should be present in this one
-            var authOk = AuthenticateBlockKeyA(DefaultBlocksNdefKeyA, 4);
+            var authOk = AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, 4);
             authOk &= ReadDataBlock(4);
 
             if (!authOk)
@@ -1206,7 +1210,7 @@ namespace Iot.Device.Card.Mifare
                     continue;
                 }
 
-                authOk = AuthenticateBlockKeyA(DefaultBlocksNdefKeyA, (byte)block);
+                authOk = AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, (byte)block);
                 if (!authOk)
                 {
                     return false;

--- a/src/devices/Card/Mifare/MifareCard.cs
+++ b/src/devices/Card/Mifare/MifareCard.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.ComponentModel.Design;
-using System.Data;
 using System.Linq;
-using System.Net.Http.Headers;
-using System.Threading;
 using Iot.Device.Ndef;
 
 namespace Iot.Device.Card.Mifare
@@ -29,24 +25,24 @@ namespace Iot.Device.Card.Mifare
         /// <summary>
         /// Default Key A
         /// </summary>
-        public byte[] DefaultKeyA { get; } = new byte[6] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        public static byte[] DefaultKeyA { get; } = new byte[6] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
         /// <summary>
         /// Default Key B
         /// </summary>
-        public byte[] DefaultKeyB { get; } = new byte[6] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+        public static byte[] DefaultKeyB { get; } = new byte[6] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 
         /// <summary>
         /// Default first block Key A for NDEF card
         /// </summary>
         /// <remarks>See https://www.nxp.com/docs/en/application-note/AN1304.pdf for more information</remarks>
-        public byte[] DefaultFirstBlockNdefKeyA { get; } = new byte[6] { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5 };
+        public static byte[] DefaultFirstBlockNdefKeyA { get; } = new byte[6] { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5 };
 
         /// <summary>
         /// Default block Key A for NDEF card
         /// </summary>
         /// <remarks>See https://www.nxp.com/docs/en/application-note/AN1304.pdf for more information</remarks>
-        public byte[] DefaultBlocksNdefKeyA { get; } = new byte[6] { 0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7 };
+        public static byte[] DefaultBlocksNdefKeyA { get; } = new byte[6] { 0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7 };
 
         /// <summary>
         /// The tag number detected by the reader, only 1 or 2

--- a/src/devices/Card/Ndef/samples/Program.cs
+++ b/src/devices/Card/Ndef/samples/Program.cs
@@ -208,7 +208,7 @@ void RunTestNdef(CardTransceiver transceiver, Data106kbpsTypeA card)
             Console.WriteLine($"This card is{isForm} NDEF formatted");
             break;
         case '7':
-            ret = mifareCard.EraseSector(mifareCard.DefaultKeyA, mifareCard.DefaultKeyB, 1, false, true);
+            ret = mifareCard.EraseSector(MifareCard.DefaultKeyA, MifareCard.DefaultKeyB, 1, false, true);
             var isErased = ret ? string.Empty : " not";
             Console.WriteLine($"The sector has{isErased} been erased");
             break;

--- a/src/devices/Mfrc522/Mfrc522.cs
+++ b/src/devices/Mfrc522/Mfrc522.cs
@@ -1,0 +1,959 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Device.Gpio;
+using System.Device.I2c;
+using System.Device.Spi;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Ports;
+using System.Threading;
+using Iot.Device.Card;
+using Iot.Device.Rfid;
+using Iot.Device.Card.Mifare;
+
+namespace Iot.Device.Mfrc522
+{
+    /// <summary>
+    /// MfRc522 module
+    /// </summary>
+    public class MfRc522 : CardTransceiver, IDisposable
+    {
+        /// <summary>
+        /// The maximum speed for SPI transfer speed
+        /// </summary>
+        public const int MaximumSpiClockFrequency = 10_000_000;
+
+        /// <summary>
+        /// Only SPI Mode supported is Mode0
+        /// </summary>
+        public const SpiMode DefaultSpiMode = SpiMode.Mode0;
+
+        private int _pinReset;
+        private SpiDevice? _spiDevice;
+        private I2cDevice? _i2CDevice;
+        private SerialPort? _serialPort;
+        private GpioController? _controller;
+        private bool _shouldDispose;
+
+        #region constructors
+
+        /// <summary>
+        /// Constructor for MFRC5222 with SPI interface.
+        /// </summary>
+        /// <param name="spiDevice">A SPI device</param>
+        /// <param name="pinReset">A reset pin for the hardware reset.</param>
+        /// <param name="gpioController">A GpioController for the hardware reset.</param>
+        /// <param name="shouldDispose">True to dispose the GpioController.</param>
+        public MfRc522(SpiDevice spiDevice, int pinReset = -1, GpioController? gpioController = null, bool shouldDispose = true)
+        {
+            _spiDevice = spiDevice;
+            _pinReset = pinReset;
+
+            HardReset(gpioController, shouldDispose);
+            SetDefaultValues();
+        }
+
+        /// <summary>
+        /// Constructor for MFRC5222 with I2C interface.
+        /// </summary>
+        /// <param name="i2cDevice">An I2C device, note that there is no default address for this device, it can be programmed with pins.</param>
+        /// <param name="pinReset">A reset pin for the hardware reset.</param>
+        /// <param name="gpioController">A GpioController for the hardware reset.</param>
+        /// <param name="shouldDispose">True to dispose the GpioController.</param>
+        public MfRc522(I2cDevice i2cDevice, int pinReset = -1, GpioController? gpioController = null, bool shouldDispose = true)
+        {
+            _i2CDevice = i2cDevice;
+            _pinReset = pinReset;
+
+            HardReset(gpioController, shouldDispose);
+            SetDefaultValues();
+        }
+
+        /// <summary>
+        /// Constructor for MFRC5222 with Serial Port interface.
+        /// </summary>
+        /// <param name="serialPort">A Serial Port name, will construct a SerialPort with default speed of 9600 baud, no parity, 1 bit stop.</param>
+        /// <param name="pinReset">A reset pin for the hardware reset.</param>
+        /// <param name="gpioController">A GpioController for the hardware reset.</param>
+        /// <param name="shouldDispose">True to dispose the GpioController.</param>
+        public MfRc522(string serialPort, int pinReset = -1, GpioController gpioController = null, bool shouldDispose = true)
+            : this(new SerialPort(serialPort, 9600, Parity.None, 8, StopBits.One), pinReset, gpioController, shouldDispose)
+        {
+        }
+
+        /// <summary>
+        /// Constructor for MFRC5222 with Serial Port interface.
+        /// </summary>
+        /// <param name="serialPort">A Serial Port, default speed is 9600 baud, no parity, 1 bit stop.</param>
+        /// <param name="pinReset">A reset pin for the hardware reset.</param>
+        /// <param name="gpioController">A GpioController for the hardware reset.</param>
+        /// <param name="shouldDispose">True to dispose the GpioController.</param>
+        public MfRc522(SerialPort serialPort, int pinReset = -1, GpioController? gpioController = null, bool shouldDispose = true)
+        {
+            _serialPort = serialPort;
+            _serialPort.ReadTimeout = 1000;
+            _serialPort.WriteTimeout = 1000;
+            if (!_serialPort.IsOpen)
+            {
+                _serialPort.Open();
+            }
+
+            _pinReset = pinReset;
+
+            HardReset(gpioController, shouldDispose);
+            SetDefaultValues();
+        }
+
+        private void SetDefaultValues()
+        {
+            // Switch off the crypto for Mifare card in case it's on
+            ClearRegisterBit(Register.Status2, (byte)Status2.MFCrypto1On);
+            // Set Timer for Timeout, see documentation on those registers to understand the values
+            WriteRegister(Register.TMode, (byte)TMode.TAutoRestart);
+            WriteRegister(Register.TPrescaler, 0xA9);
+            WriteRegister(Register.TReloadHigh, 0x06);
+            WriteRegister(Register.TReloadLow, 0xE8);
+
+            // forces a 100 % ASK modulation independent of the ModGsPReg register setting
+            WriteRegister(Register.TxAsk, 0x40);
+
+            // Set CRC to 0x6363 (iso 14443-3 6.1.6)
+            WriteRegister(Register.Mode, (byte)(Mode.TxWaitRF | Mode.PolMFinHigh) | (byte)ModeCrc.Preset6363h);
+            // Switching on the antenna
+            Enabled = true;
+        }
+
+        private void HardReset(GpioController? gpioController, bool shouldDispose)
+        {
+            if (_pinReset >= 0)
+            {
+                _shouldDispose = shouldDispose || gpioController == null;
+                _controller = gpioController ?? new GpioController();
+                _controller.OpenPin(_pinReset, PinMode.Output);
+                _controller.Write(_pinReset, PinValue.Low);
+                // 100 nano seconds at least, take some margin
+                Thread.Sleep(1);
+                _controller.Write(_pinReset, PinValue.High);
+                // 37.7 milliseconds according to documentation
+                Thread.Sleep(38);
+            }
+        }
+
+        #endregion
+
+        #region Properties and functions
+
+        /// <summary>
+        /// Get or Set the gain.
+        /// </summary>
+        public Gain Gain
+        {
+            get => (Gain)(ReadRegister(Register.RFCfg) & (byte)Gain.G48dB);
+            set
+            {
+                WriteRegister(Register.RFCfg, (byte)value);
+            }
+        }
+
+        /// <summary>
+        /// Get the Version.
+        /// </summary>
+        /// <remarks>Only versions 1.0 and  2.0 are valid for authentic MFRC522.
+        /// Some copies may not have a proper version but would just work.</remarks>
+        public Version Version
+        {
+            get
+            {
+                Version version;
+                var rev = ReadRegister(Register.Version);
+                // See documentation page 66, chapter 9.3.4.8
+                if (rev == 0x91)
+                {
+                    version = new Version(1, 0);
+                }
+                else if (rev == 0x92)
+                {
+                    version = new Version(2, 0);
+                }
+                else
+                {
+                    version = new Version(0, 0);
+                }
+
+                return version;
+            }
+        }
+
+        /// <summary>
+        /// Switch on or off the antenna.
+        /// </summary>
+        public bool Enabled
+        {
+            get => (ReadRegister(Register.TxControl) & (byte)(TxControl.Tx2RFEn | TxControl.Tx1RFEn)) == (byte)(TxControl.Tx2RFEn | TxControl.Tx1RFEn);
+            set
+            {
+                if (value)
+                {
+                    SetRegisterBit(Register.TxControl, (byte)(TxControl.Tx2RFEn | TxControl.Tx1RFEn));
+                }
+                else
+                {
+                    ClearRegisterBit(Register.TxControl, (byte)(TxControl.Tx2RFEn | TxControl.Tx1RFEn));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Set or Get the baud rate for the serial port communication.
+        /// Default is 9600 baud.
+        /// </summary>
+        public SerialSpeed SerialSpeed
+        {
+            get => (SerialSpeed)ReadRegister(Register.SerialSpeed);
+            set => WriteRegister(Register.SerialSpeed, (byte)value);
+        }
+
+        /// <summary>
+        /// Perform a soft reset. The configuration data of the internal buffer
+        /// remains unchanged.All registers are set to the reset values.This command automatically
+        /// terminates when finished.
+        /// </summary>
+        /// <remarks>The SerialSpeedReg register is reset and therefore the serial data rate is set to 9600 baud.</remarks>
+        public void SoftReset()
+        {
+            WriteRegister(Register.Command, (byte)MfrcCommand.ResetPhase);
+            // 37.7 milliseconds
+            Thread.Sleep(38);
+        }
+
+        /// <summary>
+        /// Listen to any 14443 Type A card.
+        /// </summary>
+        /// <param name="card">A card once detected.</param>
+        /// <param name="timeout">A timeout for pulling the card.</param>
+        /// <returns>True if success.</returns>
+        public bool ListenToCardIso14443TypeA(out Data106kbpsTypeA card, TimeSpan timeout)
+        {
+            card = new Data106kbpsTypeA(0, 0, 0, new byte[0], null);
+            byte[] atqa = new byte[2];
+            DateTime dtTimeout = DateTime.Now.Add(timeout);
+            // Switch off the cryptography for Mifare card in case it's on
+            ClearRegisterBit(Register.Status2, (byte)Status2.MFCrypto1On);
+            do
+            {
+                Status sc = PiccRequestA(atqa);
+                if (sc == Status.Collision || sc == Status.Ok)
+                {
+                    break;
+                }
+
+                if (dtTimeout > DateTime.Now)
+                {
+                    return false;
+                }
+
+                // Give a bit of time for the card and reader
+                Thread.Sleep(10);
+            }
+            while (true);
+
+            card.Atqa = BinaryPrimitives.ReadUInt16BigEndian(atqa);
+            var status = Select(out byte[]? nfcId, out byte sak);
+            if (status != Status.Ok)
+            {
+                return false;
+            }
+
+            if (nfcId is object)
+            {
+                card.NfcId = new byte[nfcId.Length];
+                nfcId.CopyTo(card.NfcId, 0);
+            }
+
+            card.Sak = sak;
+            return true;
+        }
+
+        /// <summary>
+        /// Check if a new card is present.
+        /// </summary>
+        /// <param name="atqa">ATQA buffer must be 2 bytes length and will contain the ATQA answer if there is a card.</param>
+        /// <returns>true if there is a card, else false.</returns>
+        public bool IsCardPresent(byte[] atqa)
+        {
+            if (atqa is not object or { Length: not 2 })
+            {
+                throw new ArgumentException($"{nameof(atqa)} must be initialized and its size must be 2.");
+            }
+
+            // Switch off the cryptography for Mifare card in case it's on
+            ClearRegisterBit(Register.Status2, (byte)Status2.MFCrypto1On);
+            Status sc = PiccRequestA(atqa);
+            if (sc == Status.Collision || sc == Status.Ok)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private Status Select(out byte[]? uid, out byte sak)
+        {
+            sak = 0;
+            uid = null;
+            bool selectDone = false;
+            int sizeUid = 0;
+            int bitKnown = 0;
+            byte[] uidKnown = new byte[4];
+            byte[] tempUid = new byte[10];
+            // all received bits will be cleared after a collision
+            // only used during bitwise anticollision at 106 kBd,
+            // otherwise it is set to logic 1
+            ClearRegisterBit(Register.Coll, 0x80);
+            int selectCascadeLevel = 1;
+            // There are 3 SL maximum. For looping and adjusting the SL
+            // SL1 = 0x93, SL2 = 0x95, SL3 = 0x97
+            while (!selectDone)
+            {
+                var bufferLength = bitKnown == 0 ? 2 : 9;
+                byte[] dataToCard = new byte[bufferLength];
+                byte[] dataFromCard = bitKnown == 0 ? new byte[5] : new byte[3];
+                byte numValidBits = (byte)(bitKnown == 0 ? 0x20 : 0x70);
+                int destinationIndex;
+                switch (selectCascadeLevel)
+                {
+                    case 1:
+                        dataToCard[0] = (byte)CardCommand.SelectCascadeLevel1;
+                        sizeUid = 4;
+                        destinationIndex = 0;
+                        break;
+                    case 2:
+                        dataToCard[0] = (byte)CardCommand.SelectCascadeLevel2;
+                        sizeUid = 7;
+                        destinationIndex = 3;
+                        break;
+                    case 3:
+                        dataToCard[0] = (byte)CardCommand.SelectCascadeLevel3;
+                        sizeUid = 10;
+                        destinationIndex = 6;
+                        break;
+                    default:
+                        return Status.Error;
+                }
+
+                dataToCard[1] = numValidBits;
+                if (bitKnown != 0)
+                {
+                    for (int i = 0; i < 4; i++)
+                    {
+                        dataToCard[i + 2] = uidKnown[i];
+                    }
+
+                    // Standard CRC byte calculation for this specific action
+                    dataToCard[6] = (byte)(dataToCard[2] ^ dataToCard[3] ^ dataToCard[4] ^ dataToCard[5]);
+                    var crcStatus = CalculateCrc(dataToCard.AsSpan(0, 7), dataToCard.AsSpan(7));
+                    if (crcStatus != Status.Ok)
+                    {
+                        return crcStatus;
+                    }
+                }
+
+                // Reset Bit Framing
+                WriteRegister(Register.BitFraming, 0x00);
+                Status sc = SendAndReceiveData(MfrcCommand.Transceive, dataToCard, dataFromCard);
+                if (sc != Status.Ok)
+                {
+                    return sc;
+                }
+
+                // Once all the bits will be known
+                if (bitKnown >= 32)
+                {
+                    if (dataToCard[2] == 0x88)
+                    {
+                        // check that there is no cascade
+                        if ((dataFromCard[0] & 0x04) != 0x04)
+                        {
+                            return Status.Error;
+                        }
+
+                        Array.Copy(dataToCard, 3, tempUid, destinationIndex, 3);
+                        selectCascadeLevel++;
+                        // ready for next CascadeLevel
+                        bitKnown = 0;
+                    }
+                    else
+                    {
+                        selectDone = true;
+                        Array.Copy(dataToCard, 2, tempUid, destinationIndex, 4);
+                        sak = dataFromCard[0];
+                        // check that there is no cascade
+                        if ((dataFromCard[0] & 0x04) == 0x04)
+                        {
+                            return Status.Error;
+                        }
+                    }
+                }
+                else
+                {
+                    // All bit are known, redo loop to do select the card
+                    bitKnown = 32;
+                    dataFromCard.AsSpan(0, 4).CopyTo(uidKnown);
+                }
+            }
+
+            // Finally create the uid buffer
+            uid = new byte[sizeUid];
+            Array.Copy(tempUid, uid, uid.Length);
+            return Status.Ok;
+        }
+
+        private Status PiccRequestA(byte[] bufferAtqa)
+        {
+            // all received bits will be cleared after a collision
+            // only used during bitwise anticollision at 106 kBd,
+            // otherwise it is set to logic 1
+            ClearRegisterBit(Register.Coll, 0x80);
+            // Only 7 bits are valid in th ReqA request
+            byte validBits = 0x07;
+            Status sc = SendAndReceiveData(MfrcCommand.Transceive, new[] { (byte)CardCommand.ReqA }, bufferAtqa, validBits);
+            if (sc != Status.Ok)
+            {
+                return sc;
+            }
+
+            // Valid bits coded on 3 bits
+            validBits = (byte)(ReadRegister(Register.Control) & 0x07);
+            if (validBits != 0)
+            {
+                return Status.Error;
+            }
+
+            return Status.Ok;
+        }
+
+        /// <summary>
+        /// Sand and Receive Data.
+        /// </summary>
+        /// <param name="command">The MFRC522 command.</param>
+        /// <param name="sendData">The data to send.</param>
+        /// <param name="receiveData">The data to receive. Note that you need to have at least the size of data you expect to receive.</param>
+        /// <param name="numberValidBitsLastByte">The number of bits valid in the last byte, 8 is the default.</param>
+        /// <returns>True if the operation is successful.</returns>
+        public Status SendAndReceiveData(MfrcCommand command, ReadOnlySpan<byte> sendData, Span<byte> receiveData, byte numberValidBitsLastByte = 8)
+        {
+            byte bitFraming = (byte)(numberValidBitsLastByte == 8 ? 0 : numberValidBitsLastByte & (byte)BitFraming.TxLastBitsMask);
+            byte waitIrq = command == MfrcCommand.MifareAuthenticate ? (byte)(ComIr.IdleIRq) : (byte)(ComIr.IdleIRq | ComIr.RxIRq);
+
+            // Set to idle, prepare FIFO and bit framing
+            WriteRegister(Register.Command, (byte)MfrcCommand.Idle);
+            WriteRegister(Register.ComIrq, 0x7f);
+            WriteRegister(Register.FifoLevel, 0x80);
+            WriteRegister(Register.FifoData, sendData);
+            WriteRegister(Register.BitFraming, bitFraming);
+            // Set the real command
+            WriteRegister(Register.Command, (byte)command);
+
+            if (command == MfrcCommand.Transceive)
+            {
+                SetRegisterBit(Register.BitFraming, 0x80);
+            }
+
+            Status status = WaitForCommandToComplete(waitIrq);
+            if (status == Status.Timeout)
+            {
+                return status;
+            }
+
+            // Check all is cleared
+            Error error = (Error)ReadRegister(Register.Error);
+            if (error.HasFlag(Error.BufferOvfl) || error.HasFlag(Error.ParityErr) || error.HasFlag(Error.ProtocolErr))
+            {
+                return Status.Error;
+            }
+
+            // Read if there is something to read
+            if (receiveData != null)
+            {
+                var bytesRead = ReadRegister(Register.FifoLevel);
+                if (bytesRead == 0 && receiveData.Length > 0)
+                {
+                    return Status.Error;
+                }
+
+                // We still read the data even if there are more available
+                if (bytesRead > receiveData.Length)
+                {
+                    return Status.Error;
+                }
+
+                ReadRegister(Register.FifoData, receiveData);
+            }
+
+            // Check collision
+            if (error.HasFlag(Error.CollErr))
+            {
+                return Status.Collision;
+            }
+
+            return Status.Ok;
+        }
+
+        private bool MifareRead(byte blockAddress, Span<byte> dataFromCard)
+        {
+            if (dataFromCard.Length < 16)
+            {
+                return false;
+            }
+
+            // 16 bytes + 2 from CRC
+            byte[] receivedBuffer = new byte[18];
+            // Command + CRC
+            byte[] commandToSend = new byte[4];
+
+            commandToSend[0] = (byte)MifareCardCommand.Read16Bytes;
+            commandToSend[1] = blockAddress;
+            var status = CalculateCrc(commandToSend.AsSpan(0, 2), commandToSend.AsSpan(2));
+            if (status != Status.Ok)
+            {
+                return false;
+            }
+
+            status = SendAndReceiveData(MfrcCommand.Transceive, commandToSend, receivedBuffer);
+            if (status != Status.Ok)
+            {
+                return false;
+            }
+
+            // Check CRC
+            byte[] crc = new byte[2];
+            status = CalculateCrc(receivedBuffer.AsSpan(0, 16), crc.AsSpan());
+            if (status != Status.Ok)
+            {
+                return false;
+            }
+
+            if (receivedBuffer[16] == crc[0] && receivedBuffer[17] == crc[1])
+            {
+                receivedBuffer.AsSpan().Slice(0, 16).CopyTo(dataFromCard);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Stop to communicate with a card.
+        /// </summary>
+        /// <returns>True if success.</returns>
+        /// <remarks>It's not because you don't get a positive result the card is not halt.</remarks>
+        public bool Halt()
+        {
+            byte[] buffer = new byte[4];
+            buffer[0] = (byte)CardCommand.HaltA;
+            buffer[1] = 0;
+            var status = CalculateCrc(buffer.AsSpan(0, 2), buffer.AsSpan(2));
+            if (status != Status.Ok)
+            {
+                return false;
+            }
+
+            status = SendAndReceiveData(MfrcCommand.Transceive, buffer, null);
+            if (status == Status.Timeout)
+            {
+                return true;
+            }
+
+            return status == Status.Error ? false : true;
+        }
+
+        /// <summary>
+        /// Prepare for sleep, make sure cryptography is off and switch off the antenna.
+        /// </summary>
+        public void PrepareForSleep()
+        {
+            Enabled = false;
+            ClearRegisterBit(Register.Status2, (byte)Status2.MFCrypto1On);
+        }
+
+        /// <summary>
+        /// Specific function to authenticate Mifare cards
+        /// </summary>
+        /// <param name="key">A 6 bytes key</param>
+        /// <param name="mifareCommand">MifareCardCommand.AuthenticationA or MifareCardCommand.AuthenticationB</param>
+        /// <param name="blockAddress">The block address to authenticate.</param>
+        /// <param name="cardUid">The 4 bytes UUID of the card.</param>
+        /// <returns>True if success.</returns>
+        public Status MifareAuthenticate(Span<byte> key, MifareCardCommand mifareCommand, byte blockAddress, Span<byte> cardUid)
+        {
+            if (mifareCommand != MifareCardCommand.AuthenticationA && mifareCommand != MifareCardCommand.AuthenticationB)
+            {
+                throw new ArgumentException("Must be AuthenticateA or AuthenticateB only");
+            }
+
+            if (key.Length != 6)
+            {
+                throw new ArgumentException("Key must have a length of 6.", nameof(key));
+            }
+
+            byte[] buffer = new byte[12];
+            buffer[0] = (byte)mifareCommand;
+            buffer[1] = blockAddress;
+            key.CopyTo(buffer.AsSpan(2, 6));
+            cardUid.CopyTo(buffer.AsSpan(8, 4));
+
+            return SendAndReceiveData(MfrcCommand.MifareAuthenticate, buffer, null);
+        }
+
+        private Status CalculateCrc(ReadOnlySpan<byte> buffer, Span<byte> crc)
+        {
+            // Timeout for the CRC calculation
+            const long Timeout = 89;
+            if (crc.Length < 2)
+            {
+                throw new ArgumentException($"CRC buffer must be at least 2 bytes");
+            }
+
+            WriteRegister(Register.Command, (byte)MfrcCommand.Idle);
+            WriteRegister(Register.DivIrq, (byte)DivIrq.CRCIRq);
+            WriteRegister(Register.FifoLevel, 0x80);
+            WriteRegister(Register.FifoData, buffer.ToArray());
+            WriteRegister(Register.Command, (byte)MfrcCommand.CalculateCrc);
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            do
+            {
+                DivIrq irgStatus = (DivIrq)ReadRegister(Register.DivIrq);
+                if (irgStatus.HasFlag(DivIrq.CRCIRq))
+                {
+                    WriteRegister(Register.Command, (byte)MfrcCommand.Idle);
+                    crc[0] = ReadRegister(Register.CrcResultLow);
+                    crc[1] = ReadRegister(Register.CrcResultHigh);
+                    return Status.Ok;
+                }
+            }
+            while (stopwatch.ElapsedMilliseconds < Timeout);
+
+            return Status.Timeout;
+        }
+
+        private Status WaitForCommandToComplete(byte waitIrq)
+        {
+            // Timeout in ms for the CRC calculation, see documentation
+            const long Timeout = 36;
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            do
+            {
+                byte irq = ReadRegister(Register.ComIrq);
+                if ((irq & waitIrq) != 0)
+                {
+                    return Status.Ok;
+                }
+
+                if (((ComIr)irq).HasFlag(ComIr.TimerIRq))
+                {
+                    return Status.Timeout;
+                }
+            }
+            while (stopwatch.ElapsedMilliseconds < Timeout);
+            return Status.Timeout;
+        }
+
+        #endregion
+
+        #region SPI, I2C and Serial Communication
+
+        private void WriteRegister(Register register, byte toCard)
+        {
+            if (_spiDevice is object)
+            {
+                SpiWriteRegister(register, toCard);
+            }
+            else if (_i2CDevice is object)
+            {
+                I2cWriteRegister(register, toCard);
+            }
+            else if (_serialPort is object)
+            {
+                SerialWriteRegister(register, toCard);
+            }
+        }
+
+        private void WriteRegister(Register register, ReadOnlySpan<byte> toCard)
+        {
+            if (_spiDevice is object)
+            {
+                SpiWriteRegister(register, toCard);
+            }
+            else if (_i2CDevice is object)
+            {
+                I2cWriteRegister(register, toCard);
+            }
+            else if (_serialPort is object)
+            {
+                SerialWriteRegister(register, toCard);
+            }
+        }
+
+        private byte ReadRegister(Register register)
+        {
+            if (_spiDevice is object)
+            {
+                return SpiReadRegister(register);
+            }
+            else if (_i2CDevice is object)
+            {
+                return I2cReadRegister(register);
+            }
+            else if (_serialPort is object)
+            {
+                return SerialReadRegister(register);
+            }
+
+            throw new IOException("No SPI, I2C or Serial port");
+        }
+
+        private void ReadRegister(Register register, Span<byte> fromCard)
+        {
+            if (_spiDevice is object)
+            {
+                SpiReadRegister(register, fromCard);
+            }
+            else if (_i2CDevice is object)
+            {
+                I2cReadRegister(register, fromCard);
+            }
+            else if (_serialPort is object)
+            {
+                SerialReadRegister(register, fromCard);
+            }
+        }
+
+        private void SetRegisterBit(Register register, byte mask)
+        {
+            var tmp = ReadRegister(register);
+            WriteRegister(register, (byte)(tmp | mask));
+        }
+
+        private void ClearRegisterBit(Register register, byte mask)
+        {
+            var tmp = ReadRegister(register);
+            WriteRegister(register, (byte)(tmp & ~mask));
+        }
+
+        private void SpiWriteRegister(Register register, byte toCard)
+        {
+            Span<byte> toWrite = stackalloc byte[2]
+            {
+                (byte)register,
+                toCard
+            };
+            _spiDevice!.TransferFullDuplex(toWrite, toWrite);
+        }
+
+        private void SpiWriteRegister(Register register, ReadOnlySpan<byte> toCard)
+        {
+            for (int i = 0; i < toCard.Length; i++)
+            {
+                SpiWriteRegister(register, toCard[i]);
+            }
+        }
+
+        private byte SpiReadRegister(Register register)
+        {
+            Span<byte> buffer = stackalloc byte[2]
+            {
+                (byte)((byte)register | 0x80),
+                0x00
+            };
+            _spiDevice!.TransferFullDuplex(buffer, buffer);
+            return buffer[1];
+        }
+
+        private void SpiReadRegister(Register register, Span<byte> fromCard)
+        {
+            if (fromCard is { Length: 0 })
+            {
+                return;
+            }
+
+            byte address = (byte)((byte)register | 0x80);
+            Span<byte> buffer = new byte[fromCard.Length + 1];
+
+            for (int i = 0; i < fromCard.Length; i++)
+            {
+                buffer[i] = address;
+            }
+
+            _spiDevice!.TransferFullDuplex(buffer, buffer);
+            buffer.Slice(1).CopyTo(fromCard);
+        }
+
+        private void I2cWriteRegister(Register register, byte toCard)
+        {
+            Span<byte> toWrite = stackalloc byte[2]
+            {
+                (byte)((byte)register >> 1),
+                toCard,
+            };
+            _i2CDevice!.Write(toWrite);
+        }
+
+        private void I2cWriteRegister(Register register, ReadOnlySpan<byte> toCard)
+        {
+            Span<byte> toWrite = stackalloc byte[1 + toCard.Length];
+            toWrite[0] = (byte)((byte)register >> 1);
+            toCard.CopyTo(toWrite.Slice(1));
+            _i2CDevice!.Write(toWrite);
+        }
+
+        private byte I2cReadRegister(Register register)
+        {
+            _i2CDevice!.WriteByte((byte)(((byte)register >> 1) | 0x80));
+            return _i2CDevice!.ReadByte();
+        }
+
+        private void I2cReadRegister(Register register, Span<byte> fromCard)
+        {
+            _i2CDevice!.WriteByte((byte)(((byte)register >> 1) | 0x80));
+            _i2CDevice!.Read(fromCard);
+        }
+
+        private void SerialReadRegister(Register register, Span<byte> fromCard)
+        {
+            byte[] toSend = new byte[] { (byte)(((byte)register >> 1) | 0x80) };
+            for (int i = 0; i < fromCard.Length; i++)
+            {
+                _serialPort!.Write(toSend, 0, 1);
+                fromCard[i] = (byte)_serialPort.ReadByte();
+            }
+        }
+
+        private byte SerialReadRegister(Register register)
+        {
+            _serialPort!.Write(new byte[] { (byte)(((byte)register >> 1) | 0x80) }, 0, 1);
+            return (byte)_serialPort!.ReadByte();
+        }
+
+        private void SerialWriteRegister(Register register, byte toCard)
+        {
+            _serialPort!.Write(new byte[] { (byte)((byte)(register) >> 1), toCard }, 0, 2);
+            // We need to read 1 byte, it's the address as confirmation
+            // No need to check it
+            _serialPort!.ReadByte();
+        }
+
+        private void SerialWriteRegister(Register register, ReadOnlySpan<byte> toCard)
+        {
+            byte[] toSend = new byte[] { (byte)((byte)(register) >> 1), 0x00 };
+            for (int i = 0; i < toCard.Length; i++)
+            {
+                toSend[1] = toCard[i];
+                _serialPort!.Write(toSend, 0, 1);
+                // We need to read 1 byte, it's the address
+                _serialPort!.ReadByte();
+                _serialPort!.Write(toSend, 1, 1);
+            }
+        }
+
+        #endregion
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_spiDevice is object)
+            {
+                PrepareForSleep();
+                _spiDevice.Dispose();
+                _spiDevice = null;
+            }
+
+            if (_i2CDevice is object)
+            {
+                PrepareForSleep();
+                _i2CDevice.Dispose();
+                _i2CDevice = null;
+            }
+
+            if (_serialPort is object)
+            {
+                _serialPort.Close();
+            }
+
+            if (_pinReset >= 0)
+            {
+                _controller?.ClosePin(_pinReset);
+            }
+
+            if (_shouldDispose)
+            {
+                _controller?.Dispose();
+                _controller = null;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard)
+        {
+            // targetNumber is not used here as only 1 card can be selected at a time so will be ignored
+            // The dataToSend buffer contains anyway the unique of the card
+            Status status = Status.Ok;
+
+            // Use built in functions for authentication
+            if ((dataToSend[0] == (byte)MifareCardCommand.AuthenticationA) || (dataToSend[0] == (byte)MifareCardCommand.AuthenticationB))
+            {
+                status = SendAndReceiveData(MfrcCommand.MifareAuthenticate, dataToSend.ToArray(), null);
+                return status == Status.Ok ? 0 : -1;
+
+            }
+            else if ((dataToSend[0] == (byte)MifareCardCommand.Incrementation) || (dataToSend[0] == (byte)MifareCardCommand.Decrementation)
+                || (dataToSend[0] == (byte)MifareCardCommand.Restore))
+            {
+                return TwoStepsIncDecRestore(dataToSend, dataFromCard);
+            }
+            else if (dataToSend[0] == (byte)MifareCardCommand.Read16Bytes)
+            {
+                var ret = MifareRead(dataToSend[1], dataFromCard);
+                return ret ? dataFromCard.Length : -1;
+            }
+
+            status = SendAndReceiveData(MfrcCommand.Transceive, dataToSend.ToArray(), dataFromCard);
+            return status == Status.Ok ? dataFromCard.Length : -1;
+        }
+
+        private int TwoStepsIncDecRestore(ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard)
+        {
+            Span<byte> toSendFirst = stackalloc byte[4];
+            dataToSend.Slice(0, 2).CopyTo(toSendFirst);
+            var status = CalculateCrc(toSendFirst.Slice(0, 2), toSendFirst.Slice(2, 2));
+
+            status = SendAndReceiveData(MfrcCommand.Transceive, toSendFirst.ToArray(), null);
+            if (status != Status.Ok)
+            {
+                LogInfo.Log($"{nameof(TwoStepsIncDecRestore)} - Error {(MfrcCommand)dataToSend[0]}", LogLevel.Debug);
+                return -1;
+            }
+
+            Span<byte> toSendSecond = stackalloc byte[dataToSend.Length];
+            dataToSend.Slice(2).CopyTo(toSendSecond);
+            status = CalculateCrc(toSendSecond.Slice(0, 2), toSendSecond.Slice(2, 2));
+
+            status = SendAndReceiveData(MfrcCommand.Transceive, toSendSecond.ToArray(), dataFromCard);
+
+            return status == Status.Ok ? dataFromCard.Length : -1;
+        }
+
+        /// <inheritdoc/>
+        public override bool ReselectTarget(byte targetNumber)
+        {
+            // We halt the card, and we don't care if it happens correctly
+            Halt();
+            // We reselect the card and ignore the target number as reader supports only 1 card
+            // And we assume here that the card hasn't been changed in the mean time
+            IsCardPresent(new byte[2]);
+            return Select(out byte[]? uuid, out byte sak) == Status.Ok;
+        }
+    }
+}

--- a/src/devices/Mfrc522/Mfrc522.cs
+++ b/src/devices/Mfrc522/Mfrc522.cs
@@ -152,10 +152,7 @@ namespace Iot.Device.Mfrc522
         public Gain Gain
         {
             get => (Gain)(ReadRegister(Register.RFCfg) & (byte)Gain.G48dB);
-            set
-            {
-                WriteRegister(Register.RFCfg, (byte)value);
-            }
+            set => WriteRegister(Register.RFCfg, (byte)value);
         }
 
         /// <summary>

--- a/src/devices/Mfrc522/Mfrc522.cs
+++ b/src/devices/Mfrc522/Mfrc522.cs
@@ -584,7 +584,7 @@ namespace Iot.Device.Mfrc522
         /// <param name="blockAddress">The block address to authenticate.</param>
         /// <param name="cardUid">The 4 bytes UUID of the card.</param>
         /// <returns>True if success.</returns>
-        public Status MifareAuthenticate(Span<byte> key, MifareCardCommand mifareCommand, byte blockAddress, Span<byte> cardUid)
+        public Status MifareAuthenticate(ReadOnlySpan<byte> key, MifareCardCommand mifareCommand, byte blockAddress, ReadOnlySpan<byte> cardUid)
         {
             if (mifareCommand != MifareCardCommand.AuthenticationA && mifareCommand != MifareCardCommand.AuthenticationB)
             {

--- a/src/devices/Mfrc522/Mfrc522.csproj
+++ b/src/devices/Mfrc522/Mfrc522.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />
+    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Card\CardRfid.csproj" />
+    <ProjectReference Include="..\Card\Mifare\Mifare.csproj" />
+    <Compile Include="*.cs" />
+    <Compile Include="RegisterElement\*.cs" />
+    <None Include="README.md" />
+  </ItemGroup>
+
+</Project>

--- a/src/devices/Mfrc522/Mfrc522.sln
+++ b/src/devices/Mfrc522/Mfrc522.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mfrc522", "Mfrc522.csproj", "{715690A1-09E4-458F-80E5-2C7BC581A437}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mfrc522.Sample", "samples\Mfrc522.Sample.csproj", "{4D2D9C55-EABC-493F-AF3B-D5CC4DC4B102}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mifare", "..\Card\Mifare\Mifare.csproj", "{59219E01-A521-425B-A28D-25C34F7FF1C5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CardRfid", "..\Card\CardRfid.csproj", "{AFDE2C7B-F7FA-4316-A73D-DED45A04FF2D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{715690A1-09E4-458F-80E5-2C7BC581A437}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{715690A1-09E4-458F-80E5-2C7BC581A437}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{715690A1-09E4-458F-80E5-2C7BC581A437}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{715690A1-09E4-458F-80E5-2C7BC581A437}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D2D9C55-EABC-493F-AF3B-D5CC4DC4B102}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D2D9C55-EABC-493F-AF3B-D5CC4DC4B102}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D2D9C55-EABC-493F-AF3B-D5CC4DC4B102}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D2D9C55-EABC-493F-AF3B-D5CC4DC4B102}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59219E01-A521-425B-A28D-25C34F7FF1C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59219E01-A521-425B-A28D-25C34F7FF1C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59219E01-A521-425B-A28D-25C34F7FF1C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59219E01-A521-425B-A28D-25C34F7FF1C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFDE2C7B-F7FA-4316-A73D-DED45A04FF2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFDE2C7B-F7FA-4316-A73D-DED45A04FF2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFDE2C7B-F7FA-4316-A73D-DED45A04FF2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFDE2C7B-F7FA-4316-A73D-DED45A04FF2D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B96E4DBE-0783-4379-AE43-2E3148A6034F}
+	EndGlobalSection
+EndGlobal

--- a/src/devices/Mfrc522/MfrcCommand.cs
+++ b/src/devices/Mfrc522/MfrcCommand.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Mfrc522
+{
+    /// <summary>
+    /// Command of MFRC522 reader
+    /// </summary>
+    /// <remarks>Most of the time, the only one you need to use is the Transceive command.
+    /// The SendAndReceiveData function is already using some of those commands to allow send and receive scenarios</remarks>
+    public enum MfrcCommand
+    {
+        /// <summary>
+        /// Idle : no action, cancels current command execution
+        /// </summary>
+        Idle = 0x00,
+
+        /// <summary>
+        /// Memory: stores 25 bytes into the internal buffer
+        /// </summary>
+        Memory = 0x01,
+
+        /// <summary>
+        /// Generate Random Id: generates a 10-byte random ID number
+        /// </summary>
+        GenerateRandomId = 0x02,
+
+        /// <summary>
+        /// Calculate CRC: activates the CRC coprocessor or performs a self test
+        /// </summary>
+        CalculateCrc = 0x03,
+
+        /// <summary>
+        /// Transmit: transmits data from the FIFO buffer
+        /// </summary>
+        Transmit = 0x04,
+
+        /// <summary>
+        /// No Command Change: no command change, can be used to modify the
+        /// CommandReg register bits without affecting the command,
+        /// for example, the PowerDown bit
+        /// </summary>
+        NoCommandChange = 0x07,
+
+        /// <summary>
+        /// Receive: activates the receiver circuits
+        /// </summary>
+        Receive = 0x08,
+
+        /// <summary>
+        /// Transceive: transmits data from FIFO buffer to antenna and automatically
+        /// activates the receiver after transmission
+        /// </summary>
+        Transceive = 0x0C,
+
+        /// <summary>
+        /// Mifare Authenticate: performs the MIFARE standard authentication as a reader
+        /// </summary>
+        MifareAuthenticate = 0x0E,
+
+        /// <summary>
+        /// Reset Phase: soft resets the MFRC522
+        /// </summary>
+        ResetPhase = 0x0F,
+    }
+}

--- a/src/devices/Mfrc522/MifareCardCommand.cs
+++ b/src/devices/Mfrc522/MifareCardCommand.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Mfrc522
+{
+    /// <summary>
+    /// Command to send to card
+    /// </summary>
+    internal enum CardCommand
+    {
+        ReqA = 0x26,
+        HaltA = 0x50,
+        RequestAll = 0x52,
+        SelectCascadeLevel1 = 0x93, // Used for anticollision as well
+        SelectCascadeLevel2 = 0x95,
+        SelectCascadeLevel3 = 0x97
+    }
+}

--- a/src/devices/Mfrc522/README.md
+++ b/src/devices/Mfrc522/README.md
@@ -1,0 +1,89 @@
+# MFRC522 - RFID reader
+
+MFRC522 is a very cheap RFID/NFC reader for Iso 14443 Type A cards. Part of those cars are the [Mifare](../Card/Mifare) family. This reader implement the proprietary Mifare cryptography protocol and can be used transparently.
+
+## Usage
+
+MFRC522 supports SPI, I2C and UART (Serial Port). You can create the reader with any of those protocols.
+
+**Note**: most of the popular boards you'll buy are SPI only. This documentation will focus on SPI. You have in the [smaples](./samples) more information on how to setup I2C and UART.
+
+```csharp
+SpiConnectionSettings connection = new(0, 1);
+// Here you can use as well MfRc522.MaximumSpiClockFrequency which is 10_000_000
+// Anything lower will work as well
+connection.ClockFrequency = 5_000_000;
+SpiDevice spi = SpiDevice.Create(connection)
+mfrc522 = new(spi, 4);
+```
+
+The code will create an instance of MFRC522 and will use the pin GPIO4 as the hardware rest pin and will create an GpioController automatically from the default driver. The [samples](./samples) folder have more advance setup using for example an [FT4222](../Ft4222) dongle as a SPI controller.
+
+You can get the version using the `Version` property.
+
+```csharp
+Console.WriteLine($"Version: {mfrc522.Version}, version should be 1 or 2. Some clones may appear with version 0");
+```
+
+Keep in mind that having a version which is 0.0 doesn't necessary means that your reader is not working properly, if you bought a cheap copy of an original MFRC522, the internal version may not be recognized.
+
+MFRC522 only supports ISO 14443 Type A. You can pull a card like this:
+
+```csharp
+bool res;
+Data106kbpsTypeA card;
+do
+{
+    res = mfrc522.ListenToCardIso14443TypeA(out card, TimeSpan.FromSeconds(2));
+    Thread.Sleep(res ? 0 : 200);
+}
+while (!res);
+```
+
+As soon as a card will be detected, it will get out a `Data106kbpsTypeA` class which is a card. You will have the Unique Identifier from the card as well as the rest of the elements to help identifying it.
+
+You can then create a Mifare card and fo operation on it:
+
+```csharp
+var mifare = new MifareCard(mfrc522, 0);
+mifare.SerialNumber = card.NfcId;
+mifare.Capacity = MifareCardCapacity.Mifare1K;
+mifare.KeyA = MifareCard.DefaultKeyA;
+mifare.KeyB = MifareCard.DefaultKeyB;
+
+mifare.BlockNumber = 0;
+mifare.Command = MifareCardCommand.AuthenticationB;
+ret = mifare.RunMifareCardCommand();
+if (ret < 0)
+{
+    mifare.ReselectCard();
+    Console.WriteLine($"Error reading bloc: {mifare.BlockNumber}");
+}
+else
+{
+    mifare.Command = MifareCardCommand.Read16Bytes;
+    ret = mifare.RunMifareCardCommand();
+    if (ret >= 0)
+    {
+        if (mifare.Data is object)
+        {
+            Console.WriteLine($"Bloc: {mifare.BlockNumber}, Data: {BitConverter.ToString(mifare.Data)}");
+        }
+    }
+    else
+    {
+        mifare.ReselectCard();
+        Console.WriteLine($"Error reading bloc: {mifare.BlockNumber}");
+    }
+}
+```
+
+**Important**: you have to do the `ReselectCard()` operation every time you have a failure in reading or authentication. By default the card will stop responding. This behavior is wanted by design to make is longer to brute force the authentication mechanism. The [samples](./samples) shows a way how to find a key from known keys for [NDEF](../Card/Ndef) scenarios for example. Note that the sample is not fully optimize, it is to help understanding what as the mechanism behind.
+
+## Reference and notes
+
+* MFRC5222 Datasheet: https://www.nxp.com/docs/en/data-sheet/MFRC522.pdf
+* The SPI implementation has been deeply tested.
+* The I2C and UART has been barely tested due to lack of hardware support. So please open issues if you have any issue.
+* When using I2C, the address can be setup using the hardware pin, it's the reason why there is no default address.
+* If you are using UART, it is more than strongly recommended to use as high as possible serial baud transfer.

--- a/src/devices/Mfrc522/Register.cs
+++ b/src/devices/Mfrc522/Register.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Mfrc522
+{
+    /// <summary>
+    /// Address of register moving all by 1 to the lest as
+    /// they are defined like this in the documentation. From documentation, all
+    /// registers' name finishes by Reg, removed from the name for clarity.
+    /// Some of those registers are not used in the current implementation. They can
+    /// be used to enhance it.
+    /// As most implementations are using SPI and it is left by 1 bit to the left, we're doing it
+    /// upfront
+    /// </summary>
+    internal enum Register
+    {
+        // Command and status
+        Command = 0x01 << 1,
+        ComIEn = 0x02 << 1,
+        DivlEn = 0x03 << 1,
+        ComIrq = 0x04 << 1,
+        DivIrq = 0x05 << 1,
+        Error = 0x06 << 1,
+        Status1 = 0x07 << 1,
+        Status2 = 0x08 << 1,
+        FifoData = 0x09 << 1,
+        FifoLevel = 0x0A << 1,
+        WaterLevel = 0x0B << 1,
+        Control = 0x0C << 1,
+        BitFraming = 0x0D << 1,
+        Coll = 0x0E << 1,
+        // Communication
+        Mode = 0x11 << 1,
+        TxMode = 0x12 << 1,
+        RxMode = 0x13 << 1,
+        TxControl = 0x14 << 1,
+        TxAsk = 0x15 << 1,
+        TxSel = 0x16 << 1,
+        RxSel = 0x17 << 1,
+        RxThreshold = 0x18 << 1,
+        Demod = 0x19 << 1,
+        MfTx = 0x1C << 1,
+        MfRx = 0x1D << 1,
+        SerialSpeed = 0x1F << 1,
+        // Configuration
+        CrcResultHigh = 0x21 << 1,
+        CrcResultLow = 0x22 << 1,
+        ModeWith = 0x24 << 1,
+        RFCfg = 0x26 << 1,
+        GsN = 0x27 << 1,
+        CWGsP = 0x28 << 1,
+        ModGsP = 0x29 << 1,
+        TMode = 0x2A << 1,
+        TPrescaler = 0x2B << 1,
+        TReloadHigh = 0x2C << 1,
+        TReloadLow = 0x2D << 1,
+        TCounterValueHigh = 0x2E << 1,
+        TCounterValueLow = 0x2F << 1,
+        // Test
+        TestSel1 = 0x31 << 1,
+        TestSel2 = 0x32 << 1,
+        TestPinEn = 0x33 << 1,
+        TestPinValue = 0x34 << 1,
+        TestBus = 0x35 << 1,
+        AutoTest = 0x36 << 1,
+        Version = 0x37 << 1,
+        AnalogTest = 0x38 << 1,
+        TestDAC1 = 0x39 << 1,
+        TestDAC2 = 0x3A << 1,
+        TestADC = 0x3B << 1,
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/BitFraming.cs
+++ b/src/devices/Mfrc522/RegisterElement/BitFraming.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mfrc522
+{
+    [Flags]
+    internal enum BitFraming
+    {
+        StartSend = 0b0000_0000,
+        RxAlignLSBPosition0 = 0b0000_0000,
+        RxAlignLSBPosition1 = 0b0001_0000,
+        RxAlignLSBPosition7 = 0b0111_0000,
+        TxLastBitsMask = 0b0000_0111,
+        TxLastBitsDefault = 0b0000_0000,
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/Coll.cs
+++ b/src/devices/Mfrc522/RegisterElement/Coll.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mfrc522
+{
+    [Flags]
+    internal enum Coll
+    {
+        ValuesAfterColl = 0b1000_0000,
+        CollPosNotValid = 0b0010_0000,
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/ComIr.cs
+++ b/src/devices/Mfrc522/RegisterElement/ComIr.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mfrc522
+{
+    [Flags]
+    internal enum ComIr
+    {
+        TimerIRq = 0b0000_0001,
+        ErrIRq = 0b0000_0010,
+        LoAlertIRq = 0b0000_0100,
+        HiAlertIRq = 0b0000_1000,
+        IdleIRq = 0b0001_0000,
+        RxIRq = 0b0010_0000,
+        TxIRq = 0b0100_0000,
+        SetIrq = 0b1000_0000,
+        All = TimerIRq | ErrIRq | LoAlertIRq | HiAlertIRq | IdleIRq | RxIRq | TxIRq,
+        None = 0b0000_0000
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/DivIrq.cs
+++ b/src/devices/Mfrc522/RegisterElement/DivIrq.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mfrc522
+{
+    [Flags]
+    internal enum DivIrq
+    {
+        CRCIRq = 0b0000_0100,
+        MfinActIRq = 0b0001_0000,
+        Set2 = 0b1000_0000
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/Error.cs
+++ b/src/devices/Mfrc522/RegisterElement/Error.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mfrc522
+{
+    [Flags]
+    internal enum Error
+    {
+        WrErr = 0b1000_0000,
+        TempErr = 0b0100_0000,
+        BufferOvfl = 0b0001_0000,
+        CollErr = 0b0000_1000,
+        CRCErr = 0b0000_0100,
+        ParityErr = 0b0000_0010,
+        ProtocolErr = 0b0000_0001
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/Gain.cs
+++ b/src/devices/Mfrc522/RegisterElement/Gain.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Mfrc522
+{
+    /// <summary>
+    /// The reception gain for the antenna
+    /// </summary>
+    public enum Gain
+    {
+        /// <summary>
+        /// Minimum gain 18 db
+        /// </summary>
+        G18dBa = 0b000_0000,
+
+        /// <summary>
+        /// 23 db
+        /// </summary>
+        G23dBa = 0b0001_0000,
+
+        /// <summary>
+        /// 18 db
+        /// </summary>
+        G18dBb = 0b0010_0000,
+
+        /// <summary>
+        /// 23 db
+        /// </summary>
+        G23dBb = 0b0011_0000,
+
+        /// <summary>
+        /// 33 db
+        /// </summary>
+        G33dB = 0b0100_0000,
+
+        /// <summary>
+        /// 38 db
+        /// </summary>
+        G38dB = 0b0101_0000,
+
+        /// <summary>
+        /// 43 db
+        /// </summary>
+        G43dB = 0b0110_0000,
+
+        /// <summary>
+        /// 48 db
+        /// </summary>
+        G48dB = 0b0111_0000,
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/Mode.cs
+++ b/src/devices/Mfrc522/RegisterElement/Mode.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mfrc522
+{
+    [Flags]
+    internal enum Mode
+    {
+        MSBFirst = 0b1000_0000,
+        TxWaitRF = 0b0010_0000,
+        PolMFinHigh = 0b0000_1000,
+    }
+
+    internal enum ModeCrc
+    {
+        Preset0000h = 0,
+        Preset6363h = 1,
+        PresetA671h = 2,
+        PresetFFFFh = 3,
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/ModeCrc.cs
+++ b/src/devices/Mfrc522/RegisterElement/ModeCrc.cs
@@ -1,15 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Iot.Device.Mfrc522
 {
-    [Flags]
-    internal enum Mode
+    internal enum ModeCrc
     {
-        MSBFirst = 0b1000_0000,
-        TxWaitRF = 0b0010_0000,
-        PolMFinHigh = 0b0000_1000,
+        Preset0000h = 0,
+        Preset6363h = 1,
+        PresetA671h = 2,
+        PresetFFFFh = 3,
     }
 }

--- a/src/devices/Mfrc522/RegisterElement/SerialSpeed.cs
+++ b/src/devices/Mfrc522/RegisterElement/SerialSpeed.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mfrc522
+{
+    /// <summary>
+    /// The serial UART speed in baud
+    /// </summary>
+    public enum SerialSpeed
+    {
+        /// <summary>7200 baud</summary>
+        B7200 = 0xFA,
+
+        /// <summary>9600 baud</summary>
+        B9600 = 0xEB,
+
+        /// <summary>14400 baud</summary>
+        B14400 = 0xDA,
+
+        /// <summary>19200 baud</summary>
+        B19200 = 0xCB,
+
+        /// <summary>38400 baud</summary>
+        B38400 = 0xAB,
+
+        /// <summary>57600 baud</summary>
+        B57600 = 0x9A,
+
+        /// <summary>115200 baud</summary>
+        B115200 = 0x7A,
+
+        /// <summary>128000 baud</summary>
+        B128000 = 0x74,
+
+        /// <summary>230400 baud</summary>
+        B230400 = 0x5A,
+
+        /// <summary>460800 baud</summary>
+        B460800 = 0x3A,
+
+        /// <summary>921600 baud</summary>
+        B921600 = 0x1C,
+
+        /// <summary>1228800 baud</summary>
+        B1228800 = 0x15,
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/Status2.cs
+++ b/src/devices/Mfrc522/RegisterElement/Status2.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mfrc522
+{
+    [Flags]
+    internal enum Status2
+    {
+        TempSensClear = 0b1000_0000,
+        I2CForceHS = 0b0100_0000,
+        MFCrypto1On = 0b0000_1000
+    }
+
+    internal enum ModemState
+    {
+        Idle = 0b0000_0000,
+        WaitForBitFramingReg = 0b0000_0001,
+        TxWait = 0b0000_0010,
+        Transmitting = 0b0000_0011,
+        RxWait = 0b0000_0100,
+        WaitForData = 0b0000_0101,
+        Receiving = 0b0000_0110,
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/TMode.cs
+++ b/src/devices/Mfrc522/RegisterElement/TMode.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mfrc522
+{
+    [Flags]
+    internal enum TMode
+    {
+        TAuto = 0b1000_0000,
+        TGatedNonGated = 0b0000_0000,
+        TGatedPinMFIN = 0b0010_0000,
+        TGatedPnAUX1 = 0b0100_0000,
+        TAutoRestart = 0b0001_0000,
+    }
+}

--- a/src/devices/Mfrc522/RegisterElement/TxControl.cs
+++ b/src/devices/Mfrc522/RegisterElement/TxControl.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mfrc522
+{
+    [Flags]
+    internal enum TxControl
+    {
+        InvTx2RFOn = 0b1000_0000,
+        InvTx1RFOn = 0b0100_0000,
+        InvTx2RFOff = 0b0010_0000,
+        InvTx1RFOff = 0b0001_0000,
+        Tx2CW = 0b0000_1000,
+        Tx2RFEn = 0b0000_0010,
+        Tx1RFEn = 0b0000_0001,
+    }
+}

--- a/src/devices/Mfrc522/Status.cs
+++ b/src/devices/Mfrc522/Status.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Mfrc522
+{
+    /// <summary>
+    /// Status for the functions
+    /// </summary>
+    public enum Status
+    {
+        /// <summary>
+        /// All happens perfectly
+        /// </summary>
+        Ok,
+
+        /// <summary>
+        /// A collision has been detected, this allows for example to use
+        /// retry mechanism
+        /// </summary>
+        Collision,
+
+        /// <summary>
+        /// An error happened
+        /// </summary>
+        Error,
+
+        /// <summary>
+        /// Timeout in reading or writing to the card, it may means the card has been
+        /// removed from the reader or is too far
+        /// </summary>
+        Timeout,
+    }
+}

--- a/src/devices/Mfrc522/samples/Mfrc522.Sample.csproj
+++ b/src/devices/Mfrc522/samples/Mfrc522.Sample.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>.net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mfrc522.csproj" />
+    <ProjectReference Include="..\..\Ft4222\Ft4222.csproj" />
+    <ProjectReference Include="..\..\Card\CardRfid.csproj" />
+    <ProjectReference Include="..\..\Card\Mifare\Mifare.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/devices/Mfrc522/samples/Program.cs
+++ b/src/devices/Mfrc522/samples/Program.cs
@@ -104,8 +104,8 @@ Console.WriteLine();
 var mifare = new MifareCard(mfrc522, 0);
 mifare.SerialNumber = card.NfcId;
 mifare.Capacity = MifareCardCapacity.Mifare1K;
-mifare.KeyA = MifareCard.DefaultKeyA;
-mifare.KeyB = MifareCard.DefaultKeyB;
+mifare.KeyA = MifareCard.DefaultKeyA.ToArray();
+mifare.KeyB = MifareCard.DefaultKeyB.ToArray();
 int ret;
 
 for (byte block = 0; block < 64; block++)
@@ -119,19 +119,19 @@ for (byte block = 0; block < 64; block++)
         // Those next lines shows how to try to authenticate with other known default keys
         mifare.ReselectCard();
         // Try the other key
-        mifare.KeyA = MifareCard.DefaultKeyA;
+        mifare.KeyA = MifareCard.DefaultKeyA.ToArray();
         mifare.Command = MifareCardCommand.AuthenticationA;
         ret = mifare.RunMifareCardCommand();
         if (ret < 0)
         {
             mifare.ReselectCard();
-            mifare.KeyA = MifareCard.DefaultBlocksNdefKeyA;
+            mifare.KeyA = MifareCard.DefaultBlocksNdefKeyA.ToArray();
             mifare.Command = MifareCardCommand.AuthenticationA;
             ret = mifare.RunMifareCardCommand();
             if (ret < 0)
             {
                 mifare.ReselectCard();
-                mifare.KeyA = MifareCard.DefaultFirstBlockNdefKeyA;
+                mifare.KeyA = MifareCard.DefaultFirstBlockNdefKeyA.ToArray();
                 mifare.Command = MifareCardCommand.AuthenticationA;
                 ret = mifare.RunMifareCardCommand();
                 if (ret < 0)
@@ -184,6 +184,5 @@ for (byte block = 0; block < 64; block++)
     else
     {
         Console.WriteLine($"Authentication error");
-
     }
 }

--- a/src/devices/Mfrc522/samples/Program.cs
+++ b/src/devices/Mfrc522/samples/Program.cs
@@ -1,0 +1,189 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Device.Gpio;
+using System.Device.I2c;
+using System.Device.Spi;
+using System.Threading;
+using Iot.Device.Card.Mifare;
+using Iot.Device.Ft4222;
+using Iot.Device.Mfrc522;
+using Iot.Device.Rfid;
+
+MfRc522? mfrc522 = null;
+
+Console.WriteLine("Hello MFRC522!");
+Console.WriteLine("Do you want to use the MFRC522 on a device like a Raspberry Pi or through a FT4222?");
+Console.WriteLine("  1. Raspberry Pi or equivalent");
+Console.WriteLine("  2. FT4222");
+var hardchoice = Console.ReadKey();
+Console.WriteLine();
+if (hardchoice.KeyChar is not('1' or '2'))
+{
+    Console.WriteLine("You have to choose option 1 or 2.");
+    return;
+}
+
+Console.WriteLine("How do you want to connect MFRC5222?");
+Console.WriteLine("  1. SPI");
+Console.WriteLine("  2. I2C");
+Console.WriteLine("  3. UART (Serial Port)");
+var connectionChoice = Console.ReadKey();
+Console.WriteLine();
+if (connectionChoice.KeyChar is not('1' or '2' or '3'))
+{
+    Console.WriteLine("You have to choose option 1, 2 or 3.");
+    return;
+}
+
+// Either create a default GPIO controller if running on a Raspberry PI or equivalent
+// Either create an FT4222 one
+GpioController gpioController = hardchoice.KeyChar == '1' ? new GpioController() : new GpioController(PinNumberingScheme.Board, new Ft4222Gpio());
+// Using GPIO4 for Raspberry PI or equivalent or 2 for FT4222;
+int pinReset = hardchoice.KeyChar == '1' ? 4 : 2;
+switch (connectionChoice.KeyChar)
+{
+    case '1':
+        SpiConnectionSettings connection = new(0, 1);
+        // Here you can use as well MfRc522.MaximumSpiClockFrequency which is 10_000_000
+        // Anything lower will work as well
+        connection.ClockFrequency = 5_000_000;
+        SpiDevice spi = hardchoice.KeyChar == '1' ? SpiDevice.Create(connection) : new Ft4222Spi(connection);
+        mfrc522 = new(spi, 2, gpioController, false);
+        break;
+    case '2':
+        Console.WriteLine("Enter the I2C address in decimal so 16 for 0x10");
+        var i2cAddChoice = Console.ReadLine();
+        try
+        {
+            int i2cAddress = Convert.ToInt32(i2cAddChoice);
+            I2cDevice i2c = hardchoice.KeyChar == '1' ? I2cDevice.Create(new I2cConnectionSettings(1, i2cAddress)) : new Ft4222I2cBus(FtCommon.GetDevices()[0]).CreateDevice(i2cAddress);
+            mfrc522 = new(i2c, 2, gpioController, false);
+        }
+        catch (Exception)
+        {
+            Console.WriteLine("Invalid I2C address entered");
+            return;
+        }
+
+        break;
+    case '3':
+        Console.WriteLine("Please enter your serial port like COM4 for Windows or /dev/ttyS0 for Linux");
+        var serialNameChoice = Console.ReadLine();
+        if (serialNameChoice is not object or { Length: 0 })
+        {
+            Console.WriteLine("Serial port needs to be a valid one");
+            return;
+        }
+
+        mfrc522 = new(serialNameChoice, 2, gpioController, false);
+        break;
+}
+
+if (mfrc522 is not object)
+{
+    Console.WriteLine("Something went wrong");
+    return;
+}
+
+Console.WriteLine($"Version: {mfrc522.Version}, version should be 1 or 2. Some clones may appear with version 0");
+Console.WriteLine("Place your Mifare card on the reader, the default B key to 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF will be used to read the card");
+
+bool res;
+Data106kbpsTypeA card;
+do
+{
+    res = mfrc522.ListenToCardIso14443TypeA(out card, TimeSpan.FromSeconds(2));
+    Thread.Sleep(res ? 0 : 200);
+}
+while (!res);
+
+Console.WriteLine();
+
+var mifare = new MifareCard(mfrc522, 0);
+mifare.SerialNumber = card.NfcId;
+mifare.Capacity = MifareCardCapacity.Mifare1K;
+mifare.KeyA = MifareCard.DefaultKeyA;
+mifare.KeyB = MifareCard.DefaultKeyB;
+int ret;
+
+for (byte block = 0; block < 64; block++)
+{
+    mifare.BlockNumber = block;
+    mifare.Command = MifareCardCommand.AuthenticationB;
+    ret = mifare.RunMifareCardCommand();
+    if (ret < 0)
+    {
+        // If you have an authentication error, you have to deselect and reselect the card again and retry
+        // Those next lines shows how to try to authenticate with other known default keys
+        mifare.ReselectCard();
+        // Try the other key
+        mifare.KeyA = MifareCard.DefaultKeyA;
+        mifare.Command = MifareCardCommand.AuthenticationA;
+        ret = mifare.RunMifareCardCommand();
+        if (ret < 0)
+        {
+            mifare.ReselectCard();
+            mifare.KeyA = MifareCard.DefaultBlocksNdefKeyA;
+            mifare.Command = MifareCardCommand.AuthenticationA;
+            ret = mifare.RunMifareCardCommand();
+            if (ret < 0)
+            {
+                mifare.ReselectCard();
+                mifare.KeyA = MifareCard.DefaultFirstBlockNdefKeyA;
+                mifare.Command = MifareCardCommand.AuthenticationA;
+                ret = mifare.RunMifareCardCommand();
+                if (ret < 0)
+                {
+                    mifare.ReselectCard();
+                    Console.WriteLine($"Error reading bloc: {block}");
+                }
+            }
+        }
+    }
+
+    if (ret >= 0)
+    {
+        mifare.BlockNumber = block;
+        mifare.Command = MifareCardCommand.Read16Bytes;
+        ret = mifare.RunMifareCardCommand();
+        if (ret >= 0)
+        {
+            if (mifare.Data is object)
+            {
+                Console.WriteLine($"Bloc: {block}, Data: {BitConverter.ToString(mifare.Data)}");
+            }
+        }
+        else
+        {
+            mifare.ReselectCard();
+            Console.WriteLine($"Error reading bloc: {block}");
+        }
+
+        if (block % 4 == 3)
+        {
+            if (mifare.Data != null)
+            {
+                // Check what are the permissions
+                for (byte j = 3; j > 0; j--)
+                {
+                    var access = mifare.BlockAccess((byte)(block - j), mifare.Data);
+                    Console.WriteLine($"Bloc: {block - j}, Access: {access}");
+                }
+
+                var sector = mifare.SectorTailerAccess(block, mifare.Data);
+                Console.WriteLine($"Bloc: {block}, Access: {sector}");
+            }
+            else
+            {
+                Console.WriteLine("Can't check any sector bloc");
+            }
+        }
+    }
+    else
+    {
+        Console.WriteLine($"Authentication error");
+
+    }
+}

--- a/src/devices/Pn5180/Pn5180.cs
+++ b/src/devices/Pn5180/Pn5180.cs
@@ -712,7 +712,7 @@ namespace Iot.Device.Pn5180
         /// <param name="blockAddress">The block address to authenticate</param>
         /// <param name="cardUid">The 4 bytes UUID of the card</param>
         /// <returns>True if success</returns>
-        public bool MifareAuthenticate(Span<byte> key, MifareCardCommand mifareCommand, byte blockAddress, Span<byte> cardUid)
+        public bool MifareAuthenticate(ReadOnlySpan<byte> key, MifareCardCommand mifareCommand, byte blockAddress, ReadOnlySpan<byte> cardUid)
         {
             LogInfo.Log($"{nameof(MifareAuthenticate)}: ", LogLevel.Debug);
             if (key.Length != 6)


### PR DESCRIPTION
- Add support for MFRC522
- Add documentation
- Add example on how to use MFRC522 including with FT4222 and native Raspberry Pi and other hardware supported boards
- SPI support fully tested
- MFRC522 support Iso 14443 Type A cards including Mifare card family. They are fully supported by this hardware including the latest NDEF addition

Note:

- I2C and UART support barely tested as most boards do not implement it properly
- Related to #293 and reusing part of this previous work