### PR TITLE
Add device binding - Sensorion SGP30 TVOC / eCO2 Gas Sensor

### DIFF
--- a/src/devices/Sgp30/ChecksumFailedException.cs
+++ b/src/devices/Sgp30/ChecksumFailedException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Iot.Device.Sgp30
+{
+    /// <summary>
+    /// Exception raised where an SGP30 Checksum Validation fails during a device read operation.
+    /// </summary>
+    public class ChecksumFailedException : Exception
+    {
+    }
+}

--- a/src/devices/Sgp30/README.md
+++ b/src/devices/Sgp30/README.md
@@ -1,0 +1,18 @@
+﻿# Sgp30
+
+## Summary
+Provide a brief description on what the component is and its functionality.
+
+## Device Family
+Provide a list of component names and link to datasheets (if available) the binding will work with.
+
+**[Family Name Here]**: [Datasheet link here]
+
+## Binding Notes
+
+Provide any specifics related to binding API.  This could include how to configure component for particular functions and example code.
+
+**NOTE**:  Don't repeat the basics related to System.Device.API* (e.g. connection settings, etc.).  This helps keep text/steps down to a minimum for maintainability.
+
+## References 
+Provide any references to other tutorials, blogs and hardware related to the component that could help others get started.

--- a/src/devices/Sgp30/README.md
+++ b/src/devices/Sgp30/README.md
@@ -1,18 +1,8 @@
-﻿# Sgp30
+﻿# Sensorion SGP30 TVOC + eCO2 Gas Sensor
+This is a device binding for the Sensorion SGP30 TVOC + eCO2 Gas Sensor.
 
