### PR TITLE
A GPIO has to be writeable even in drive mode input because one wants to set the value used when switching to output mode.

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
@@ -46,7 +46,7 @@ namespace System.Device.Gpio.Tests
         }
 
         [Fact]
-        public void WriteInputPinThrows()
+        public void WriteInputPinDoesNotThrow()
         {
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, It.IsAny<PinMode>())).Returns(true);
@@ -55,7 +55,7 @@ namespace System.Device.Gpio.Tests
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
 
             ctrl.OpenPin(1, PinMode.Input);
-            Assert.Throws<InvalidOperationException>(() => ctrl.Write(1, PinValue.High));
+            ctrl.Write(1, PinValue.High);
         }
 
         [Fact]

--- a/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
@@ -51,7 +51,6 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, It.IsAny<PinMode>())).Returns(true);
             _mockedGpioDriver.Setup(x => x.SetPinModeEx(1, It.IsAny<PinMode>()));
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Input);
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
 
             ctrl.OpenPin(1, PinMode.Input);
@@ -63,7 +62,6 @@ namespace System.Device.Gpio.Tests
         {
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
             _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
@@ -105,7 +103,6 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.SetPinModeEx(1, PinMode.Output));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
             _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
             _mockedGpioDriver.Setup(x => x.ReadEx(1)).Returns(PinValue.High);
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
@@ -123,7 +120,6 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
             ctrl.OpenPin(1, PinMode.Output);
             ctrl.Write(1, PinValue.High);
@@ -179,8 +175,6 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(2));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(2, PinMode.Output)).Returns(true);
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
-            _mockedGpioDriver.Setup(x => x.GetPinModeEx(2)).Returns(PinMode.Output);
             _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
             _mockedGpioDriver.Setup(x => x.WriteEx(2, PinValue.Low));
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));

--- a/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
@@ -51,6 +51,7 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, It.IsAny<PinMode>())).Returns(true);
             _mockedGpioDriver.Setup(x => x.SetPinModeEx(1, It.IsAny<PinMode>()));
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Input);
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
 
             ctrl.OpenPin(1, PinMode.Input);
@@ -62,6 +63,7 @@ namespace System.Device.Gpio.Tests
         {
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
             _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
@@ -103,6 +105,7 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.SetPinModeEx(1, PinMode.Output));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
             _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
             _mockedGpioDriver.Setup(x => x.ReadEx(1)).Returns(PinValue.High);
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
@@ -120,6 +123,7 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
             var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
             ctrl.OpenPin(1, PinMode.Output);
             ctrl.Write(1, PinValue.High);
@@ -175,6 +179,8 @@ namespace System.Device.Gpio.Tests
             _mockedGpioDriver.Setup(x => x.OpenPinEx(2));
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(1, PinMode.Output)).Returns(true);
             _mockedGpioDriver.Setup(x => x.IsPinModeSupportedEx(2, PinMode.Output)).Returns(true);
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(1)).Returns(PinMode.Output);
+            _mockedGpioDriver.Setup(x => x.GetPinModeEx(2)).Returns(PinMode.Output);
             _mockedGpioDriver.Setup(x => x.WriteEx(1, PinValue.High));
             _mockedGpioDriver.Setup(x => x.WriteEx(2, PinValue.Low));
             _mockedGpioDriver.Setup(x => x.ClosePinEx(1));

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -112,12 +112,12 @@ namespace System.Device.Gpio.Tests
         }
 
         [Fact]
-        public void ThrowsIfWritingOnInputPin()
+        public void AllowWritingOnInputPin()
         {
             using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
             {
                 controller.OpenPin(InputPin, PinMode.Input);
-                Assert.Throws<InvalidOperationException>(() => controller.Write(InputPin, PinValue.High));
+                controller.Write(InputPin, PinValue.High);
             }
         }
 

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -64,6 +64,20 @@ namespace System.Device.Gpio.Tests
         }
 
         [Fact]
+        public void PinCanChangeStateWhileItIsOpen()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(OutputPin, PinMode.Input);
+                Thread.SpinWait(100);
+                controller.SetPinMode(OutputPin, PinMode.Output);
+                controller.Write(OutputPin, PinValue.High);
+                controller.SetPinMode(OutputPin, PinMode.Input);
+                controller.ClosePin(OutputPin);
+            }
+        }
+
+        [Fact]
         public void ThrowsInvalidOperationExceptionWhenPinIsNotOpened()
         {
             using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))

