### PR TITLE
Fixing Firmata test run case

### DIFF
--- a/src/devices/Arduino/tests/ApiBehaviorTests.cs
+++ b/src/devices/Arduino/tests/ApiBehaviorTests.cs
@@ -12,6 +12,7 @@ namespace Iot.Device.Arduino.Tests
     /// Extending this class with more unit tests would require Moq'ing the Firmata interface. This is not currently possible.
     /// Simulating on the stream level is probably not worth the effort - better get the simulator to work automatically.
     /// </summary>
+    [Trait("feature", "firmata")]
     public sealed class ApiBehaviorTests : IDisposable
     {
         private Mock<Stream> _streamMock;

--- a/src/devices/Arduino/tests/Arduino.Tests.csproj
+++ b/src/devices/Arduino/tests/Arduino.Tests.csproj
@@ -4,7 +4,9 @@
     <TargetFrameworks>net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile> 
+    <!-- We don't want to run hardware test by default -->
+    <VSTestTestCaseFilter Condition="'$(VSTestTestCaseFilter)'==''">requires!=hardware</VSTestTestCaseFilter>    
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,8 +18,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    </PackageReference>    
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
 

--- a/src/devices/Arduino/tests/BasicFirmataIntegrationTests.cs
+++ b/src/devices/Arduino/tests/BasicFirmataIntegrationTests.cs
@@ -27,7 +27,6 @@ namespace Iot.Device.Arduino.Tests
         public BasicFirmataIntegrationTests(FirmataTestFixture fixture)
         {
             _fixture = fixture;
-            // Skip.If(_fixture.Board == null, "No Board found");
             Board = _fixture.Board ?? throw new Exception("Couldn't find the board");
         }
 

--- a/src/devices/Arduino/tests/BasicFirmataIntegrationTests.cs
+++ b/src/devices/Arduino/tests/BasicFirmataIntegrationTests.cs
@@ -18,6 +18,8 @@ namespace Iot.Device.Arduino.Tests
     /// Basic firmata integrations tests. These tests require functional hardware, that is an Arduino, loaded with a matching firmata firmware. It can also
     /// run against the *ExtendedConfigurableFirmata" simulator. If neither is found, the test is marked as "Inconclusive".
     /// </summary>
+    [Trait("feature", "firmata")]
+    [Trait("requires", "hardware")]
     public sealed class BasicFirmataIntegrationTests : IClassFixture<FirmataTestFixture>
     {
         private readonly FirmataTestFixture _fixture;
@@ -25,8 +27,8 @@ namespace Iot.Device.Arduino.Tests
         public BasicFirmataIntegrationTests(FirmataTestFixture fixture)
         {
             _fixture = fixture;
-            Skip.If(_fixture.Board == null, "No Board found");
-            Board = _fixture.Board;
+            // Skip.If(_fixture.Board == null, "No Board found");
+            Board = _fixture.Board ?? throw new Exception("Couldn't find the board");
         }
 
         public ArduinoBoard Board
@@ -34,7 +36,7 @@ namespace Iot.Device.Arduino.Tests
             get;
         }
 
-        [SkippableFact]
+        [Fact]
         public void CheckFirmwareVersion()
         {
             Assert.False(string.IsNullOrWhiteSpace(Board.FirmwareName));
@@ -42,7 +44,7 @@ namespace Iot.Device.Arduino.Tests
             Assert.True(Board.FirmwareVersion >= Version.Parse("2.11"));
         }
 
-        [SkippableFact]
+        [Fact]
         public void CheckFirmataVersion()
         {
             Assert.NotNull(Board.FirmataVersion);
@@ -52,7 +54,7 @@ namespace Iot.Device.Arduino.Tests
         /// <summary>
         /// Verifies the pin capability message. Also verifies that the arduino is configured properly for these tests
         /// </summary>
-        [SkippableFact]
+        [Fact]
         public void CheckBoardFeatures()
         {
             var caps = Board.SupportedPinConfigurations;
@@ -66,7 +68,7 @@ namespace Iot.Device.Arduino.Tests
             Assert.True(caps.Count(x => x.PinModes.Contains(SupportedMode.Spi)) >= 3);
         }
 
-        [SkippableFact]
+        [Fact]
         public void CanBlink()
         {
             var ctrl = Board.CreateGpioController();
@@ -80,7 +82,7 @@ namespace Iot.Device.Arduino.Tests
             ctrl.ClosePin(6);
         }
 
-        [SkippableFact]
+        [Fact]
         public void SetPinMode()
         {
             var ctrl = Board.CreateGpioController();
@@ -98,7 +100,7 @@ namespace Iot.Device.Arduino.Tests
             ctrl.ClosePin(6);
         }
 
-        [SkippableFact]
+        [Fact]
         public void ReadAnalog()
         {
             int pinNumber = GetFirstAnalogPin(Board);

--- a/src/devices/Arduino/tests/README.md
+++ b/src/devices/Arduino/tests/README.md
@@ -1,3 +1,3 @@
 # How to run the Arduino Firmata tests
 
-it should be explicit use: `dotnet test --filter feature=firmata`
+In order to run all Firmata tests use: `dotnet test --filter feature=firmata`

--- a/src/devices/Arduino/tests/README.md
+++ b/src/devices/Arduino/tests/README.md
@@ -1,0 +1,3 @@
+# How to run the Arduino Firmata tests
+
+it should be explicit use: `dotnet test --filter feature=firmata`


### PR DESCRIPTION
This fix the Firmata hardware Arduino test not to run if not explicitly asked. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1481)