-## Summary
-Provide a brief description on what the component is and its functionality.
-
-## Device Family
-Provide a list of component names and link to datasheets (if available) the binding will work with.
-
-**[Family Name Here]**: [Datasheet link here]
+## Datasheet
+[SGP30](https://cdn.shopify.com/s/files/1/0174/1800/files/Sensirion_Gas_Sensors_SGP30_Datasheet_EN-1148053.pdf)
 
 ## Binding Notes
-
-Provide any specifics related to binding API.  This could include how to configure component for particular functions and example code.
-
-**NOTE**:  Don't repeat the basics related to System.Device.API* (e.g. connection settings, etc.).  This helps keep text/steps down to a minimum for maintainability.
-
-## References 
-Provide any references to other tutorials, blogs and hardware related to the component that could help others get started.
+**NOTE**: Once initialised, this sensor **must** be queried at least once per second or re-initialisation will be required.

--- a/src/devices/Sgp30/README.md
+++ b/src/devices/Sgp30/README.md
@@ -5,4 +5,41 @@ This is a device binding for the Sensorion SGP30 TVOC + eCO2 Gas Sensor.
 [SGP30](https://cdn.shopify.com/s/files/1/0174/1800/files/Sensirion_Gas_Sensors_SGP30_Datasheet_EN-1148053.pdf)
 
 ## Binding Notes
-**NOTE**: Once initialised, this sensor **must** be queried at least once per second or re-initialisation will be required.
+**NOTE**: Once initialised, this sensor should be queried at least once per second. If more than several seconds pass,
+the initialisation routine should be called again to ensure the device is returning valid data.
+
+```cs
+// Setup Device Instance
+I2cDevice sgp30Device = I2cDevice.Create(new I2cConnectionSettings(1, Sgp30.DefaultI2cAddress));
+Sgp30 sgp30 = new Sgp30(sgp30Device);
+
+// Initialise the SGP30 device
+Console.WriteLine("Wait for initialisation (upto 20 seconds).");
+try
+{
+    Sgp30Measurement measurement = sgp30.InitialiseMeasurement();
+    Console.WriteLine($"TVOC: {measurement.Tvoc.ToString()} ppb, eCO2: {measurement.Eco2.ToString()} ppm.");
+}
+catch (ChecksumFailedException)
+{
+    Console.WriteLine("Checksum was invalid when initialising SGP30 measurement operation.");
+    throw;
+}
+```
+
+After initialisation, getting sensor readings is straightforward.
+```cs
+try
+{
+    Sgp30Measurement measurement = sgp30.GetMeasurement();
+    Console.WriteLine($"TVOC: {measurement.Tvoc.ToString()} ppb, eCO2: {measurement.Eco2.ToString()} ppm.");
+}
+catch (ChecksumFailedException)
+{
+    Console.WriteLine("Checksum was invalid when reading SGP30 measurement.");
+    throw;
+}
+```
+
+Note that all device commands may throw `ChecksumFailedException` if the data and checksum read from the device do not
+match. This will typically indicate that the connected device is not an SGP30 sensor.

--- a/src/devices/Sgp30/Sgp30.cs
+++ b/src/devices/Sgp30/Sgp30.cs
@@ -48,7 +48,7 @@ namespace Iot.Device.Sgp30
         /// </summary>
         /// <returns>Device Serial ID.</returns>
         /// <exception cref="ChecksumFailedException">Thrown if checksum validation fails.</exception>
-        public ushort[]? GetSerialId()
+        public ushort[] GetSerialId()
         {
             Span<byte> resultBuffer = stackalloc byte[10];
             _i2cDevice.Write(new ReadOnlySpan<byte>(new byte[] { (byte)((SGP30_GET_SERIAL_ID & 0xFF00) >> 8), (byte)(SGP30_GET_SERIAL_ID & 0x00FF) }));
@@ -57,16 +57,16 @@ namespace Iot.Device.Sgp30
 
             ushort[] serialValues = new ushort[]
             {
-                        (ushort)(resultArray[1] << 8 | resultArray[2]),
-                        (ushort)(resultArray[4] << 8 | resultArray[5]),
-                        (ushort)(resultArray[7] << 8 | resultArray[8])
+                (ushort)(resultArray[1] << 8 | resultArray[2]),
+                (ushort)(resultArray[4] << 8 | resultArray[5]),
+                (ushort)(resultArray[7] << 8 | resultArray[8])
             };
 
             byte[] checksums = new byte[]
             {
-                        CalculateChecksum(serialValues[0]),
-                        CalculateChecksum(serialValues[1]),
-                        CalculateChecksum(serialValues[2]),
+                CalculateChecksum(serialValues[0]),
+                CalculateChecksum(serialValues[1]),
+                CalculateChecksum(serialValues[2]),
             };
 
             if (checksums[0] != resultArray[3] || checksums[1] != resultArray[6] || checksums[2] != resultArray[9])

--- a/src/devices/Sgp30/Sgp30.cs
+++ b/src/devices/Sgp30/Sgp30.cs
@@ -137,21 +137,21 @@ namespace Iot.Device.Sgp30
         public Sgp30Measurement GetMeasurement()
         {
             Span<byte> resultBuffer = stackalloc byte[7];
-            _i2cDevice.Write(new ReadOnlySpan<byte>(new byte[] { (byte)((SGP30_INITIALISE_AIR_QUALITY & 0xFF00) >> 8), (byte)(SGP30_INITIALISE_AIR_QUALITY & 0x00FF) }));
+            _i2cDevice.Write(new ReadOnlySpan<byte>(new byte[] { (byte)((SGP30_MEASURE_AIR_QUALITY & 0xFF00) >> 8), (byte)(SGP30_MEASURE_AIR_QUALITY & 0x00FF) }));
             Thread.Sleep(12);
             _i2cDevice.Read(resultBuffer.Slice(1));
             byte[] resultArray = resultBuffer.ToArray();
 
             Sgp30Measurement result = new Sgp30Measurement
             {
-                Tvoc = (ushort)(resultArray[1] << 8 | resultArray[2]),
-                Eco2 = (ushort)(resultArray[4] << 8 | resultArray[5])
+                Eco2 = (ushort)(resultArray[1] << 8 | resultArray[2]),
+                Tvoc = (ushort)(resultArray[4] << 8 | resultArray[5])
             };
 
             byte[] checksums = new byte[]
             {
-                CalculateChecksum(result.Tvoc),
-                CalculateChecksum(result.Eco2)
+                CalculateChecksum(result.Eco2),
+                CalculateChecksum(result.Tvoc)
             };
 
             if (checksums[0] != resultArray[3] || checksums[1] != resultArray[6])

--- a/src/devices/Sgp30/Sgp30.cs
+++ b/src/devices/Sgp30/Sgp30.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Device.Gpio;
+using System.Device.I2c;
+using System.Device.Spi;
+
+namespace Iot.Device.Sgp30
+{
+    /// <summary>
+    /// Add documentation here
+    /// </summary>
+    public class Sgp30 : IDisposable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Sgp30"/> class.
+        /// </summary>
+        public Sgp30()
+        {
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/devices/Sgp30/Sgp30.cs
+++ b/src/devices/Sgp30/Sgp30.cs
@@ -77,6 +77,27 @@ namespace Iot.Device.Sgp30
             return serialValues;
         }
 
+        /// <summary>
+        /// Get the device featureset version.
+        /// </summary>
+        /// <returns>Device Features.</returns>
+        public ushort GetFeaturesetVersion()
+        {
+            Span<byte> resultBuffer = stackalloc byte[3];
+            _i2cDevice.Write(new ReadOnlySpan<byte>(new byte[] { (byte)((SGP30_GET_FEATURESET_VERSION & 0xFF00) >> 8), (byte)(SGP30_GET_FEATURESET_VERSION & 0x00FF) }));
+            _i2cDevice.Read(resultBuffer.Slice(1));
+            byte[] resultArray = resultBuffer.ToArray();
+            ushort result = (ushort)(resultArray[0] << 8 | resultArray[1]);
+            byte checksum = CalculateChecksum(result);
+
+            if (checksum != resultArray[2])
+            {
+                throw new ChecksumFailedException();
+            }
+
+            return result;
+        }
+
         private byte CalculateChecksum(ushort data)
         {
             byte crc = 0xFF;

--- a/src/devices/Sgp30/Sgp30.cs
+++ b/src/devices/Sgp30/Sgp30.cs
@@ -2,22 +2,101 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Device.Gpio;
+using System.Collections.Generic;
 using System.Device.I2c;
-using System.Device.Spi;
+using System.Linq;
+using UnitsNet;
 
 namespace Iot.Device.Sgp30
 {
     /// <summary>
-    /// Add documentation here
+    /// Device binding for Sensorion SGP30 TVOC + eCO2 Gas Sensor.
     /// </summary>
     public class Sgp30 : IDisposable
     {
+        // SGP30 Air Quality Sensor I2C Commands
+        // NOTE: The 'Measure Test' command is used for production verification only and is not included here
+        private const ushort SGP30_INIT_AIR_QUALITY = 0x2003;
+        private const ushort SGP30_MEASURE_AIR_QUALITY = 0x2008;
+        private const ushort SGP30_GET_BASELINE = 0x2015;
+        private const ushort SGP30_SET_BASELINE = 0x201E;
+        private const ushort SGP30_SET_HUMIDITY = 0x2061;
+        private const ushort SGP30_GET_FEATURESET_VERSION = 0x202F;
+        private const ushort SGP30_MEASURE_RAW_SIGNALS = 0x2050;
+        private const ushort SGP30_GET_SERIAL_ID = 0x3682;
+
+        /// <summary>
+        /// Default I2C Address, up to four IS31FL3730's can be on the same I2C Bus.
+        /// </summary>
+        public const byte DefaultI2cAddress = 0x58;
+
+        /// <summary>
+        /// I2C Device instance to communicate with the IS31FL3730.
+        /// </summary>
+        protected I2cDevice _i2cDevice;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Sgp30"/> class.
         /// </summary>
-        public Sgp30()
+        public Sgp30(I2cDevice i2cDevice)
         {
+            _i2cDevice = i2cDevice;
+        }
+
+        /// <summary>
+        /// Gets the Serial ID of the SGP30 sensor.
+        /// </summary>
+        /// <returns>Device Serial ID.</returns>
+        public int GetSerialId()
+        {
+            ushort[] result = ExecuteCommand(SGP30_GET_SERIAL_ID, null);
+            return 0;
+            ////return result[0] << 32 | result[1] << 16 | result[0];
+        }
+
+        private ushort[] ExecuteCommand(ushort command, ushort[]? parameters)
+        {
+            IList<ushort> result = new List<ushort>();
+
+            switch (command)
+            {
+                case SGP30_GET_SERIAL_ID:
+                    Span<byte> resultBuffer = null;
+                    _i2cDevice.Write(new ReadOnlySpan<byte>(new byte[] { (byte)((SGP30_GET_SERIAL_ID & 0xFF00) >> 8), (byte)(SGP30_GET_SERIAL_ID & 0x00FF) }));
+                    _i2cDevice.Read(resultBuffer);
+                    Console.WriteLine(resultBuffer.ToString());
+                    break;
+            }
+
+            return result.ToArray<ushort>();
+        }
+
+        private byte CalculateChecksum(ushort data)
+        {
+            byte crc = 0xFF;
+            byte[] bytes = new byte[]
+            {
+                (byte)((data & 0xFF00) >> 8),
+                (byte)(data & 0x00FF)
+            };
+
+            foreach (byte item in bytes)
+            {
+                crc ^= item;
+                for (int i = 0; i <= 7; i++)
+                {
+                    if ((crc & 0x80) == 0x80)
+                    {
+                        crc = (byte)((crc << 1) ^ 0x31);
+                    }
+                    else
+                    {
+                        crc = (byte)(crc << 1);
+                    }
+                }
+            }
+
+            return (byte)(crc & 0xFF);
         }
 
         /// <inheritdoc />

--- a/src/devices/Sgp30/Sgp30.cs
+++ b/src/devices/Sgp30/Sgp30.cs
@@ -83,14 +83,14 @@ namespace Iot.Device.Sgp30
         /// <returns>Device Features.</returns>
         public ushort GetFeaturesetVersion()
         {
-            Span<byte> resultBuffer = stackalloc byte[3];
+            Span<byte> resultBuffer = stackalloc byte[4];
             _i2cDevice.Write(new ReadOnlySpan<byte>(new byte[] { (byte)((SGP30_GET_FEATURESET_VERSION & 0xFF00) >> 8), (byte)(SGP30_GET_FEATURESET_VERSION & 0x00FF) }));
             _i2cDevice.Read(resultBuffer.Slice(1));
             byte[] resultArray = resultBuffer.ToArray();
-            ushort result = (ushort)(resultArray[0] << 8 | resultArray[1]);
+            ushort result = (ushort)(resultArray[1] << 8 | resultArray[2]);
             byte checksum = CalculateChecksum(result);
 
-            if (checksum != resultArray[2])
+            if (checksum != resultArray[3])
             {
                 throw new ChecksumFailedException();
             }

--- a/src/devices/Sgp30/Sgp30.cs
+++ b/src/devices/Sgp30/Sgp30.cs
@@ -16,14 +16,14 @@ namespace Iot.Device.Sgp30
     {
         // SGP30 Air Quality Sensor I2C Commands
         // NOTE: The 'Measure Test' command is used for production verification only and is not included here
-        private const ushort SGP30_INITIALISE_AIR_QUALITY = 0x2003; // DONE
-        private const ushort SGP30_MEASURE_AIR_QUALITY = 0x2008; // DONE
-        private const ushort SGP30_GET_BASELINE = 0x2015; // DONE
-        private const ushort SGP30_SET_BASELINE = 0x201E; // DONE
+        private const ushort SGP30_INITIALISE_AIR_QUALITY = 0x2003;
+        private const ushort SGP30_MEASURE_AIR_QUALITY = 0x2008;
+        private const ushort SGP30_GET_BASELINE = 0x2015;
+        private const ushort SGP30_SET_BASELINE = 0x201E;
         private const ushort SGP30_SET_HUMIDITY = 0x2061;
-        private const ushort SGP30_GET_FEATURESET_VERSION = 0x202F; // DONE
-        private const ushort SGP30_MEASURE_RAW_SIGNALS = 0x2050; // DONE
-        private const ushort SGP30_GET_SERIAL_ID = 0x3682; // DONE
+        private const ushort SGP30_GET_FEATURESET_VERSION = 0x202F;
+        private const ushort SGP30_MEASURE_RAW_SIGNALS = 0x2050;
+        private const ushort SGP30_GET_SERIAL_ID = 0x3682;
 
         /// <summary>
         /// Default I2C Address, up to four IS31FL3730's can be on the same I2C Bus.

--- a/src/devices/Sgp30/Sgp30.cs
+++ b/src/devices/Sgp30/Sgp30.cs
@@ -209,8 +209,7 @@ namespace Iot.Device.Sgp30
                     (byte)((eco2 & 0xFF00) >> 8),
                     (byte)(eco2 & 0x00FF),
                     CalculateChecksum(eco2)
-                })
-            );
+                }));
         }
 
         /// <summary>
@@ -236,8 +235,7 @@ namespace Iot.Device.Sgp30
                     firstByte,
                     secondByte,
                     CalculateChecksum((ushort)(firstByte << 8 | secondByte))
-                })
-            );
+                }));
         }
 
         /// <summary>