--- a/src/System.Device.Gpio.Tests/LibGpiodDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/LibGpiodDriverTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Device.Gpio.Drivers;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,5 +21,38 @@ namespace System.Device.Gpio.Tests
         protected override GpioDriver GetTestDriver() => new LibGpiodDriver();
 
         protected override PinNumberingScheme GetTestNumberingScheme() => PinNumberingScheme.Logical;
+
+        [Fact]
+        public void SetPinModeSetsDefaultValue()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                int testPin = OutputPin;
+                // Set value to low prior to test, so that we have a defined start situation
+                controller.OpenPin(testPin, PinMode.Output);
+                controller.Write(testPin, PinValue.Low);
+                controller.ClosePin(testPin);
+                // For this test, we use the input pin as an external pull-up
+                controller.OpenPin(InputPin, PinMode.Output);
+                controller.Write(InputPin, PinValue.High);
+                Thread.Sleep(2);
+
+                controller.OpenPin(testPin, PinMode.Input);
+                Thread.Sleep(50);
+                // It's not possible to change the direction while listening to events (causes an error). Therefore the real behavior of the driver
+                // can only be tested with a scope (or if we had a third pin connected in the lab hardware)
+
+                // We do another test here and make sure the
+                // pin is really high now
+                controller.Write(testPin, PinValue.High);
+                controller.SetPinMode(testPin, PinMode.Output);
+                controller.SetPinMode(InputPin, PinMode.Input);
+
+                Assert.True(controller.Read(InputPin) == PinValue.High);
+
+                controller.ClosePin(OutputPin);
+                controller.ClosePin(InputPin);
+            }
+        }
     }
 }

--- a/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.cs
@@ -54,7 +54,7 @@ namespace System.Device.Gpio.Tests
         }
 
         [Fact]
-        public void HighPulledPinDoesNotGlitchToLowWhenChangedToOutput()
+        public void HighPulledPinDoesNotChangeToLowWhenChangedToOutput()
         {
             using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
             {

--- a/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.cs
@@ -56,11 +56,6 @@ namespace System.Device.Gpio.Tests
         [Fact]
         public void HighPulledPinDoesNotGlitchToLowWhenChangedToOutput()
         {
-            ////while (!System.Diagnostics.Debugger.IsAttached)
-            ////{
-            ////    Thread.Sleep(100);
-            ////}
-
             using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
             {
                 bool didTriggerToLow = false;

--- a/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.cs
@@ -52,5 +52,29 @@ namespace System.Device.Gpio.Tests
                 Assert.Equal(PinValue.Low, controller.Read(OpenPin));
             }
         }
+
+        [Fact]
+        public void HighPulledPinDoesNotGlitchToLowWhenChangedToOutput()
+        {
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                bool didTriggerToLow = false;
+                int testPin = OutputPin; // TODO: Change to OpenPin
+                controller.OpenPin(testPin, PinMode.InputPullUp);
+                Thread.Sleep(50);
+                controller.RegisterCallbackForPinValueChangedEvent(testPin, PinEventTypes.Falling, (sender, args) =>
+                {
+                    if (args.ChangeType == PinEventTypes.Falling)
+                    {
+                        didTriggerToLow = true;
+                    }
+                });
+
+                controller.Write(testPin, PinValue.High);
+                controller.SetPinMode(testPin, PinMode.Output);
+                Thread.Sleep(50);
+                Assert.False(didTriggerToLow);
+            }
+        }
     }
 }

--- a/src/System.Device.Gpio/Interop/Unix/SafeLineHandle.cs
+++ b/src/System.Device.Gpio/Interop/Unix/SafeLineHandle.cs
@@ -19,8 +19,17 @@ namespace System.Device.Gpio
 
         protected override bool ReleaseHandle()
         {
+            // Contrary to intuition, this does not invalidate the handle (see comment on declaration)
             Interop.libgpiod.gpiod_line_release(handle);
             return true;
+        }
+
+        /// <summary>
+        /// Release the lock on the line handle. <see cref="Interop.libgpiod.gpiod_line_release"/>
+        /// </summary>
+        public void ReleaseLock()
+        {
+            ReleaseHandle();
         }
 
         public override bool IsInvalid => handle == IntPtr.Zero || handle == Interop.libgpiod.InvalidHandleValue;

