### PR TITLE
Removed Segment Mask from LargeSevenSegmentDisplay to allow the support of HT16k33 AdaFruit backpack displays

### DIFF
--- a/src/devices/Display/Large4Digit7SegmentDisplay.cs
+++ b/src/devices/Display/Large4Digit7SegmentDisplay.cs
@@ -28,13 +28,6 @@ namespace Iot.Device.Display
         /// Number of digits supported by display
         /// </summary>
         private const int MaxNumberOfDigits = 4;
-
-        /// <summary>
-        /// This display does not support dot bits for each digit,
-        /// so the first bit should be masked before flushing to
-        /// the device
-        /// </summary>
-        private const byte SegmentMask = 0b0111_1111;
         #endregion
 
         #region Enums
@@ -168,7 +161,7 @@ namespace Iot.Device.Display
 
             foreach (byte digit in digits)
             {
-                _displayBuffer[(int)s_digitAddressList[startAddress++]] = (byte)(digit & SegmentMask);
+                _displayBuffer[(int)s_digitAddressList[startAddress++]] = digit;
             }
 
             AutoFlush();


### PR DESCRIPTION
Fixes #1441

I have connected a (AdaFruit 0.56" 4 digit, 7 segment ) display using I2C bus to a Raspberry PI. The digits display correctly, but I cannot control the decimal points on any of the digits. The centre ':' can be controlled.

This fix allows the decimal points for each digit to be controlled by the Segment enum


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1459)