--- a/src/devices/Sgp30/Sgp30.cs
+++ b/src/devices/Sgp30/Sgp30.cs
@@ -16,7 +16,7 @@ namespace Iot.Device.Sgp30
         // NOTE: The 'Measure Test' command is used for production verification only and is not included here
         private const ushort SGP30_INITIALISE_AIR_QUALITY = 0x2003; // DONE
         private const ushort SGP30_MEASURE_AIR_QUALITY = 0x2008; // DONE
-        private const ushort SGP30_GET_BASELINE = 0x2015;
+        private const ushort SGP30_GET_BASELINE = 0x2015; // DONE
         private const ushort SGP30_SET_BASELINE = 0x201E;
         private const ushort SGP30_SET_HUMIDITY = 0x2061;
         private const ushort SGP30_GET_FEATURESET_VERSION = 0x202F; // DONE
@@ -188,6 +188,25 @@ namespace Iot.Device.Sgp30
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Set SGP30 baseline values.
+        /// </summary>
+        /// <param name="tvoc">TVOC Baseline.</param>
+        /// <param name="eco2">eCO2 Baseline.</param>
+        public void SetBaseline(ushort tvoc, ushort eco2)
+        {
+            _i2cDevice.Write(new ReadOnlySpan<byte>(new byte[]
+                {
+                    (byte)((tvoc & 0xFF00) >> 8),
+                    (byte)(tvoc & 0x00FF),
+                    CalculateChecksum(tvoc),
+                    (byte)((eco2 & 0xFF00) >> 8),
+                    (byte)(eco2 & 0x00FF),
+                    CalculateChecksum(eco2)
+                })
+            );
         }
 
         /// <summary>

