### PR TITLE
remove last trace of autoDispose

### DIFF
--- a/src/devices/GoPiGo3/samples/README.md
+++ b/src/devices/GoPiGo3/samples/README.md
@@ -59,4 +59,4 @@ while (!Console.KeyAvailable)
 }
 ```
 
-Please keep in mind that default behavior when GoPiGo is disposed, the SpiDevice as well. You can override this default behavior by changing ```autoDispose``` to false.
+Please keep in mind that default behavior when GoPiGo is disposed, the SpiDevice as well. You can override this default behavior by changing ```shouldDispose``` to false.


### PR DESCRIPTION
Related to #1272 in updating documentation to change ```autoDispose``` to be the new ```shouldDispose``` name.  This is the final reference to ```autoDispose``` that I have found in the repo.
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1523)