--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
@@ -111,6 +111,13 @@ internal partial class Interop
         internal static extern void gpiod_line_release(IntPtr lineHandle);
 
         /// <summary>
+        /// Release a previously reserved line.
+        /// </summary>
+        /// <param name="lineHandle">GPIO line handle</param>
+        [DllImport(LibgpiodLibrary)]
+        internal static extern void gpiod_line_release(SafeLineHandle lineHandle);
+
+        /// <summary>
         /// Request all event type notifications on a single line.
         /// </summary>
         /// <param name="line">GPIO line handle</param>

--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
@@ -107,15 +107,11 @@ internal partial class Interop
         /// Release a previously reserved line.
         /// </summary>
         /// <param name="lineHandle">GPIO line handle</param>
+        /// <remarks>
+        /// This does NOT invalidate the line handle. This only releases the lock, so that a gpiod_line_request_input/gpiod_line_request_output can be called again.
+        /// </remarks>
         [DllImport(LibgpiodLibrary)]
         internal static extern void gpiod_line_release(IntPtr lineHandle);
-
-        /// <summary>
-        /// Release a previously reserved line.
-        /// </summary>
-        /// <param name="lineHandle">GPIO line handle</param>
-        [DllImport(LibgpiodLibrary)]
-        internal static extern void gpiod_line_release(SafeLineHandle lineHandle);
 
         /// <summary>
         /// Request all event type notifications on a single line.

--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
@@ -74,9 +74,10 @@ internal partial class Interop
         /// </summary>
         /// <param name="line">GPIO line handle</param>
         /// <param name="consumer">Name of the consumer.</param>
+        /// <param name="default_val">Initial value of the line</param>
         /// <returns>0 if the line was properly reserved, -1 on failure.</returns>
         [DllImport(LibgpiodLibrary, SetLastError = true)]
-        internal static extern int gpiod_line_request_output(SafeLineHandle line, string consumer);
+        internal static extern int gpiod_line_request_output(SafeLineHandle line, string consumer, int default_val);
 
         /// <summary>
         /// Set the value of a single GPIO line.

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/HummingBoardDriver.cs
@@ -89,6 +89,9 @@ namespace System.Device.Gpio.Drivers
         protected internal override void SetPinMode(int pinNumber, PinMode mode) => _internalDriver.SetPinMode(pinNumber, mode);
 
         /// <inheritdoc/>
+        protected internal override void SetPinMode(int pinNumber, PinMode mode, PinValue initialValue) => _internalDriver.SetPinMode(pinNumber, mode, initialValue);
+
+        /// <inheritdoc/>
         protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken) => _internalDriver.WaitForEvent(pinNumber, eventTypes, cancellationToken);
 
         /// <inheritdoc/>

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
@@ -232,7 +232,9 @@ namespace System.Device.Gpio.Drivers
         {
             if (_pinNumberToSafeLineHandle.TryGetValue(pinNumber, out SafeLineHandle? pinHandle))
             {
-                Interop.libgpiod.gpiod_line_release(pinHandle);
+                // This call does not release the handle. It only releases the lock on the handle. Without this, changing the direction of a line is not possible.
+                // Line handles cannot be freed and are cached until the chip is closed.
+                pinHandle.ReleaseLock();
                 int requestResult = mode switch
                 {
                     PinMode.Input => Interop.libgpiod.gpiod_line_request_input(pinHandle, s_consumerName),

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
@@ -153,14 +153,14 @@ namespace System.Device.Gpio.Drivers
         {
             lock (_pinNumberLock)
             {
-            if (!_pinNumberToSafeLineHandle.TryGetValue(pinNumber, out SafeLineHandle? pinHandle))
-            {
+                if (!_pinNumberToSafeLineHandle.TryGetValue(pinNumber, out SafeLineHandle? pinHandle))
+                {
                     throw ExceptionHelper.GetInvalidOperationException(ExceptionResource.PinNotOpenedError,
                         pin: pinNumber);
-            }
+                }
 
-            return pinHandle.PinMode;
-        }
+                return pinHandle.PinMode;
+            }
         }
 
         /// <inheritdoc/>

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
@@ -257,6 +257,14 @@ namespace System.Device.Gpio.Drivers
             throw new InvalidOperationException($"Pin {pinNumber} is not open");
         }
 
+        /// <inheritdoc />
+        protected internal override void SetPinMode(int pinNumber, PinMode mode, PinValue initialValue)
+        {
+            // On the Raspberry Pi, we can Write the out value even if the mode is something other than out. It will take effect once we change the mode
+            Write(pinNumber, initialValue);
+            SetPinMode(pinNumber, mode);
+        }
+
         /// <inheritdoc/>
         protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
         {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -188,6 +188,9 @@ namespace System.Device.Gpio.Drivers
         protected internal override void SetPinMode(int pinNumber, PinMode mode) => _internalDriver.SetPinMode(pinNumber, mode);
 
         /// <inheritdoc/>
+        protected internal override void SetPinMode(int pinNumber, PinMode mode, PinValue initialValue) => _internalDriver.SetPinMode(pinNumber, mode, initialValue);
+
+        /// <inheritdoc/>
         protected internal override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken) => _internalDriver.WaitForEvent(pinNumber, eventTypes, cancellationToken);
 
         /// <inheritdoc/>

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
@@ -239,6 +239,13 @@ namespace System.Device.Gpio.Drivers
             }
         }
 