--- a/src/devices/Sgp30/Sgp30.csproj
+++ b/src/devices/Sgp30/Sgp30.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <!--Disabling default items so samples source won't get build by the main library-->
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <LangVersion>9</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="*.cs" />
+    <None Include="README.md" />
+    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/devices/Sgp30/Sgp30.csproj
+++ b/src/devices/Sgp30/Sgp30.csproj
@@ -11,6 +11,7 @@
     <Compile Include="*.cs" />
     <None Include="README.md" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Sgp30/Sgp30.sln
+++ b/src/devices/Sgp30/Sgp30.sln
@@ -1,0 +1,53 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sgp30", "Sgp30.csproj", "{B82C190A-642B-465B-BD3F-DB56FFF22253}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{6A4DE7B1-03F3-4EE0-BF73-A0BAEF88BA2B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sgp30.Samples", "samples\Sgp30.Samples.csproj", "{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Debug|x64.Build.0 = Debug|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Debug|x86.Build.0 = Debug|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Release|x64.ActiveCfg = Release|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Release|x64.Build.0 = Release|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Release|x86.ActiveCfg = Release|Any CPU
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF}.Release|x86.Build.0 = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|x64.Build.0 = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|x86.Build.0 = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|x64.ActiveCfg = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|x64.Build.0 = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|x86.ActiveCfg = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{3CFA13D6-1D29-4C87-B0C1-01A6901A50EF} = {6A4DE7B1-03F3-4EE0-BF73-A0BAEF88BA2B}
+	EndGlobalSection
+EndGlobal

--- a/src/devices/Sgp30/Sgp30Measurement.cs
+++ b/src/devices/Sgp30/Sgp30Measurement.cs
@@ -1,0 +1,18 @@
+﻿namespace Iot.Device.Sgp30
+{
+    /// <summary>
+    /// SGP30 Gss sensor measurement result.
+    /// </summary>
+    public struct Sgp30Measurement
+    {
+        /// <summary>
+        /// Total VOC result (parts per billion).
+        /// /// </summary>
+        public ushort Tvoc;
+
+        /// <summary>
+        /// Equivalent CO2 result (parts per million).
+        /// </summary>
+        public ushort Eco2;
+    }
+}

--- a/src/devices/Sgp30/samples/README.md
+++ b/src/devices/Sgp30/samples/README.md
@@ -1,0 +1,4 @@
+# TODO: This needs to be determined
+
+Help Wanted Please
+

--- a/src/devices/Sgp30/samples/Sgp30.Sample.cs
+++ b/src/devices/Sgp30/samples/Sgp30.Sample.cs
@@ -34,3 +34,29 @@ catch (ChecksumFailedException)
     Console.WriteLine("Checksum was invalid when attempting to retrieve SGP30 featureset version information.");
     throw;
 }
