### PR TITLE
Found some problems in the UFirePh.cs code and made some fixes.

### DIFF
--- a/src/devices/UFireIse/UFirePh.cs
+++ b/src/devices/UFireIse/UFirePh.cs
@@ -93,54 +93,54 @@ namespace Iot.Device.UFire
         /// </summary>
         /// <param name="solutionpH">pH value</param>
         public void CalibrateSingle(float solutionpH) =>
-            CalibrateSingle(PhToMillivolts(solutionpH));
+            CalibrateFromSingleValue(PhToEp(solutionpH));
 
         /// <summary>
         /// Calibrates the dual-point values for the high reading and saves them in the devices's EEPROM.
         /// </summary>
         /// <param name="solutionpH">The pH of the calibration solution</param>
         public void CalibrateProbeHigh(float solutionpH) =>
-            CalibrateProbeHigh(PhToMillivolts(solutionpH));
+            CalibrateFromTwoValuesHighValue(PhToEp(solutionpH));
 
         /// <summary>
         /// Returns the dual-point calibration high-reference value.
         /// </summary>
         /// <returns></returns>
         public new float GetCalibrateHighReference() =>
-            MVtopH(GetCalibrateHighReference());
+            EpToPh(base.GetCalibrateHighReference());
 
         /// <summary>
         /// Returns the dual-point calibration high-reading value.
         /// </summary>
         /// <returns></returns>
         public new float GetCalibrateHighReading() =>
-            MVtopH(GetCalibrateHighReading());
+            EpToPh(base.GetCalibrateHighReading());
 
         /// <summary>
         /// Calibrates the dual-point values for the low reading and saves them in the devices's EEPROM.
         /// </summary>
         /// <param name="solutionpH"> the pH of the calibration solution</param>
         public void CalibrateProbeLow(float solutionpH) =>
-            CalibrateProbeLow(PhToMillivolts(solutionpH));
+            CalibrateFromTwoValuesLowValue(PhToEp(solutionpH));
 
         /// <summary>
         /// Returns the dual-point calibration low-reference value.
         /// </summary>
         /// <returns></returns>
         public new float GetCalibrateLowReference() =>
-            MVtopH(GetCalibrateLowReference());
+            EpToPh(base.GetCalibrateLowReference());
 
         /// <summary>
         /// Returns the dual-point calibration low-reading value.
         /// </summary>
         /// <returns></returns>
         public new float GetCalibrateLowReading() =>
-            MVtopH(GetCalibrateLowReading());
+            EpToPh(base.GetCalibrateLowReading());
 
-        private float PhToMillivolts(float pH) =>
-            (7 - pH) * ProbeMvToPh;
+        private ElectricPotential PhToEp(float pH) =>
+            ElectricPotential.FromMillivolts((7 - pH) * ProbeMvToPh);
 
-        private float MVtopH(float mV) =>
-            Convert.ToSingle(Math.Abs(7.0 - (mV / ProbeMvToPh)));
+        private float EpToPh(ElectricPotential ep) =>
+            Convert.ToSingle(Math.Abs(7 - ep.Millivolts / ProbeMvToPh));
     }
 }


### PR DESCRIPTION
These methods were infinitely recursive:
GetCalibrateHighReference
GetCalibrateHighReading
CalibrateProbeLow
GetCalibrateLowReference
GetCalibrateLowReading

Method PhToMillivolts renamed to PhToEp and now returns ElectricPotential.

Method MVtopH renamed to EpToPh and now takes a parameter of type ElectricPotential.

- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/master/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
