### PR TITLE
Fix unreliable code branch

### DIFF
--- a/src/devices/Pca9685/samples/Program.cs
+++ b/src/devices/Pca9685/samples/Program.cs
@@ -115,7 +115,12 @@ void ServoDemo(Pca9685 pca9685, int channel)
     while (true)
     {
         string? command = Console.ReadLine()?.ToLower();
-        if (command?[0] is 'q')
+        if (command is null)
+        {
+            return;
+        }
+
+        if (command[0] is 'q')
         {
             return;
         }

--- a/src/devices/Pca9685/samples/Program.cs
+++ b/src/devices/Pca9685/samples/Program.cs
@@ -115,7 +115,7 @@ void ServoDemo(Pca9685 pca9685, int channel)
     while (true)
     {
         string? command = Console.ReadLine()?.ToLower();
-        if (command?[0] is not 'q')
+        if (command?[0] is 'q')
         {
             return;
         }


### PR DESCRIPTION
I fix an unreliable code branch in example app.

Prev behaviour:
- I catch exception if enter 'Q'
- Return from function if enter any

Observe: 
```
while (true)
{
    string? command = Console.ReadLine()?.ToLower();
    if (command?[0] is not 'q') // 'c' or <double> will return
    {
        return;
    }
    if (command[0] == 'c') // command[0] is 'q'
    {
        CalibrateServo(servo);
        PrintServoDemoHelp();
    }
    else
    {
        double value = double.Parse(command); // Catch an exception because parse 'q'
        servo.WriteAngle(value);
        Console.WriteLine($"Angle set to {value}. PWM duty cycle = {pca9685.GetDutyCycle(channel)}");
    }
}
```

Solution:
- Remove 'not'