+
+try
+{
+    Sgp30Measurement measurement = sgp30.InitialiseMeasurement();
+    Console.WriteLine($"TVOC: {measurement.Tvoc.ToString()}ppb, eCO2: {measurement.Eco2.ToString()}ppm.");
+}
+catch (ChecksumFailedException)
+{
+    Console.WriteLine("Checksum was invalid when initialising SGP30 measurement operation.");
+    throw;
+}
+
+for (int i = 0; i < 30; i++)
+{
+    try
+    {
+        Sgp30Measurement measurement = sgp30.GetMeasurement();
+        Console.WriteLine($"TVOC: {measurement.Tvoc.ToString()}ppb, eCO2: {measurement.Eco2.ToString()}ppm.");
+        Thread.Sleep(1000);
+    }
+    catch (ChecksumFailedException)
+    {
+        Console.WriteLine("Checksum was invalid when reading SGP30 measurement.");
+        throw;
+    }
+}

--- a/src/devices/Sgp30/samples/Sgp30.Sample.cs
+++ b/src/devices/Sgp30/samples/Sgp30.Sample.cs
@@ -23,3 +23,14 @@ catch (ChecksumFailedException)
     Console.WriteLine("Checksum was invalid when attempting to retrieve SGP30 device Serial ID.");
     throw;
 }
