### PR TITLE
ignore Interrupted system call error and retry

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.cs
@@ -11,6 +11,8 @@ namespace System.Device.Gpio.Drivers
 {
     internal sealed class LibGpiodDriverEventHandler : IDisposable
     {
+        private const int ERROR_CODE_EINTR = 4; // Interrupted system call
+
         private static string s_consumerName = Process.GetCurrentProcess().ProcessName;
 
         public event PinChangeEventHandler? ValueRising;
@@ -55,7 +57,14 @@ namespace System.Device.Gpio.Drivers
                     WaitEventResult waitResult = Interop.libgpiod.gpiod_line_event_wait(pinHandle, ref timeout);
                     if (waitResult == WaitEventResult.Error)
                     {
-                        throw ExceptionHelper.GetIOException(ExceptionResource.EventWaitError, Marshal.GetLastWin32Error(), _pinNumber);
+                        var errorCode = Marshal.GetLastWin32Error();
+                        if (errorCode == ERROR_CODE_EINTR)
+                        {
+                            // ignore Interrupted system call error and retry
+                            continue;
+                        }
+
+                        throw ExceptionHelper.GetIOException(ExceptionResource.EventWaitError, errorCode, _pinNumber);
                     }
 
                     if (waitResult == WaitEventResult.EventOccured)


### PR DESCRIPTION
Fixes #1210
Libgpiod method gpiod_line_event_wait can be interrupted and return error code 4 (Interrupted system call).
In this case we can ignore Interrupted system call error continue waiting for events.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1499)