+        protected internal override void SetPinMode(int pinNumber, PinMode mode, PinValue initialValue)
+        {
+            // On the Raspberry Pi, we can Write the out value even if the mode is something other than out. It will take effect once we change the mode
+            Write(pinNumber, initialValue);
+            SetPinMode(pinNumber, mode);
+        }
+
         /// <summary>
         /// Sets the resistor pull up/down mode for an input pin.
         /// </summary>

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -228,11 +228,6 @@ namespace System.Device.Gpio
             }
 
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
-            if (_driver.GetPinMode(logicalPinNumber) != PinMode.Output)
-            {
-                throw new InvalidOperationException($"Can not write to pin {logicalPinNumber} because it is not set to Output mode.");
-            }
-
             _driver.Write(logicalPinNumber, value);
         }
 

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -128,7 +128,14 @@ namespace System.Device.Gpio
         public void OpenPin(int pinNumber, PinMode mode, PinValue initialValue)
         {
             OpenPin(pinNumber);
-            Write(pinNumber, initialValue);
+            if (GetPinMode(pinNumber) == PinMode.Output)
+            {
+                // If we're opening in output mode, set the desired value before changing the mode to avoid glitches.
+                // Otherwise skip this, as it would toggle the output if the pin mode is currently Output but the
+                // desired value is input
+                Write(pinNumber, initialValue);
+            }
+
             SetPinMode(pinNumber, mode);
         }
 

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -34,7 +34,7 @@ namespace System.Device.Gpio
         /// <summary>
         /// Last value that was written to the pin, or null if it was opened as input and never written. Uses logical pin number addressing
         /// </summary>
-        private readonly PinValue?[] _desiredPinValues;
+        private readonly Dictionary<int, PinValue?> _desiredPinValues;
         private GpioDriver _driver;
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace System.Device.Gpio
             _driver = driver;
             NumberingScheme = numberingScheme;
             _openPins = new HashSet<int>();
-            _desiredPinValues = new PinValue?[driver.PinCount];
+            _desiredPinValues = new Dictionary<int, PinValue?>();
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace System.Device.Gpio
             _openPins.Remove(pinNumber);
 
             int logicalPinNumber = GetLogicalPinNumber(pinNumber);
-            _desiredPinValues[logicalPinNumber] = null;
+            _desiredPinValues.Remove(logicalPinNumber);
         }
 
         /// <summary>
@@ -184,8 +184,7 @@ namespace System.Device.Gpio
                 throw new InvalidOperationException($"Pin {pinNumber} does not support mode {mode}.");
             }
 
-            var desired = _desiredPinValues[logicalPinNumber];
-            if (desired.HasValue)
+            if (_desiredPinValues.TryGetValue(logicalPinNumber, out var desired) && desired.HasValue)
             {
                 _driver.SetPinMode(logicalPinNumber, mode, desired.Value);
             }

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -144,6 +144,7 @@ namespace System.Device.Gpio
 
             ClosePinCore(pinNumber);
             _openPins.Remove(pinNumber);