+
+try
+{
+    ushort featureSet = sgp30.GetFeaturesetVersion();
+    Console.WriteLine(featureSet.ToString("X4"));
+}
+catch (ChecksumFailedException)
+{
+    Console.WriteLine("Checksum was invalid when attempting to retrieve SGP30 featureset version information.");
+    throw;
+}

--- a/src/devices/Sgp30/samples/Sgp30.Sample.cs
+++ b/src/devices/Sgp30/samples/Sgp30.Sample.cs
@@ -6,5 +6,11 @@ using System.Device.Gpio;
 using System.Device.I2c;
 using System.Device.Spi;
 using System.Threading;
+using Iot.Device.Sgp30;
 
 Console.WriteLine("Hello Sgp30 Sample!");
+
+I2cDevice sgp30Device = I2cDevice.Create(new I2cConnectionSettings(1, Sgp30.DefaultI2cAddress));
+Sgp30 sgp30 = new Sgp30(sgp30Device);
+
+sgp30.GetSerialId();

--- a/src/devices/Sgp30/samples/Sgp30.Sample.cs
+++ b/src/devices/Sgp30/samples/Sgp30.Sample.cs
@@ -13,4 +13,21 @@ Console.WriteLine("Hello Sgp30 Sample!");
 I2cDevice sgp30Device = I2cDevice.Create(new I2cConnectionSettings(1, Sgp30.DefaultI2cAddress));
 Sgp30 sgp30 = new Sgp30(sgp30Device);
 
