### PR TITLE
Fixes #1432

### DIFF
--- a/src/devices/Ssd13xx/Ssd1306.cs
+++ b/src/devices/Ssd13xx/Ssd1306.cs
@@ -50,7 +50,7 @@ namespace Iot.Device.Ssd13xx
             }
 
             Span<byte> writeBuffer = SliceGenericBuffer(commandBytes.Length + 1);
-
+            writeBuffer[0] = 0x00; // Control byte
             commandBytes.CopyTo(writeBuffer.Slice(1));
 
             // Be aware there is a Continuation Bit in the Control byte and can be used


### PR DESCRIPTION
Fixes #1432 
- Control byte was not being set to 0x00 on SendCommand method of Ssd1306 device. Because of that, after sending data to the device commands where not working properly

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1435)