### PR TITLE
Fixes #1423

### DIFF
--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -1191,11 +1191,11 @@ namespace Iot.Device.Pn532
         /// <summary>
         /// Read the PN532 GPIO
         /// </summary>
-        /// <param name="p7">The P7 GPIO</param>
         /// <param name="p3">The P3 GPIO</param>
+        /// <param name="p7">The P7 GPIO</param>
         /// <param name="l0L1">The specific operation mode register</param>
         /// <returns>True if success</returns>
-        public bool ReadGpio(out Port7 p7, out Port3 p3, out OperatingMode l0L1)
+        public bool ReadGpio(out Port3 p3, out Port7 p7, out OperatingMode l0L1)
         {
             // No flag as default
             p7 = 0;
@@ -1209,14 +1209,14 @@ namespace Iot.Device.Pn532
 
             Span<byte> retGPIO = stackalloc byte[3];
             ret = ReadResponse(CommandSet.ReadGPIO, retGPIO);
-            p7 = (Port7)retGPIO[0];
-            p3 = (Port3)retGPIO[1];
+            p3 = (Port3)retGPIO[0];
+            p7 = (Port7)retGPIO[1];
             l0L1 = (OperatingMode)retGPIO[2];
             return ret >= 0;
         }
 
         /// <summary>
-        /// Write the PN532 GPIO
+        /// Write the PN532 GPIO ports 3 and 7
         /// </summary>
         /// <param name="p7">The P7 GPIO</param>
         /// <param name="p3">The P3 GPIO</param>
@@ -1225,8 +1225,52 @@ namespace Iot.Device.Pn532
         {
             Span<byte> toWrite = stackalloc byte[2]
             {
-                (byte)p7,
-                (byte)p3
+                (byte)(0x80 | (byte)p3),
+                (byte)(0x80 | (byte)p7)
+            };
+            var ret = WriteCommand(CommandSet.WriteGPIO, toWrite);
+            if (ret < 0)
+            {
+                return false;
+            }
+
+            ret = ReadResponse(CommandSet.WriteGPIO, Span<byte>.Empty);
+            return ret >= 0;
+        }
+
+        /// <summary>
+        /// Write the PN532 GPIO port 3 leaving port 7 in it's current state
+        /// </summary>
+        /// <param name="p3">The P3 GPIO</param>
+        /// <returns>True if success</returns>
+        public bool WriteGpio(Port3 p3)
+        {
+            Span<byte> toWrite = stackalloc byte[2]
+            {
+                (byte)(0x80 | (byte)p3),
+                (byte)(0x00)
+            };
+            var ret = WriteCommand(CommandSet.WriteGPIO, toWrite);
+            if (ret < 0)
+            {
+                return false;
+            }
+
+            ret = ReadResponse(CommandSet.WriteGPIO, Span<byte>.Empty);
+            return ret >= 0;
+        }
+
+        /// <summary>
+        /// Write the PN532 GPIO port 7 leaving port 3 in it's current state
+        /// </summary>
+        /// <param name="p7">The P7 GPIO</param>
+        /// <returns>True if success</returns>
+        public bool WriteGpio(Port7 p7)
+        {
+            Span<byte> toWrite = stackalloc byte[2]
+            {
+                (byte)(0x00),
+                (byte)(0x80 | (byte)p7)
             };
             var ret = WriteCommand(CommandSet.WriteGPIO, toWrite);
             if (ret < 0)

--- a/src/devices/Pn532/samples/Program.cs
+++ b/src/devices/Pn532/samples/Program.cs
@@ -8,6 +8,7 @@ using System.Device.I2c;
 using System.Device.Spi;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Iot.Device.Card;
 using Iot.Device.Card.CreditCardProcessing;
 using Iot.Device.Card.Mifare;
@@ -53,7 +54,7 @@ if (choiceInterface is { KeyChar: '3' })
 }
 else if (choiceInterface is { KeyChar: '2' })
 {
-    pn532 = new Pn532(I2cDevice.Create(new I2cConnectionSettings(1, Pn532.I2cDefaultAddress)), debugLevel);
+    pn532 = new Pn532(I2cDevice.Create(new I2cConnectionSettings(2, Pn532.I2cDefaultAddress)), debugLevel);
 }
 else
 {
@@ -75,7 +76,8 @@ if (pn532.FirmwareVersion is FirmwareVersion version)
 
     // To run tests, uncomment the next line
     // RunTests(pn532);
-    ReadMiFare(pn532);
+    // ReadMiFare(pn532);
+    TestGPIO(pn532);
 
     // To read Credit Cards, uncomment the next line
     // ReadCreditCard(pn532);
@@ -209,6 +211,35 @@ void ReadMiFare(Pn532 pn532)
     }
 }
 
+void TestGPIO(Pn532 pn532)
+{
+    Console.WriteLine("Turning Off Port 7!");
+    var ret = pn532.WriteGpio((Port7)0);
+
+    // Access GPIO
+    ret = pn532.ReadGpio(out Port3 p3, out Port7 p7, out OperatingMode l0L1);
+    Console.WriteLine($"P7: {p7}");
+    Console.WriteLine($"P3: {p3}");
+    Console.WriteLine($"L0L1: {l0L1} ");
+
+    var on = true;
+    for (var i = 0; i < 10; i++)
+    {
+        if (on)
+        {
+            p7 = Port7.P71;
+        }
+        else
+        {
+            p7 = 0;
+        }
+
+        ret = pn532.WriteGpio(p7);
+        Task.Delay(150).Wait();
+        on = !on;
+    }
+}
+
 void RunTests(Pn532 pn532)
 {
     Console.WriteLine(
@@ -240,7 +271,7 @@ void RunTests(Pn532 pn532)
 
     Console.WriteLine($"Are results same: {redSfrus.SequenceEqual(redSfrs)}");
     // Access GPIO
-    ret = pn532.ReadGpio(out Port7 p7, out Port3 p3, out OperatingMode l0L1);
+    ret = pn532.ReadGpio(out Port3 p3, out Port7 p7, out OperatingMode l0L1);
     Console.WriteLine($"P7: {p7}");
     Console.WriteLine($"P3: {p3}");
     Console.WriteLine($"L0L1: {l0L1} ");

--- a/src/devices/Pn532/samples/Program.cs
+++ b/src/devices/Pn532/samples/Program.cs
@@ -54,7 +54,7 @@ if (choiceInterface is { KeyChar: '3' })
 }
 else if (choiceInterface is { KeyChar: '2' })
 {
-    pn532 = new Pn532(I2cDevice.Create(new I2cConnectionSettings(2, Pn532.I2cDefaultAddress)), debugLevel);
+    pn532 = new Pn532(I2cDevice.Create(new I2cConnectionSettings(1, Pn532.I2cDefaultAddress)), debugLevel);
 }
 else
 {
@@ -76,8 +76,8 @@ if (pn532.FirmwareVersion is FirmwareVersion version)
 
     // To run tests, uncomment the next line
     // RunTests(pn532);
-    // ReadMiFare(pn532);
-    TestGPIO(pn532);
+    ReadMiFare(pn532);
+    // TestGPIO(pn532);
 
     // To read Credit Cards, uncomment the next line
     // ReadCreditCard(pn532);


### PR DESCRIPTION
Fixes #1423 :
Fixing methods WriteGPIO and ReadGPIO on Pn532 device. Now methods are implemented according Pn532 specifications.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1434)