-sgp30.GetSerialId();
+try
+{
+    ushort[]? serialId = sgp30.GetSerialId();
+
+    if (serialId != null)
+    {
+        Console.WriteLine(String.Join("-", Array.ConvertAll(serialId, x => x.ToString("X4"))));
+    }
+    else
+    {
+        Console.WriteLine("Unable to retrive SGP30 device Serial ID.");
+    }
+}
+catch (ChecksumFailedException)
+{
+    Console.WriteLine("Checksum was invalid when attempting to retrieve SGP30 device Serial ID.");
+    throw;
+}

--- a/src/devices/Sgp30/samples/Sgp30.Sample.cs
+++ b/src/devices/Sgp30/samples/Sgp30.Sample.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Device.Gpio;
+using System.Device.I2c;
+using System.Device.Spi;
+using System.Threading;
+
+Console.WriteLine("Hello Sgp30 Sample!");

--- a/src/devices/Sgp30/samples/Sgp30.Sample.cs
+++ b/src/devices/Sgp30/samples/Sgp30.Sample.cs
@@ -35,10 +35,11 @@ catch (ChecksumFailedException)
     throw;
 }
 
+Console.WriteLine("Wait for initialisation (upto 20 seconds).");
 try
 {
     Sgp30Measurement measurement = sgp30.InitialiseMeasurement();
-    Console.WriteLine($"TVOC: {measurement.Tvoc.ToString()}ppb, eCO2: {measurement.Eco2.ToString()}ppm.");
+    Console.WriteLine($"TVOC: {measurement.Tvoc.ToString()} ppb, eCO2: {measurement.Eco2.ToString()} ppm.");
 }
 catch (ChecksumFailedException)
 {
@@ -51,7 +52,7 @@ for (int i = 0; i < 30; i++)
     try
     {
         Sgp30Measurement measurement = sgp30.GetMeasurement();
-        Console.WriteLine($"TVOC: {measurement.Tvoc.ToString()}ppb, eCO2: {measurement.Eco2.ToString()}ppm.");
+        Console.WriteLine($"TVOC: {measurement.Tvoc.ToString()} ppb, eCO2: {measurement.Eco2.ToString()} ppm.");
         Thread.Sleep(1000);
     }
     catch (ChecksumFailedException)

--- a/src/devices/Sgp30/samples/Sgp30.Sample.cs
+++ b/src/devices/Sgp30/samples/Sgp30.Sample.cs
@@ -15,16 +15,8 @@ Sgp30 sgp30 = new Sgp30(sgp30Device);
 
 try
 {
-    ushort[]? serialId = sgp30.GetSerialId();
-
-    if (serialId != null)
-    {
-        Console.WriteLine(String.Join("-", Array.ConvertAll(serialId, x => x.ToString("X4"))));
-    }
-    else
-    {
-        Console.WriteLine("Unable to retrive SGP30 device Serial ID.");
-    }
+    ushort[] serialId = sgp30.GetSerialId();
+    Console.WriteLine(String.Join("-", Array.ConvertAll(serialId, x => x.ToString("X4"))));
 }
 catch (ChecksumFailedException)
 {

--- a/src/devices/Sgp30/samples/Sgp30.Sample.cs
+++ b/src/devices/Sgp30/samples/Sgp30.Sample.cs
@@ -52,7 +52,9 @@ for (int i = 0; i < 30; i++)
     try
     {
         Sgp30Measurement measurement = sgp30.GetMeasurement();
+        ushort[] rawMeasurement = sgp30.GetRawSignalData();
         Console.WriteLine($"TVOC: {measurement.Tvoc.ToString()} ppb, eCO2: {measurement.Eco2.ToString()} ppm.");
+        Console.WriteLine($"TVOC Raw: {rawMeasurement[0].ToString("X4")}, eCO2 Raw: {rawMeasurement[1].ToString("X4")}.");
         Thread.Sleep(1000);
     }
     catch (ChecksumFailedException)

--- a/src/devices/Sgp30/samples/Sgp30.Sample.cs
+++ b/src/devices/Sgp30/samples/Sgp30.Sample.cs
@@ -52,9 +52,9 @@ for (int i = 0; i < 30; i++)
     try
     {
         Sgp30Measurement measurement = sgp30.GetMeasurement();
-        ushort[] rawMeasurement = sgp30.GetRawSignalData();
+        Sgp30Measurement rawMeasurement = sgp30.GetRawSignalData();
         Console.WriteLine($"TVOC: {measurement.Tvoc.ToString()} ppb, eCO2: {measurement.Eco2.ToString()} ppm.");
-        Console.WriteLine($"TVOC Raw: {rawMeasurement[0].ToString("X4")}, eCO2 Raw: {rawMeasurement[1].ToString("X4")}.");
+        Console.WriteLine($"TVOC Raw: {rawMeasurement.Tvoc.ToString("X4")}, eCO2 Raw: {rawMeasurement.Eco2.ToString("X4")}.");
         Thread.Sleep(1000);
     }
     catch (ChecksumFailedException)
@@ -62,4 +62,15 @@ for (int i = 0; i < 30; i++)
         Console.WriteLine("Checksum was invalid when reading SGP30 measurement.");
         throw;
     }
+}
+
+try
+{
+    Sgp30Measurement baseline = sgp30.GetBaseline();
+    Console.WriteLine($"TVOC: {baseline.Tvoc.ToString()} ppb (baseline), eCO2: {baseline.Eco2.ToString()} ppm (baseline).");
+}
+catch (ChecksumFailedException)
+{
+    Console.WriteLine("Checksum was invalid when reading SGP30 baseline data.");
+    throw;
 }

--- a/src/devices/Sgp30/samples/Sgp30.Sample.cs
+++ b/src/devices/Sgp30/samples/Sgp30.Sample.cs
@@ -67,7 +67,7 @@ for (int i = 0; i < 30; i++)
 try
 {
     Sgp30Measurement baseline = sgp30.GetBaseline();
-    Console.WriteLine($"TVOC: {baseline.Tvoc.ToString()} ppb (baseline), eCO2: {baseline.Eco2.ToString()} ppm (baseline).");
+    Console.WriteLine($"TVOC: {baseline.Tvoc.ToString("X4")} (baseline), eCO2: {baseline.Eco2.ToString("X4")} (baseline).");
 }
 catch (ChecksumFailedException)
 {

--- a/src/devices/Sgp30/samples/Sgp30.Samples.csproj
+++ b/src/devices/Sgp30/samples/Sgp30.Samples.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Sgp30.csproj" />
+    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds a device binding for the Sensorion SGP30 TVOC / eCO2 Gas Sensor.  All device features are implemented with the exception of the 'Measure Test' command, which is used during device manufacture and test only.