### PR TITLE
Introduce wait states for some commands

### DIFF
--- a/src/devices/CharacterLcd/Hd44780.cs
+++ b/src/devices/CharacterLcd/Hd44780.cs
@@ -103,18 +103,13 @@ namespace Iot.Device.CharacterLcd
             _displayControl |= DisplayControl.DisplayOn;
             _displayMode |= DisplayEntryMode.Increment;
 
-            ReadOnlySpan<byte> commands = stackalloc byte[]
-            {
-                // Function must be set first to ensure that we always have the basic
-                // instruction set selected. (See PCF2119x datasheet Function_set note
-                // for one documented example of where this is necessary.)
-                (byte)_displayFunction,
-                (byte)_displayControl,
-                (byte)_displayMode,
-                ClearDisplayCommand
-            };
-
-            SendCommands(commands);
+            // Function must be set first to ensure that we always have the basic
+            // instruction set selected. (See PCF2119x datasheet Function_set note
+            // for one documented example of where this is necessary.)
+            SendCommandAndWait((byte)_displayFunction);
+            SendCommandAndWait((byte)_displayControl);
+            SendCommandAndWait((byte)_displayMode);
+            SendCommandAndWait(ClearDisplayCommand);
         }
 
         /// <summary>
@@ -137,6 +132,14 @@ namespace Iot.Device.CharacterLcd
         /// </summary>
         /// <param name="command">Byte representing the command to be sent</param>
         protected void SendCommand(byte command) => _lcdInterface.SendCommand(command);
+
+        /// <summary>
+        /// The initialization sequence and some other complex commands should be sent with delays, or the display may
+        /// behave unexpectedly. It may show random, blinking characters
+        /// or display text very faintly only.
+        /// </summary>
+        /// <param name="command">The command to send</param>
+        protected void SendCommandAndWait(byte command) => _lcdInterface.SendCommandAndWait(command);
 
         /// <summary>
         /// Sends data to the device
@@ -253,7 +256,7 @@ namespace Iot.Device.CharacterLcd
         public bool DisplayOn
         {
             get => (_displayControl & DisplayControl.DisplayOn) > 0;
-            set => SendCommand((byte)(value ? _displayControl |= DisplayControl.DisplayOn
+            set => SendCommandAndWait((byte)(value ? _displayControl |= DisplayControl.DisplayOn
                 : _displayControl &= ~DisplayControl.DisplayOn));
         }
 
@@ -263,7 +266,7 @@ namespace Iot.Device.CharacterLcd
         public bool UnderlineCursorVisible
         {
             get => (_displayControl & DisplayControl.CursorOn) > 0;
-            set => SendCommand((byte)(value ? _displayControl |= DisplayControl.CursorOn
+            set => SendCommandAndWait((byte)(value ? _displayControl |= DisplayControl.CursorOn
                 : _displayControl &= ~DisplayControl.CursorOn));
         }
 
@@ -273,7 +276,7 @@ namespace Iot.Device.CharacterLcd
         public bool BlinkingCursorVisible
         {
             get => (_displayControl & DisplayControl.BlinkOn) > 0;
-            set => SendCommand((byte)(value ? _displayControl |= DisplayControl.BlinkOn
+            set => SendCommandAndWait((byte)(value ? _displayControl |= DisplayControl.BlinkOn
                 : _displayControl &= ~DisplayControl.BlinkOn));
         }
 
@@ -283,7 +286,7 @@ namespace Iot.Device.CharacterLcd
         public bool AutoShift
         {
             get => (_displayMode & DisplayEntryMode.DisplayShift) > 0;
-            set => SendCommand((byte)(value ? _displayMode |= DisplayEntryMode.DisplayShift
+            set => SendCommandAndWait((byte)(value ? _displayMode |= DisplayEntryMode.DisplayShift
                 : _displayMode &= ~DisplayEntryMode.DisplayShift));
         }
 
@@ -293,7 +296,7 @@ namespace Iot.Device.CharacterLcd
         public bool Increment
         {
             get => (_displayMode & DisplayEntryMode.Increment) > 0;
-            set => SendCommand((byte)(value ? _displayMode |= DisplayEntryMode.Increment
+            set => SendCommandAndWait((byte)(value ? _displayMode |= DisplayEntryMode.Increment
                 : _displayMode &= ~DisplayEntryMode.Increment));
         }
 
@@ -387,14 +390,13 @@ namespace Iot.Device.CharacterLcd
         /// </remarks>
         public void Write(string text)
         {
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(text.Length);
+            Span<byte> buffer = stackalloc byte[text.Length];
             for (int i = 0; i < text.Length; ++i)
             {
                 buffer[i] = (byte)text[i];
             }
 
-            SendData(new ReadOnlySpan<byte>(buffer, 0, text.Length));
-            ArrayPool<byte>.Shared.Return(buffer);
+            SendData(buffer);
         }
 
         /// <summary>

--- a/src/devices/CharacterLcd/LcdInterface.I2c4Bit.cs
+++ b/src/devices/CharacterLcd/LcdInterface.I2c4Bit.cs
@@ -54,7 +54,7 @@ namespace Iot.Device.CharacterLcd
                 {
                     _backlightOn = value;
                     // Need to send a command to make this happen immediately.
-                    SendCommand(0);
+                    SendCommandAndWait(0);
                 }
             }
 
@@ -87,7 +87,7 @@ namespace Iot.Device.CharacterLcd
                 SendCommandAndWait(LCD_ENTRYMODESET | LCD_ENTRYLEFT);
             }
 
-            private void SendCommandAndWait(byte command)
+            public override void SendCommandAndWait(byte command)
             {
                 // Must not run the init sequence to fast or undefined behavior may occur
                 SendCommand(command);

--- a/src/devices/CharacterLcd/LcdInterface.cs
+++ b/src/devices/CharacterLcd/LcdInterface.cs
@@ -5,6 +5,7 @@ using System;
 using System.Device;
 using System.Device.Gpio;
 using System.Device.I2c;
+using System.Threading;
 
 namespace Iot.Device.CharacterLcd
 {
@@ -74,6 +75,19 @@ namespace Iot.Device.CharacterLcd
         /// </summary>
         /// <param name="values">Each byte represents command to be send</param>
         public abstract void SendCommands(ReadOnlySpan<byte> values);
+
+        /// <summary>
+        /// The initialization sequence and some other complex commands should be sent with delays, or the display may
+        /// behave unexpectedly. It may show random, blinking characters
+        /// or display text very faintly only.
+        /// </summary>
+        /// <param name="command">The command to send</param>
+        public virtual void SendCommandAndWait(byte command)
+        {
+            // Must not run the init sequence to fast or undefined behavior may occur
+            SendCommand(command);
+            Thread.Sleep(1);
+        }
 
         /// <summary>
         /// True if device uses 8-bits for communication, false if device uses 4-bits


### PR DESCRIPTION
This improves the stability of the initialization sequence for the CharacterLcd-Displays. Previously, it sometimes happened that the init sequence was executing to fast, which caused the display to enter an undefined state (displaying random characters and not properly updating)

The problem mostly showed up on a 20x4 Display connected trough I2C. The patch is verified to work with this and also a 16x2 Display connected using GPIOs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1466)