+            _desiredPinValues[pinNumber] = null;
         }
 
         /// <summary>

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -129,13 +129,8 @@ namespace System.Device.Gpio
         public void OpenPin(int pinNumber, PinMode mode, PinValue initialValue)
         {
             OpenPin(pinNumber);
-            if (GetPinMode(pinNumber) == PinMode.Output)
-            {
-                // If we're opening in output mode, set the desired value before changing the mode to avoid glitches.
-                // Otherwise skip this, as it would toggle the output if the pin mode is currently Output but the
-                // desired value is input
-                Write(pinNumber, initialValue);
-            }
+            // Set the desired initial value
+            _openPins[pinNumber] = initialValue;
 
             SetPinMode(pinNumber, mode);
         }

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Device.Gpio.Drivers;
 using System.Threading;
@@ -29,7 +30,7 @@ namespace System.Device.Gpio
         /// <summary>
         /// If a pin element exists, that pin is open. Uses current controller's numbering scheme
         /// </summary>
-        private readonly Dictionary<int, PinValue?> _openPins;
+        private readonly ConcurrentDictionary<int, PinValue?> _openPins;
         private GpioDriver _driver;
 
         /// <summary>
@@ -49,7 +50,7 @@ namespace System.Device.Gpio
         {
             _driver = driver;
             NumberingScheme = numberingScheme;
-            _openPins = new Dictionary<int, PinValue?>();
+            _openPins = new ConcurrentDictionary<int, PinValue?>();
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace System.Device.Gpio
             }
 
             OpenPinCore(pinNumber);
-            _openPins.Add(pinNumber, null);
+            _openPins.TryAdd(pinNumber, null);
         }
 
         /// <summary>
@@ -151,7 +152,7 @@ namespace System.Device.Gpio
             }
 
             ClosePinCore(pinNumber);
-            _openPins.Remove(pinNumber);
+            _openPins.TryRemove(pinNumber, out _);
         }
 
         /// <summary>

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -193,19 +193,6 @@ namespace System.Device.Gpio
         }
 
         /// <summary>
-        /// Sets the mode to a pin and sets an initial value for an output pin.
-        /// </summary>
-        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
-        /// <param name="mode">The mode to be set.</param>
-        /// <param name="initialValue">The initial value if the <paramref name="mode"/> is output. The driver will do it's best to prevent glitches to the other value when
-        /// changing from input to output.</param>
-        public void SetPinMode(int pinNumber, PinMode mode, PinValue initialValue)
-        {
-            Write(pinNumber, initialValue);
-            SetPinMode(pinNumber, mode);
-        }
-
-        /// <summary>
         /// Gets the mode of a pin.
         /// </summary>
         /// <param name="pinNumber">The pin number in the controller's numbering scheme.</param>

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
@@ -52,7 +52,6 @@ namespace System.Device.Gpio
         /// changing from input to output.</param>
         protected internal virtual void SetPinMode(int pinNumber, PinMode mode, PinValue initialValue)
         {
-            // TODO: Find out which driver support this atomically
             SetPinMode(pinNumber, mode);
             if (mode == PinMode.Output)
             {

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
@@ -44,6 +44,23 @@ namespace System.Device.Gpio
         protected internal abstract void SetPinMode(int pinNumber, PinMode mode);
 
         /// <summary>
+        /// Sets the mode to a pin and sets an initial value for an output pin.
+        /// </summary>
+        /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>
+        /// <param name="mode">The mode to be set.</param>
+        /// <param name="initialValue">The initial value if the <paramref name="mode"/> is output. The driver will do it's best to prevent glitches to the other value when
+        /// changing from input to output.</param>
+        protected internal virtual void SetPinMode(int pinNumber, PinMode mode, PinValue initialValue)
+        {
+            // TODO: Find out which driver support this atomically
+            SetPinMode(pinNumber, mode);
+            if (mode == PinMode.Output)
+            {
+                Write(pinNumber, initialValue);
+            }
+        }
+
+        /// <summary>
         /// Gets the mode of a pin.
         /// </summary>
         /// <param name="pinNumber">The pin number in the driver's logical numbering scheme.</param>


### PR DESCRIPTION
Fixes #721 
Fixes https://github.com/dotnet/iot/issues/1222
Superseedes #1361 

Adds two new methods to GpioController:
```csharp
OpenPin(int pinNumber, PinMode mode, PinValue initialValue);
SetPinMode(int pinNumber, PinMode mode, PinValue initialValue);
```

Writing a value before changing the mode, so that the pin immediatelly enters that state (or stays where it is), seems to work just fine on the Raspi. The other boards will currently emulate the feature as good as possible (libgpiod seems to have a separate problem that changing modes always fails). 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1473)