### PR TITLE
Add .NET Standard 2.0 as target

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -26,7 +26,6 @@
 
   <Target Name="BuildProduct">
     <ItemGroup>
-      <_ExcludeBuildProductProjects Include="$(MSBuildThisFileDirectory)src\Iot.Device.Bindings\Iot.Device.Bindings.csproj" />
       <_ExcludeBuildProductProjects Include="$(MSBuildThisFileDirectory)src\Native\build-native.proj" />
       <_BuildProductProjects Include="$(MSBuildThisFileDirectory)src\**\*.csproj" Exclude="@(_ExcludeBuildProductProjects);@(UnitTestProjects)" />
     </ItemGroup>

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -19,6 +19,19 @@
     <!-- Excluding samples and test projects when getting source files -->
     <_ExcludeProjectReferences Include="$(DeviceRoot)**/samples/**/*.csproj" />
     <_ExcludeProjectReferences Include="$(DeviceRoot)**/tests/**/*.csproj" />
+
+    <!-- These projects are not currently supported on Netstandard. The Netstandard build is mostly for use in projects targeting
+    the .NET Framework, where these bindings have little use.-->
+    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/BoardLed/BoardLed.csproj" />
+    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/BrickPi3/BrickPi3.csproj" />
+    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/GrovePi/GrovePiDevice.csproj" />
+    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/GoPiGo3/GoPiGo3.csproj" />
+    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/SocketCan/SocketCan.csproj" />
+    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/Media/Media.csproj" />
+    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/OneWire/OneWire.csproj" />
+    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/PiJuice/PiJuice.csproj" />
+    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/RGBLedMatrix/RGBLedMatrix.csproj" />
+    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/SenseHat/SenseHat.csproj" />
 
     <ProjectReference Include="$(DeviceRoot)**/*.csproj" Exclude="@(_ExcludeProjectReferences)" ReferenceOutputAssembly="false" BuildReference="false" />
   </ItemGroup>

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -28,9 +28,7 @@
     <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/GoPiGo3/GoPiGo3.csproj" />
     <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/SocketCan/SocketCan.csproj" />
     <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/Media/Media.csproj" />
-    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/OneWire/OneWire.csproj" />
     <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/RGBLedMatrix/RGBLedMatrix.csproj" />
-    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/SenseHat/SenseHat.csproj" />
 
     <ProjectReference Include="$(DeviceRoot)**/*.csproj" Exclude="@(_ExcludeProjectReferences)" ReferenceOutputAssembly="false" BuildReference="false" />
   </ItemGroup>

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -14,12 +14,14 @@
     <!--Disabling default items so samples source won't get build by the main library-->
   </PropertyGroup>
   
-  <!-- The following ItemGroup is in charge of getting the source files we will compile on each TFM -->
   <ItemGroup>
     <!-- Excluding samples and test projects when getting source files -->
     <_ExcludeProjectReferences Include="$(DeviceRoot)**/samples/**/*.csproj" />
     <_ExcludeProjectReferences Include="$(DeviceRoot)**/tests/**/*.csproj" />
+  </ItemGroup>
 
+  <!-- The following ItemGroup is in charge of getting the source files we will compile on each TFM -->
+  <ItemGroup>
     <ProjectReference Include="$(DeviceRoot)**/*.csproj" Exclude="@(_ExcludeProjectReferences)" ReferenceOutputAssembly="false" BuildReference="false" />
   </ItemGroup>
 

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -20,16 +20,6 @@
     <_ExcludeProjectReferences Include="$(DeviceRoot)**/samples/**/*.csproj" />
     <_ExcludeProjectReferences Include="$(DeviceRoot)**/tests/**/*.csproj" />
 
-    <!-- These projects are not currently supported on Netstandard. The Netstandard build is mostly for use in projects targeting
-    the .NET Framework, where these bindings have little use.-->
-    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/BoardLed/BoardLed.csproj" />
-    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/BrickPi3/BrickPi3.csproj" />
-    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/GrovePi/GrovePiDevice.csproj" />
-    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/GoPiGo3/GoPiGo3.csproj" />
-    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/SocketCan/SocketCan.csproj" />
-    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/Media/Media.csproj" />
-    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/RGBLedMatrix/RGBLedMatrix.csproj" />
-
     <ProjectReference Include="$(DeviceRoot)**/*.csproj" Exclude="@(_ExcludeProjectReferences)" ReferenceOutputAssembly="false" BuildReference="false" />
   </ItemGroup>
 

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -29,7 +29,6 @@
     <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/SocketCan/SocketCan.csproj" />
     <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/Media/Media.csproj" />
     <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/OneWire/OneWire.csproj" />
-    <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/PiJuice/PiJuice.csproj" />
     <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/RGBLedMatrix/RGBLedMatrix.csproj" />
     <_ExcludeProjectReferences Condition="$(TargetFramework)=='netstandard2.0'" Include="$(DeviceRoot)/SenseHat/SenseHat.csproj" />
 

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/devices/AD5328/AD5328.csproj
+++ b/src/devices/AD5328/AD5328.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/AD5328/AD5328.csproj
+++ b/src/devices/AD5328/AD5328.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ads1115/Ads1115.csproj
+++ b/src/devices/Ads1115/Ads1115.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ads1115/Ads1115.csproj
+++ b/src/devices/Ads1115/Ads1115.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Adxl345/Adxl345.csproj
+++ b/src/devices/Adxl345/Adxl345.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Adxl345/Adxl345.csproj
+++ b/src/devices/Adxl345/Adxl345.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Adxl357/Adxl357.csproj
+++ b/src/devices/Adxl357/Adxl357.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Adxl357/Adxl357.csproj
+++ b/src/devices/Adxl357/Adxl357.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ags01db/Ags01db.csproj
+++ b/src/devices/Ags01db/Ags01db.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ags01db/Ags01db.csproj
+++ b/src/devices/Ags01db/Ags01db.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ahtxx/Ahtxx.csproj
+++ b/src/devices/Ahtxx/Ahtxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Ahtxx/Ahtxx.csproj
+++ b/src/devices/Ahtxx/Ahtxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net48;</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Ahtxx/Ahtxx.csproj
+++ b/src/devices/Ahtxx/Ahtxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net48;</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Ak8963/Ak8963.csproj
+++ b/src/devices/Ak8963/Ak8963.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ak8963/Ak8963.csproj
+++ b/src/devices/Ak8963/Ak8963.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Amg88xx/Amg88xx.csproj
+++ b/src/devices/Amg88xx/Amg88xx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Amg88xx/Amg88xx.csproj
+++ b/src/devices/Amg88xx/Amg88xx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Apa102/Apa102.csproj
+++ b/src/devices/Apa102/Apa102.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Apa102/Apa102.csproj
+++ b/src/devices/Apa102/Apa102.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Arduino/Arduino.csproj
+++ b/src/devices/Arduino/Arduino.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RootNamespace>Iot.Device.Arduino</RootNamespace>
   </PropertyGroup>

--- a/src/devices/Arduino/Arduino.csproj
+++ b/src/devices/Arduino/Arduino.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RootNamespace>Iot.Device.Arduino</RootNamespace>
   </PropertyGroup>

--- a/src/devices/Arduino/ArduinoBoard.cs
+++ b/src/devices/Arduino/ArduinoBoard.cs
@@ -93,7 +93,7 @@ namespace Iot.Device.Arduino
         /// <param name="board">[Out] Returns the board reference. It is already initialized.</param>
         /// <returns>True on success, false if no board was found</returns>
         public static bool TryFindBoard(IEnumerable<string> comPorts, IEnumerable<int> baudRates,
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
             [NotNullWhen(true)]
 #endif
             out ArduinoBoard? board)
@@ -131,7 +131,7 @@ namespace Iot.Device.Arduino
         /// <see cref="TryFindBoard(System.Collections.Generic.IEnumerable{string},System.Collections.Generic.IEnumerable{int},out Iot.Device.Arduino.ArduinoBoard?)"/> overload excluding ports that shall not be tested.
         /// </remarks>
         public static bool TryFindBoard(
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
             [NotNullWhen(true)]
 #endif
             out ArduinoBoard? board)

--- a/src/devices/Arduino/samples/Arduino.Monitor.csproj
+++ b/src/devices/Arduino/samples/Arduino.Monitor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <RootNamespace>Iot.Device.Arduino.Sample</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AssemblyName>Arduino.Monitor</AssemblyName>

--- a/src/devices/Arduino/samples/Arduino.Monitor.csproj
+++ b/src/devices/Arduino/samples/Arduino.Monitor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <RootNamespace>Iot.Device.Arduino.Sample</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AssemblyName>Arduino.Monitor</AssemblyName>

--- a/src/devices/Arduino/samples/Arduino.sample.csproj
+++ b/src/devices/Arduino/samples/Arduino.sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <RootNamespace>Iot.Device.Arduino.Sample</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AssemblyName>Arduino.sample</AssemblyName>

--- a/src/devices/Arduino/samples/Arduino.sample.csproj
+++ b/src/devices/Arduino/samples/Arduino.sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <RootNamespace>Iot.Device.Arduino.Sample</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AssemblyName>Arduino.sample</AssemblyName>

--- a/src/devices/Bh1745/Bh1745.csproj
+++ b/src/devices/Bh1745/Bh1745.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Bh1745/Bh1745.csproj
+++ b/src/devices/Bh1745/Bh1745.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
@@ -11,6 +11,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)/../Common/System/Runtime/CompilerServices/IsExternalInit.cs" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <None Include="README.md" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Bh1745/Bh1745.sln
+++ b/src/devices/Bh1745/Bh1745.sln
@@ -1,15 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{EA121A48-7916-4D9D-94C8-8E59BCDE3A96}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bh1745.Sample", "samples\Bh1745.Sample.csproj", "{24A728CA-F4EF-4DB0-B13F-65FFD772352B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bh1745.Sample", "samples\Bh1745.Sample.csproj", "{24A728CA-F4EF-4DB0-B13F-65FFD772352B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bh1745CustomConfiguration.Sample", "samples\Bh1745CustomConfiguration.Sample.csproj", "{F6ED35EA-2FDE-4056-8165-0FAB6CE5DD5E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bh1745CustomConfiguration.Sample", "samples\Bh1745CustomConfiguration.Sample.csproj", "{F6ED35EA-2FDE-4056-8165-0FAB6CE5DD5E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bh1745", "Bh1745.csproj", "{C572C86D-5BB2-4610-84EA-768257758933}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bh1745", "Bh1745.csproj", "{C572C86D-5BB2-4610-84EA-768257758933}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{195588CF-3E28-4CCA-B529-123708FAD880}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,9 +21,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{24A728CA-F4EF-4DB0-B13F-65FFD772352B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -60,9 +59,27 @@ Global
 		{C572C86D-5BB2-4610-84EA-768257758933}.Release|x64.Build.0 = Release|Any CPU
 		{C572C86D-5BB2-4610-84EA-768257758933}.Release|x86.ActiveCfg = Release|Any CPU
 		{C572C86D-5BB2-4610-84EA-768257758933}.Release|x86.Build.0 = Release|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Debug|x64.Build.0 = Debug|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Debug|x86.Build.0 = Debug|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Release|Any CPU.Build.0 = Release|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Release|x64.ActiveCfg = Release|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Release|x64.Build.0 = Release|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Release|x86.ActiveCfg = Release|Any CPU
+		{195588CF-3E28-4CCA-B529-123708FAD880}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{24A728CA-F4EF-4DB0-B13F-65FFD772352B} = {EA121A48-7916-4D9D-94C8-8E59BCDE3A96}
 		{F6ED35EA-2FDE-4056-8165-0FAB6CE5DD5E} = {EA121A48-7916-4D9D-94C8-8E59BCDE3A96}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E5265435-CEAB-4096-A7F2-30C5E9ED025E}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/Bh1750fvi/Bh1750fvi.csproj
+++ b/src/devices/Bh1750fvi/Bh1750fvi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Bh1750fvi/Bh1750fvi.csproj
+++ b/src/devices/Bh1750fvi/Bh1750fvi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Bmp180/Bmp180.csproj
+++ b/src/devices/Bmp180/Bmp180.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Bmp180/Bmp180.csproj
+++ b/src/devices/Bmp180/Bmp180.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Bmxx80/Bmxx80.csproj
+++ b/src/devices/Bmxx80/Bmxx80.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Bmxx80/Bmxx80.csproj
+++ b/src/devices/Bmxx80/Bmxx80.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Bmxx80/Bmxx80Base.cs
+++ b/src/devices/Bmxx80/Bmxx80Base.cs
@@ -83,7 +83,7 @@ namespace Iot.Device.Bmxx80
 
             ReadCalibrationData();
             Reset();
-#if NETCOREAPP2_1
+#if !NET5_0_OR_GREATER
             if (_calibrationData is null)
             {
                 throw new Exception("BMxx80 device is not correctly configured.");
@@ -304,7 +304,7 @@ namespace Iot.Device.Bmxx80
             BigEndian
         }
 
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
         [MemberNotNull(nameof(_calibrationData))]
 #endif
         private void ReadCalibrationData()

--- a/src/devices/Bmxx80/tests/Bmxx80.Tests.csproj
+++ b/src/devices/Bmxx80/tests/Bmxx80.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net48;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net48</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/devices/Bmxx80/tests/Bmxx80.Tests.csproj
+++ b/src/devices/Bmxx80/tests/Bmxx80.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net48;</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/devices/Bno055/Bno055.csproj
+++ b/src/devices/Bno055/Bno055.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Bno055/Bno055.csproj
+++ b/src/devices/Bno055/Bno055.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Board/Board.csproj
+++ b/src/devices/Board/Board.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <LangVersion>preview</LangVersion>
     <RootNamespace>Iot.Device.Board</RootNamespace>

--- a/src/devices/BoardLed/BoardLed.cs
+++ b/src/devices/BoardLed/BoardLed.cs
@@ -119,15 +119,7 @@ namespace Iot.Device.BoardLed
 
         private void SetBrightness(int value)
         {
-            if (value < 0)
-            {
-                value = 0;
-            }
-
-            if (value > 255)
-            {
-                value = 255;
-            }
+            value = MathExtensions.Clamp(value, 0, 255);
 
             _brightnessWriter.BaseStream.SetLength(0);
             _brightnessWriter.Write(value);

--- a/src/devices/BoardLed/BoardLed.cs
+++ b/src/devices/BoardLed/BoardLed.cs
@@ -66,7 +66,7 @@ namespace Iot.Device.BoardLed
         {
             Name = name;
             Initialize();
-#if NETCOREAPP2_1
+#if !NET5_0_OR_GREATER
             if (_brightnessReader is null ||
                 _brightnessWriter is null ||
                 _maxBrightnessReader is null ||
@@ -119,7 +119,16 @@ namespace Iot.Device.BoardLed
 
         private void SetBrightness(int value)
         {
-            value = Math.Clamp(value, 0, 255);
+            if (value < 0)
+            {
+                value = 0;
+            }
+
+            if (value > 255)
+            {
+                value = 255;
+            }
+
             _brightnessWriter.BaseStream.SetLength(0);
             _brightnessWriter.Write(value);
             _brightnessWriter.Flush();
@@ -145,7 +154,7 @@ namespace Iot.Device.BoardLed
             _triggerWriter.Flush();
         }
 
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
         [MemberNotNull(nameof(_brightnessReader), nameof(_brightnessWriter), nameof(_triggerReader), nameof(_triggerWriter), nameof(_maxBrightnessReader))]
 #endif
         private void Initialize()

--- a/src/devices/BoardLed/BoardLed.csproj
+++ b/src/devices/BoardLed/BoardLed.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/BoardLed/BoardLed.csproj
+++ b/src/devices/BoardLed/BoardLed.csproj
@@ -9,4 +9,8 @@
     <Compile Include="BoardLed.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/devices/BoardLed/BoardLed.csproj
+++ b/src/devices/BoardLed/BoardLed.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/BoardLed/BoardLed.csproj
+++ b/src/devices/BoardLed/BoardLed.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/BoardLed/BoardLed.sln
+++ b/src/devices/BoardLed/BoardLed.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{E3BCE30D-56D7-422C-B77A-6C47739C6EC2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoardLed.Sample", "samples\BoardLed.Sample.csproj", "{F2A31327-2447-4F7C-9659-717ADAE282F3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BoardLed.Sample", "samples\BoardLed.Sample.csproj", "{F2A31327-2447-4F7C-9659-717ADAE282F3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoardLed", "BoardLed.csproj", "{3A4798D1-FC49-46C0-8774-0519EB7987C2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BoardLed", "BoardLed.csproj", "{3A4798D1-FC49-46C0-8774-0519EB7987C2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F2A31327-2447-4F7C-9659-717ADAE282F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{3A4798D1-FC49-46C0-8774-0519EB7987C2}.Release|x64.Build.0 = Release|Any CPU
 		{3A4798D1-FC49-46C0-8774-0519EB7987C2}.Release|x86.ActiveCfg = Release|Any CPU
 		{3A4798D1-FC49-46C0-8774-0519EB7987C2}.Release|x86.Build.0 = Release|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Debug|x64.Build.0 = Debug|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Debug|x86.Build.0 = Debug|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Release|x64.ActiveCfg = Release|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Release|x64.Build.0 = Release|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Release|x86.ActiveCfg = Release|Any CPU
+		{FF04E59C-5C7E-44C7-B322-D11DFDEBC769}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{F2A31327-2447-4F7C-9659-717ADAE282F3} = {E3BCE30D-56D7-422C-B77A-6C47739C6EC2}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E0A2A2A9-304F-4964-81E1-7D9475FA6AE8}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/BrickPi3/BrickPi3.csproj
+++ b/src/devices/BrickPi3/BrickPi3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/BrickPi3/BrickPi3.csproj
+++ b/src/devices/BrickPi3/BrickPi3.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <None Include="README.md" />
   </ItemGroup>
 

--- a/src/devices/BrickPi3/BrickPi3.csproj
+++ b/src/devices/BrickPi3/BrickPi3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/BrickPi3/BrickPi3.sln
+++ b/src/devices/BrickPi3/BrickPi3.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{424441BB-88AF-47CB-9120-2003DBD91788}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrickPi3.samples", "samples\BrickPi3.samples.csproj", "{B015B30B-0C71-450A-903E-627F439D45CC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BrickPi3.samples", "samples\BrickPi3.samples.csproj", "{B015B30B-0C71-450A-903E-627F439D45CC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrickPi3", "BrickPi3.csproj", "{AFEC6FF8-C770-4F7A-B2A3-7BA82466E91F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BrickPi3", "BrickPi3.csproj", "{AFEC6FF8-C770-4F7A-B2A3-7BA82466E91F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{CD70B1FE-53D8-48DB-AEBA-C3995A373144}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B015B30B-0C71-450A-903E-627F439D45CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{AFEC6FF8-C770-4F7A-B2A3-7BA82466E91F}.Release|x64.Build.0 = Release|Any CPU
 		{AFEC6FF8-C770-4F7A-B2A3-7BA82466E91F}.Release|x86.ActiveCfg = Release|Any CPU
 		{AFEC6FF8-C770-4F7A-B2A3-7BA82466E91F}.Release|x86.Build.0 = Release|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Debug|x64.Build.0 = Debug|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Debug|x86.Build.0 = Debug|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Release|x64.ActiveCfg = Release|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Release|x64.Build.0 = Release|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Release|x86.ActiveCfg = Release|Any CPU
+		{CD70B1FE-53D8-48DB-AEBA-C3995A373144}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B015B30B-0C71-450A-903E-627F439D45CC} = {424441BB-88AF-47CB-9120-2003DBD91788}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {568B6C0F-D6E3-439B-B544-737C05035D6B}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/BrickPi3/Movement/Motor.cs
+++ b/src/devices/BrickPi3/Movement/Motor.cs
@@ -58,7 +58,7 @@ namespace Iot.Device.BrickPi3.Movement
         /// <param name="speed">speed is between -255 and +255</param>
         public void SetSpeed(int speed)
         {
-            speed = Math.Clamp(speed, -255, 255);
+            speed = MathExtensions.Clamp(speed, -255, 255);
             _brick.SetMotorPower((byte)Port, speed);
             OnPropertyChanged(nameof(Speed));
         }

--- a/src/devices/BrickPi3/Movement/Vehicle.cs
+++ b/src/devices/BrickPi3/Movement/Vehicle.cs
@@ -224,7 +224,7 @@ namespace Iot.Device.BrickPi3.Movement
 
         private void StartMotor(int port, int speed)
         {
-            speed = Math.Clamp(speed, -255, 255);
+            speed = MathExtensions.Clamp(speed, -255, 255);
             _brick.SetMotorPower((byte)port, speed);
         }
 

--- a/src/devices/Buzzer/Buzzer.csproj
+++ b/src/devices/Buzzer/Buzzer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Buzzer/Buzzer.csproj
+++ b/src/devices/Buzzer/Buzzer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Card/CardRfid.csproj
+++ b/src/devices/Card/CardRfid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Card/CardRfid.csproj
+++ b/src/devices/Card/CardRfid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Card/CreditCard/CreditCard.cs
+++ b/src/devices/Card/CreditCard/CreditCard.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.PortableExecutable;
 using System.Text;
 using Iot.Device.Common;
 using Microsoft.Extensions.Logging;

--- a/src/devices/Card/CreditCard/CreditCardProcessing.csproj
+++ b/src/devices/Card/CreditCard/CreditCardProcessing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Card/CreditCard/CreditCardProcessing.csproj
+++ b/src/devices/Card/CreditCard/CreditCardProcessing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Card/Mifare/Mifare.csproj
+++ b/src/devices/Card/Mifare/Mifare.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Card/Mifare/Mifare.csproj
+++ b/src/devices/Card/Mifare/Mifare.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Ccs811/Ccs811.csproj
+++ b/src/devices/Ccs811/Ccs811.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ccs811/Ccs811.csproj
+++ b/src/devices/Ccs811/Ccs811.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/CharacterLcd/CharacterLcd.csproj
+++ b/src/devices/CharacterLcd/CharacterLcd.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/CharacterLcd/CharacterLcd.csproj
+++ b/src/devices/CharacterLcd/CharacterLcd.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/CharacterLcd/LcdConsole.cs
+++ b/src/devices/CharacterLcd/LcdConsole.cs
@@ -223,7 +223,7 @@ namespace Iot.Device.CharacterLcd
 
             text = text.Replace("\r\n", "\n"); // Change to linux format only, so we have to consider only this case further
 
-            List<string> lines = text.Split("\n", StringSplitOptions.None).ToList();
+            List<string> lines = text.Split('\n').ToList();
             FindLineWraps(CursorLeft, lines);
             for (int i = 0; i < lines.Count; i++)
             {

--- a/src/devices/CharacterLcd/tests/CharacterLcd.Tests.csproj
+++ b/src/devices/CharacterLcd/tests/CharacterLcd.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net48</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/devices/CharacterLcd/tests/CharacterLcd.Tests.csproj
+++ b/src/devices/CharacterLcd/tests/CharacterLcd.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net48</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/devices/Charlieplex/Charlieplex.csproj
+++ b/src/devices/Charlieplex/Charlieplex.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Charlieplex/Charlieplex.csproj
+++ b/src/devices/Charlieplex/Charlieplex.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Common/CommonHelpers.csproj
+++ b/src/devices/Common/CommonHelpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RootNamespace></RootNamespace>
     <Nullable>enable</Nullable>

--- a/src/devices/Common/CommonHelpers.csproj
+++ b/src/devices/Common/CommonHelpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RootNamespace></RootNamespace>
     <Nullable>enable</Nullable>

--- a/src/devices/Common/CommonHelpers.csproj
+++ b/src/devices/Common/CommonHelpers.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="*.cs" />
+    <Compile Include="MathExtensions.cs" />
     <Compile Include="Iot/Device/Common/*.cs" />
     <Compile Include="Iot/Device/Graphics/*.cs" />
     <Compile Include="Iot/Device/Multiplexing/*.cs" />    
@@ -18,6 +18,11 @@
     <Compile Include="System/Device/Spi/*.cs" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <Compile Include="FrameworkCompatibilityExtensions.cs" />
+    <Compile Include="IsExternalInit.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Common/FrameworkCompatibilityExtensions.cs
+++ b/src/devices/Common/FrameworkCompatibilityExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -45,6 +46,19 @@ namespace Iot.Device
             {
                 buffer[i] = (byte)random.Next();
             }
+        }
+
+        public static void Write(this Stream stream, Span<byte> data)
+        {
+            stream.Write(data.ToArray(), 0, data.Length);
+        }
+
+        public static int Read(this Stream stream, Span<byte> data)
+        {
+            byte[] rawData = new byte[data.Length];
+            int result = stream.Read(rawData, 0, rawData.Length);
+            rawData.CopyTo(data);
+            return result;
         }
 
         /// <summary>

--- a/src/devices/Common/FrameworkCompatibilityExtensions.cs
+++ b/src/devices/Common/FrameworkCompatibilityExtensions.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#pragma warning disable CS1591 // Missing documentation (these methods are mostly hidden from the user)
+#if NETFRAMEWORK
+namespace Iot.Device
+{
+    /// <summary>
+    /// .NET Core compatibility helper functions (methods that do not exist in .NET Framework)
+    /// </summary>
+    public static class FrameworkCompatibilityExtensions
+    {
+        public static bool StartsWith(this Span<char> span, string value)
+        {
+            return span.StartsWith(new ReadOnlySpan<char>(value.ToCharArray()));
+        }
+
+        public static bool StartsWith(this Span<char> span, string value, StringComparison comparison)
+        {
+            return span.ToString().StartsWith(value, comparison);
+        }
+
+        public static bool StartsWith(this ReadOnlySpan<char> span, string value, StringComparison comparison)
+        {
+            return span.ToString().StartsWith(value, comparison);
+        }
+
+        public static int CompareTo(this ReadOnlySpan<char> span, string value, StringComparison comparison)
+        {
+            return string.Compare(span.ToString(), value, comparison);
+        }
+
+        public static string GetString(this Encoding encoding, Span<byte> input)
+        {
+            return encoding.GetString(input.ToArray());
+        }
+
+        public static void NextBytes(this Random random, Span<byte> buffer)
+        {
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                buffer[i] = (byte)random.Next();
+            }
+        }
+
+        /// <summary>
+        /// Attempts to add the specified key and value to the dictionary.
+        /// </summary>
+        /// <typeparam name="TKey">Type of key</typeparam>
+        /// <typeparam name="TValue">Type of value</typeparam>
+        /// <param name="dictionary">Dictionary</param>
+        /// <param name="key">Key to add</param>
+        /// <param name="value">Value to add</param>
+        /// <returns>True if the value was added, false otherwise. No exception is thrown</returns>
+        public static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        {
+            if (dictionary.ContainsKey(key))
+            {
+                return false;
+            }
+
+            dictionary.Add(key, value);
+            return true;
+        }
+    }
+}
+
+#pragma warning disable SA1403 // File may only contain a single namespace
+namespace System.Runtime.CompilerServices
+#pragma warning restore SA1403 // File may only contain a single namespace
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class IsExternalInit
+    {
+    }
+}
+#endif

--- a/src/devices/Common/FrameworkCompatibilityExtensions.cs
+++ b/src/devices/Common/FrameworkCompatibilityExtensions.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 #pragma warning disable CS1591 // Missing documentation (these methods are mostly hidden from the user)
-#if NETFRAMEWORK
+#if NETSTANDARD2_0
 namespace Iot.Device
 {
     /// <summary>
@@ -69,17 +69,4 @@ namespace Iot.Device
     }
 }
 
-#pragma warning disable SA1403 // File may only contain a single namespace
-namespace System.Runtime.CompilerServices
-#pragma warning restore SA1403 // File may only contain a single namespace
-{
-    /// <summary>
-    /// Reserved to be used by the compiler for tracking metadata.
-    /// This class should not be used by developers in source code.
-    /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static class IsExternalInit
-    {
-    }
-}
 #endif

--- a/src/devices/Common/FrameworkCompatibilityExtensions.cs
+++ b/src/devices/Common/FrameworkCompatibilityExtensions.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 #pragma warning disable CS1591 // Missing documentation (these methods are mostly hidden from the user)
-#if NETSTANDARD2_0
 namespace Iot.Device
 {
     /// <summary>
@@ -82,5 +78,3 @@ namespace Iot.Device
         }
     }
 }
-
-#endif

--- a/src/devices/Common/Iot/Device/Common/SimpleConsoleLogger.cs
+++ b/src/devices/Common/Iot/Device/Common/SimpleConsoleLogger.cs
@@ -21,7 +21,7 @@ namespace Iot.Device.Common
         }
 
         /// <summary>
-        /// Specifies the minimum log level that is printed. Default is <see cref="LogLevel.Information"/>
+        /// Specifies the minimum log level that is printed. Default is Information
         /// </summary>
         public LogLevel MinLogLevel
         {

--- a/src/devices/Common/Iot/Device/Graphics/LcdCharacterEncoding.cs
+++ b/src/devices/Common/Iot/Device/Graphics/LcdCharacterEncoding.cs
@@ -13,11 +13,11 @@ namespace Iot.Device.Graphics
     /// </summary>
     public class LcdCharacterEncoding : Encoding
     {
-        private Dictionary<char, byte> _characterMapping;
-        private char _unknownLetter;
+        private readonly Dictionary<char, byte> _characterMapping;
+        private readonly char _unknownLetter;
         // Character pixel maps for characters that will need to be written to the character RAM for this code page
-        private List<byte[]> _extraCharacters;
-        private string _cultureName;
+        private readonly List<byte[]> _extraCharacters;
+        private readonly string _cultureName;
 
         /// <summary>
         /// Creates an instance of <see cref="LcdCharacterEncoding"/>.
@@ -25,7 +25,7 @@ namespace Iot.Device.Graphics
         /// <param name="cultureName">Culture name for this encoding (informational only)</param>
         /// <param name="readOnlyMemoryName">Name of the ROM (hard coded read-only character memory) on the display</param>
         /// <param name="characterMap">The character map to use</param>
-        /// <param name="unknownLetter">The character to print when a letter not in the map is found</param>
+        /// <param name="unknownLetter">The character to print when a letter not in the map is found. This letter must be part of the map</param>
         public LcdCharacterEncoding(string cultureName, string readOnlyMemoryName, Dictionary<char, byte> characterMap, char unknownLetter)
         {
             _cultureName = cultureName;
@@ -34,6 +34,10 @@ namespace Iot.Device.Graphics
             _extraCharacters = new List<byte[]>();
             AllCharactersSupported = true;
             ReadOnlyMemoryName = readOnlyMemoryName;
+            if (!_characterMapping.ContainsKey(unknownLetter))
+            {
+                throw new ArgumentException($"The replacement letter {unknownLetter} is not part of the character map", nameof(unknownLetter));
+            }
         }
 
         /// <summary>

--- a/src/devices/Common/Iot/Device/Graphics/LcdCharacterEncoding.cs
+++ b/src/devices/Common/Iot/Device/Graphics/LcdCharacterEncoding.cs
@@ -102,7 +102,7 @@ namespace Iot.Device.Graphics
                 }
                 else
                 {
-                    bytes[byteIndex] = _characterMapping.GetValueOrDefault(_unknownLetter);
+                    bytes[byteIndex] = _characterMapping[_unknownLetter];
                 }
 
                 byteIndex++;

--- a/src/devices/Common/IsExternalInit.cs
+++ b/src/devices/Common/IsExternalInit.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#if NETSTANDARD2_0
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// This dummy class is required to compile records when targeting .NET Standard
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class IsExternalInit
+    {
+    }
+}
+#endif

--- a/src/devices/Common/IsExternalInit.cs
+++ b/src/devices/Common/IsExternalInit.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
 
-#if NETSTANDARD2_0
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
@@ -18,4 +12,3 @@ namespace System.Runtime.CompilerServices
     {
     }
 }
-#endif

--- a/src/devices/Common/MathExtensions.cs
+++ b/src/devices/Common/MathExtensions.cs
@@ -16,7 +16,7 @@ namespace Iot.Device
         /// </summary>
         public static double Clamp(double val, double min, double max)
         {
-#if NETFRAMEWORK
+#if NETSTANDARD2_0
             if (val < min)
             {
                 return min;
@@ -38,7 +38,7 @@ namespace Iot.Device
         /// </summary>
         public static int Clamp(int val, int min, int max)
         {
-#if NETFRAMEWORK
+#if NETSTANDARD2_0
             if (val < min)
             {
                 return min;

--- a/src/devices/Common/MathExtensions.cs
+++ b/src/devices/Common/MathExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -14,6 +15,7 @@ namespace Iot.Device
         /// <summary>
         /// Returns val, limited to the range min-max (inclusive)
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Clamp(double val, double min, double max)
         {
 #if NETSTANDARD2_0
@@ -36,7 +38,77 @@ namespace Iot.Device
         /// <summary>
         /// Returns val, limited to the range min-max (inclusive)
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Clamp(int val, int min, int max)
+        {
+#if NETSTANDARD2_0
+            if (val < min)
+            {
+                return min;
+            }
+
+            if (val > max)
+            {
+                return max;
+            }
+
+            return val;
+#else
+            return Math.Clamp(val, min, max);
+#endif
+        }
+
+        /// <summary>
+        /// Returns val, limited to the range min-max (inclusive)
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte Clamp(byte val, byte min, byte max)
+        {
+#if NETSTANDARD2_0
+            if (val < min)
+            {
+                return min;
+            }
+
+            if (val > max)
+            {
+                return max;
+            }
+
+            return val;
+#else
+            return Math.Clamp(val, min, max);
+#endif
+        }
+
+        /// <summary>
+        /// Returns val, limited to the range min-max (inclusive)
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Clamp(long val, long min, long max)
+        {
+#if NETSTANDARD2_0
+            if (val < min)
+            {
+                return min;
+            }
+
+            if (val > max)
+            {
+                return max;
+            }
+
+            return val;
+#else
+            return Math.Clamp(val, min, max);
+#endif
+        }
+
+        /// <summary>
+        /// Returns val, limited to the range min-max (inclusive)
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint Clamp(uint val, uint min, uint max)
         {
 #if NETSTANDARD2_0
             if (val < min)

--- a/src/devices/Common/MathExtensions.cs
+++ b/src/devices/Common/MathExtensions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Iot.Device
+{
+    /// <summary>
+    /// Implementations of some functions missing in older .NET versions
+    /// </summary>
+    public static class MathExtensions
+    {
+        /// <summary>
+        /// Returns val, limited to the range min-max (inclusive)
+        /// </summary>
+        public static double Clamp(double val, double min, double max)
+        {
+#if NETFRAMEWORK
+            if (val < min)
+            {
+                return min;
+            }
+
+            if (val > max)
+            {
+                return max;
+            }
+
+            return val;
+#else
+            return Math.Clamp(val, min, max);
+#endif
+        }
+
+        /// <summary>
+        /// Returns val, limited to the range min-max (inclusive)
+        /// </summary>
+        public static int Clamp(int val, int min, int max)
+        {
+#if NETFRAMEWORK
+            if (val < min)
+            {
+                return min;
+            }
+
+            if (val > max)
+            {
+                return max;
+            }
+
+            return val;
+#else
+            return Math.Clamp(val, min, max);
+#endif
+        }
+    }
+}

--- a/src/devices/Common/tests/Common.Tests.csproj
+++ b/src/devices/Common/tests/Common.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net48</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/devices/Common/tests/FrameworkCompatibilityExtensionsTest.cs
+++ b/src/devices/Common/tests/FrameworkCompatibilityExtensionsTest.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Iot.Device.Common.Tests
+{
+    public class FrameworkCompatibilityExtensionsTest
+    {
+        [Fact]
+        public void SpanTests()
+        {
+            string hello = "Hello!";
+            ReadOnlySpan<char> helloSpan = hello.AsSpan();
+            Assert.True(helloSpan.StartsWith("He", StringComparison.OrdinalIgnoreCase));
+            Assert.True(helloSpan.StartsWith("hello", StringComparison.OrdinalIgnoreCase));
+            Assert.True(helloSpan.Contains("!".AsSpan(), StringComparison.Ordinal));
+            string hello2 = "Hello!";
+            Assert.True(helloSpan.CompareTo(hello2.AsSpan(), StringComparison.CurrentCulture) == 0);
+        }
+
+        [Fact]
+        public void StreamTests()
+        {
+            MemoryStream ms = new MemoryStream();
+            byte[] data = new byte[10];
+            data[0] = 10;
+            Span<byte> helloSpan = data.AsSpan();
+            ms.Write(helloSpan);
+            ms.Position = 0;
+
+            Span<byte> reply = stackalloc byte[10];
+            ms.Read(reply);
+            Assert.Equal(data.ToList(), reply.ToArray());
+        }
+    }
+}

--- a/src/devices/Common/tests/MathExtensionsTest.cs
+++ b/src/devices/Common/tests/MathExtensionsTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Iot.Device.Common.Tests
+{
+    /// <summary>
+    /// Note that these tests test the framework implementation in .NET Core based builds
+    /// </summary>
+    public class MathExtensionsTest
+    {
+        [Fact]
+        public void ClampDouble()
+        {
+            Assert.Equal(23.0, MathExtensions.Clamp(23.0, 0.0, 100.0));
+            Assert.Equal(0.0, MathExtensions.Clamp(-10, 0.0, 100.0));
+            Assert.Equal(100.0, MathExtensions.Clamp(222, 0.0, 100.0));
+        }
+
+        [Fact]
+        public void ClampByte()
+        {
+            Assert.Equal(23, MathExtensions.Clamp((byte)23, (byte)0, (byte)100));
+            Assert.Equal(0, MathExtensions.Clamp((byte)0, (byte)0, (byte)100));
+            Assert.Equal(100, MathExtensions.Clamp((byte)200, (byte)0, (byte)100));
+        }
+
+        [Fact]
+        public void ClampInt()
+        {
+            Assert.Equal(2000, MathExtensions.Clamp(200, 2000, 10000));
+            Assert.Equal(-10, MathExtensions.Clamp(-100, -10, 100));
+            Assert.Equal(500, MathExtensions.Clamp(600, -10, 500));
+        }
+
+        [Fact]
+        public void ClampUint()
+        {
+            Assert.Equal(2000u, MathExtensions.Clamp(200u, 2000u, 10000u));
+            Assert.Equal(10u, MathExtensions.Clamp(0u, 10u, 100u));
+            Assert.Equal(500u, MathExtensions.Clamp(600u, 10u, 500u));
+        }
+    }
+}

--- a/src/devices/CpuTemperature/CpuTemperature.csproj
+++ b/src/devices/CpuTemperature/CpuTemperature.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/CpuTemperature/CpuTemperature.csproj
+++ b/src/devices/CpuTemperature/CpuTemperature.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/DCMotor/DCMotor.csproj
+++ b/src/devices/DCMotor/DCMotor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -14,5 +14,7 @@
     <Compile Include="DCMotor2PinWithBiDirectionalPin.cs" />
     <None Include="README.md" />
   </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/devices/DCMotor/DCMotor.csproj
+++ b/src/devices/DCMotor/DCMotor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/DCMotor/DCMotor.sln
+++ b/src/devices/DCMotor/DCMotor.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{516FDA54-2B34-4701-BFE3-DC983BE19B0F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DCMotor.sample", "samples\DCMotor.sample.csproj", "{20EFC80F-EF6C-4B37-826F-B1681973C27F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DCMotor.sample", "samples\DCMotor.sample.csproj", "{20EFC80F-EF6C-4B37-826F-B1681973C27F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DCMotor", "DCMotor.csproj", "{A94399DE-7398-46DD-921F-8B39BC809209}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DCMotor", "DCMotor.csproj", "{A94399DE-7398-46DD-921F-8B39BC809209}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{335712A6-9249-42DA-A590-04704BCC1CCC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{20EFC80F-EF6C-4B37-826F-B1681973C27F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{A94399DE-7398-46DD-921F-8B39BC809209}.Release|x64.Build.0 = Release|Any CPU
 		{A94399DE-7398-46DD-921F-8B39BC809209}.Release|x86.ActiveCfg = Release|Any CPU
 		{A94399DE-7398-46DD-921F-8B39BC809209}.Release|x86.Build.0 = Release|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Debug|x64.Build.0 = Debug|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Debug|x86.Build.0 = Debug|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Release|x64.ActiveCfg = Release|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Release|x64.Build.0 = Release|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Release|x86.ActiveCfg = Release|Any CPU
+		{335712A6-9249-42DA-A590-04704BCC1CCC}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{20EFC80F-EF6C-4B37-826F-B1681973C27F} = {516FDA54-2B34-4701-BFE3-DC983BE19B0F}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E76DFDD3-405F-4A42-8C61-442320F99580}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/DCMotor/DCMotor2PinNoEnable.cs
+++ b/src/devices/DCMotor/DCMotor2PinNoEnable.cs
@@ -46,7 +46,7 @@ namespace Iot.Device.DCMotor
             get => _speed;
             set
             {
-                double val = Math.Clamp(value, _pin1 != -1 ? -1.0 : 0.0, 1.0);
+                double val = MathExtensions.Clamp(value, _pin1 != -1 ? -1.0 : 0.0, 1.0);
 
                 if (_speed == val)
                 {

--- a/src/devices/DCMotor/DCMotor2PinWithBiDirectionalPin.cs
+++ b/src/devices/DCMotor/DCMotor2PinWithBiDirectionalPin.cs
@@ -52,7 +52,7 @@ namespace Iot.Device.DCMotor
             }
             set
             {
-                double val = Math.Clamp(value, _dirPin != -1 ? -1.0 : 0.0, 1.0);
+                double val = MathExtensions.Clamp(value, _dirPin != -1 ? -1.0 : 0.0, 1.0);
 
                 if (_speed == val)
                 {

--- a/src/devices/DCMotor/DCMotor3Pin.cs
+++ b/src/devices/DCMotor/DCMotor3Pin.cs
@@ -57,7 +57,7 @@ namespace Iot.Device.DCMotor
             }
             set
             {
-                double val = Math.Clamp(value, -1.0, 1.0);
+                double val = MathExtensions.Clamp(value, -1.0, 1.0);
 
                 if (_speed == val)
                 {

--- a/src/devices/Dhtxx/Dhtxx.csproj
+++ b/src/devices/Dhtxx/Dhtxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Dhtxx/Dhtxx.csproj
+++ b/src/devices/Dhtxx/Dhtxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -3,6 +3,7 @@
   <Import Project="../../eng/Versions.props" />
   <Import Project="../../eng/Analyzers.props" />
   <PropertyGroup>
+    <TargetFrameworksBase>net5.0;netcoreapp2.1;net48;</TargetFrameworksBase>
     <NoWarn>$(NoWarn);CS8321</NoWarn>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
     <IsPackable>false</IsPackable>
@@ -12,6 +13,7 @@
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  
 
   <ItemGroup>
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -3,7 +3,10 @@
   <Import Project="../../eng/Versions.props" />
   <Import Project="../../eng/Analyzers.props" />
   <PropertyGroup>
+    <!-- Most projects should use this value to build for all possible target frameworks -->
     <TargetFrameworksBase>net5.0;netcoreapp2.1;netstandard2.0;</TargetFrameworksBase>
+    <!-- If .NET Standard is not supported (and adding support is not useful) use this instead -->
+    <TargetFrameworksReduced>net5.0;netcoreapp2.1</TargetFrameworksReduced>
     <NoWarn>$(NoWarn);CS8321</NoWarn>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
     <IsPackable>false</IsPackable>

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -14,7 +14,6 @@
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  
 
   <ItemGroup>
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="../../eng/Versions.props" />
   <Import Project="../../eng/Analyzers.props" />
   <PropertyGroup>
-    <TargetFrameworksBase>net5.0;netcoreapp2.1;net48;</TargetFrameworksBase>
+    <TargetFrameworksBase>net5.0;netcoreapp2.1;netstandard2.0;</TargetFrameworksBase>
     <NoWarn>$(NoWarn);CS8321</NoWarn>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
     <IsPackable>false</IsPackable>

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -4,7 +4,7 @@
   <Import Project="../../eng/Analyzers.props" />
   <PropertyGroup>
     <!-- Most projects should use this value to build for all possible target frameworks -->
-    <TargetFrameworksBase>net5.0;netcoreapp2.1;netstandard2.0;</TargetFrameworksBase>
+    <DefaultBindingTfms>net5.0;netcoreapp2.1;netstandard2.0;</DefaultBindingTfms>
     <NoWarn>$(NoWarn);CS8321</NoWarn>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
     <IsPackable>false</IsPackable>

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -5,8 +5,6 @@
   <PropertyGroup>
     <!-- Most projects should use this value to build for all possible target frameworks -->
     <TargetFrameworksBase>net5.0;netcoreapp2.1;netstandard2.0;</TargetFrameworksBase>
-    <!-- If .NET Standard is not supported (and adding support is not useful) use this instead -->
-    <TargetFrameworksReduced>net5.0;netcoreapp2.1</TargetFrameworksReduced>
     <NoWarn>$(NoWarn);CS8321</NoWarn>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
     <IsPackable>false</IsPackable>

--- a/src/devices/Display/Display.csproj
+++ b/src/devices/Display/Display.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Display/Display.csproj
+++ b/src/devices/Display/Display.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/ExplorerHat/ExplorerHat.csproj
+++ b/src/devices/ExplorerHat/ExplorerHat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/ExplorerHat/ExplorerHat.csproj
+++ b/src/devices/ExplorerHat/ExplorerHat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ft4222/Ft4222.csproj
+++ b/src/devices/Ft4222/Ft4222.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ft4222/Ft4222.csproj
+++ b/src/devices/Ft4222/Ft4222.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/GoPiGo3/GoPiGo3.cs
+++ b/src/devices/GoPiGo3/GoPiGo3.cs
@@ -392,7 +392,7 @@ namespace Iot.Device.GoPiGo3
         /// <param name="power">The power from - 100 to 100, or -128 for float</param>
         public void SetMotorPower(MotorPort port, int power)
         {
-            power = Math.Clamp(power, -128, 127);
+            power = MathExtensions.Clamp(power, -128, 127);
             byte bPower = (byte)(power & 0xFF);
             byte[] outArray = { SpiAddress, (byte)SpiMessageType.SetMotorPower, (byte)port, bPower };
             var ret = SpiTransferArray(outArray);
@@ -594,7 +594,7 @@ namespace Iot.Device.GoPiGo3
         /// <param name="duty">The PWM duty cycle in percent from 0.0 to 100.0, 1 floating point precision</param>
         public void SetGrovePwmDuty(GrovePort port, double duty)
         {
-            duty = Math.Clamp(duty, (byte)0, (byte)100);
+            duty = MathExtensions.Clamp(duty, (byte)0, (byte)100);
 
             var duty_value = (UInt16)(duty * 10.0);
             byte[] outArray = { SpiAddress, (byte)SpiMessageType.SetGrovePwmDuty, (byte)port, (byte)((duty_value >> 8) & 0xFF), (byte)(duty_value & 0xFF) };
@@ -608,7 +608,7 @@ namespace Iot.Device.GoPiGo3
         /// <param name="freq">The PWM frequency.Range is 3 through 48000Hz.Default is 24000(24kHz). Limit to 48000, which is the highest frequency supported for 0.1% resolution.</param>
         public void GetGrovePwmFrequency(GrovePort port, uint freq = 24000)
         {
-            freq = Math.Clamp(freq, 3, 48000);
+            freq = MathExtensions.Clamp(freq, 3, 48000);
             byte[] outArray = { SpiAddress, (byte)SpiMessageType.SetGrovePwmFrequency, (byte)port, (byte)((freq >> 8) & 0xFF), (byte)(freq & 0xFF) };
             SpiTransferArray(outArray);
         }
@@ -661,7 +661,7 @@ namespace Iot.Device.GoPiGo3
             // but make sure we wait a minimum of 1 ms
             if (towait > 0)
             {
-                timeout = Math.Clamp(timeout, 1, 32);
+                timeout = MathExtensions.Clamp(timeout, 1, 32);
                 Thread.Sleep((int)timeout);
             }
 

--- a/src/devices/GoPiGo3/GoPiGo3.csproj
+++ b/src/devices/GoPiGo3/GoPiGo3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/GoPiGo3/GoPiGo3.csproj
+++ b/src/devices/GoPiGo3/GoPiGo3.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>

--- a/src/devices/GoPiGo3/GoPiGo3.csproj
+++ b/src/devices/GoPiGo3/GoPiGo3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/GoPiGo3/GoPiGo3.sln
+++ b/src/devices/GoPiGo3/GoPiGo3.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{7C994138-50A2-422A-8F2B-DCA860C0DF30}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GoPiGo3.sample", "samples\GoPiGo3.sample.csproj", "{0F42F9DC-6064-4A7A-8338-59DA604784B7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GoPiGo3.sample", "samples\GoPiGo3.sample.csproj", "{0F42F9DC-6064-4A7A-8338-59DA604784B7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GoPiGo3", "GoPiGo3.csproj", "{11A7D68C-6F57-4E7B-ACC3-1B024603C32C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GoPiGo3", "GoPiGo3.csproj", "{11A7D68C-6F57-4E7B-ACC3-1B024603C32C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{8D2DF499-D68D-4496-AF56-A2663D952E1B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0F42F9DC-6064-4A7A-8338-59DA604784B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{11A7D68C-6F57-4E7B-ACC3-1B024603C32C}.Release|x64.Build.0 = Release|Any CPU
 		{11A7D68C-6F57-4E7B-ACC3-1B024603C32C}.Release|x86.ActiveCfg = Release|Any CPU
 		{11A7D68C-6F57-4E7B-ACC3-1B024603C32C}.Release|x86.Build.0 = Release|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Debug|x64.Build.0 = Debug|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Debug|x86.Build.0 = Debug|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Release|x64.ActiveCfg = Release|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Release|x64.Build.0 = Release|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Release|x86.ActiveCfg = Release|Any CPU
+		{8D2DF499-D68D-4496-AF56-A2663D952E1B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0F42F9DC-6064-4A7A-8338-59DA604784B7} = {7C994138-50A2-422A-8F2B-DCA860C0DF30}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {989B67CE-B2F0-4751-8629-CA7210A35A19}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/GoPiGo3/Movements/Motor.cs
+++ b/src/devices/GoPiGo3/Movements/Motor.cs
@@ -69,7 +69,7 @@ namespace Iot.Device.GoPiGo3.Movements
         /// <param name="speed">speed is between -255 and +255</param>
         public void SetSpeed(int speed)
         {
-            speed = Math.Clamp(speed, -255, 255);
+            speed = MathExtensions.Clamp(speed, -255, 255);
             _goPiGo.SetMotorPower(Port, speed);
         }
 

--- a/src/devices/GoPiGo3/Movements/Vehicle.cs
+++ b/src/devices/GoPiGo3/Movements/Vehicle.cs
@@ -201,7 +201,7 @@ namespace Iot.Device.GoPiGo3.Movements
 
         private void StartMotor(MotorPort port, int speed)
         {
-            speed = Math.Clamp(speed, -255, 255);
+            speed = MathExtensions.Clamp(speed, -255, 255);
             _goPiGo.SetMotorPower(port, speed);
         }
 

--- a/src/devices/GoPiGo3/Sensors/Buzzer.cs
+++ b/src/devices/GoPiGo3/Sensors/Buzzer.cs
@@ -62,7 +62,7 @@ namespace Iot.Device.GoPiGo3.Sensors
             set
             {
                 var prev = _duty;
-                _duty = Math.Clamp(value, (byte)0, (byte)100);
+                _duty = MathExtensions.Clamp(value, (byte)0, (byte)100);
                 if (prev != _duty)
                 {
                     Start();

--- a/src/devices/Gpio/Iot.Device.Gpio.csproj
+++ b/src/devices/Gpio/Iot.Device.Gpio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/devices/Gpio/Iot.Device.Gpio.csproj
+++ b/src/devices/Gpio/Iot.Device.Gpio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/devices/GrovePi/GrovePi.sln
+++ b/src/devices/GrovePi/GrovePi.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{61C135C2-1483-4B3D-8070-27A0DE4AF808}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GrovePiDevice.sample", "samples\GrovePiDevice.sample.csproj", "{3EB7131B-0DF9-43FB-9101-950A8A0581BE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GrovePiDevice.sample", "samples\GrovePiDevice.sample.csproj", "{3EB7131B-0DF9-43FB-9101-950A8A0581BE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GrovePiDevice", "GrovePiDevice.csproj", "{0E37E7A7-C104-41F0-BF03-20BFFB6CE10E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GrovePiDevice", "GrovePiDevice.csproj", "{0E37E7A7-C104-41F0-BF03-20BFFB6CE10E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3EB7131B-0DF9-43FB-9101-950A8A0581BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{0E37E7A7-C104-41F0-BF03-20BFFB6CE10E}.Release|x64.Build.0 = Release|Any CPU
 		{0E37E7A7-C104-41F0-BF03-20BFFB6CE10E}.Release|x86.ActiveCfg = Release|Any CPU
 		{0E37E7A7-C104-41F0-BF03-20BFFB6CE10E}.Release|x86.Build.0 = Release|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Debug|x64.Build.0 = Debug|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Debug|x86.Build.0 = Debug|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Release|x64.ActiveCfg = Release|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Release|x64.Build.0 = Release|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Release|x86.ActiveCfg = Release|Any CPU
+		{71908DF8-A1DD-47AF-86F8-5FEF5139AC6B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{3EB7131B-0DF9-43FB-9101-950A8A0581BE} = {61C135C2-1483-4B3D-8070-27A0DE4AF808}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {993750A5-C041-461D-BB7F-4E697A279723}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/GrovePi/GrovePiDevice.csproj
+++ b/src/devices/GrovePi/GrovePiDevice.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/GrovePi/GrovePiDevice.csproj
+++ b/src/devices/GrovePi/GrovePiDevice.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>

--- a/src/devices/GrovePi/GrovePiDevice.csproj
+++ b/src/devices/GrovePi/GrovePiDevice.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/GrovePi/Sensors/DhtSensor.cs
+++ b/src/devices/GrovePi/Sensors/DhtSensor.cs
@@ -94,8 +94,8 @@ namespace Iot.Device.GrovePiDevice.Sensors
             // This is needed for firmware 1.4.0 and also working for previous versions
             Thread.Sleep(300);
             var retArray = _grovePi.ReadCommand(GrovePiCommand.DhtTemp, _port);
-            _lastTemHum[0] = BitConverter.ToSingle(retArray.AsSpan(1, 4));
-            _lastTemHum[1] = BitConverter.ToSingle(retArray.AsSpan(5, 4));
+            _lastTemHum[0] = BitConverter.ToSingle(retArray!, 1);
+            _lastTemHum[1] = BitConverter.ToSingle(retArray!, 5);
         }
 
         /// <summary>

--- a/src/devices/GrovePi/Sensors/LedBar.cs
+++ b/src/devices/GrovePi/Sensors/LedBar.cs
@@ -167,7 +167,7 @@ namespace Iot.Device.GrovePiDevice.Sensors
         /// <param name="led">The led from 0 to 10</param>
         public void ToggleLeds(byte led)
         {
-            led = Math.Clamp(led, (byte)0, (byte)10);
+            led = MathExtensions.Clamp(led, (byte)0, (byte)10);
             _grovePi.WriteCommand(GrovePiCommand.LedBarToggleOneLed, _port, led, 0);
         }
 

--- a/src/devices/GrovePi/Sensors/PwmOutput.cs
+++ b/src/devices/GrovePi/Sensors/PwmOutput.cs
@@ -77,7 +77,7 @@ namespace Iot.Device.GrovePiDevice.Sensors
             set
             {
                 var prev = _duty;
-                _duty = Math.Clamp(value, (byte)0, (byte)100);
+                _duty = MathExtensions.Clamp(value, (byte)0, (byte)100);
                 if (prev != _duty)
                 {
                     Start();

--- a/src/devices/HardwareMonitor/HardwareMonitor.csproj
+++ b/src/devices/HardwareMonitor/HardwareMonitor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/HardwareMonitor/HardwareMonitor.csproj
+++ b/src/devices/HardwareMonitor/HardwareMonitor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/HardwareMonitor/OpenHardwareMonitor.cs
+++ b/src/devices/HardwareMonitor/OpenHardwareMonitor.cs
@@ -313,7 +313,7 @@ namespace Iot.Device.HardwareMonitor
         /// <exception cref="NotSupportedException">There were multiple sensors found, but they return different units (i.e. CPU temperature is
         /// reported as Celsius for some cores and Fahrenheit for others)</exception>
         public bool TryGetAverage<T>(Hardware hardware,
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
         [NotNullWhen(true)]
 #endif
         out T? average)
@@ -328,13 +328,13 @@ namespace Iot.Device.HardwareMonitor
                 {
                     if (unitThatWasUsed == null)
                     {
-#if NETCOREAPP2_1
+#if !NET5_0_OR_GREATER
                         unitThatWasUsed = singleValue!.Unit;
 #else
                         unitThatWasUsed = singleValue.Unit;
 #endif
                     }
-#if NETCOREAPP2_1
+#if !NET5_0_OR_GREATER
                     else if (!unitThatWasUsed.Equals(singleValue!.Unit))
 #else
                     else if (!unitThatWasUsed.Equals(singleValue.Unit))
@@ -473,7 +473,7 @@ namespace Iot.Device.HardwareMonitor
                         {
                             if (elem.Sensor.TryGetValue(out IQuantity? value))
                             {
-#if NETCOREAPP2_1
+#if !NET5_0_OR_GREATER
                                 elem.OnNewValue(elem.Sensor, value!, timeSinceLastUpdate);
 #else
                                 elem.OnNewValue(elem.Sensor, value, timeSinceLastUpdate);
@@ -672,7 +672,7 @@ namespace Iot.Device.HardwareMonitor
             /// <param name="value">Returned value</param>
             /// <returns>True if a value was available</returns>
             public bool TryGetValue(
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
             [NotNullWhen(true)]
 #endif
             out IQuantity? value)
@@ -697,7 +697,7 @@ namespace Iot.Device.HardwareMonitor
             /// <param name="value">The returned value</param>
             /// <returns>True if a value of type T could be retrieved</returns>
             public bool TryGetValue<T>(
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
             [NotNullWhen(true)]
 #endif
             out T? value)

--- a/src/devices/Hcsr04/Hcsr04.csproj
+++ b/src/devices/Hcsr04/Hcsr04.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Hcsr04/Hcsr04.csproj
+++ b/src/devices/Hcsr04/Hcsr04.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Hcsr501/Hcsr501.csproj
+++ b/src/devices/Hcsr501/Hcsr501.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Hcsr501/Hcsr501.csproj
+++ b/src/devices/Hcsr501/Hcsr501.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Hmc5883l/Hmc5883l.csproj
+++ b/src/devices/Hmc5883l/Hmc5883l.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Hmc5883l/Hmc5883l.csproj
+++ b/src/devices/Hmc5883l/Hmc5883l.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Hts221/Hts221.csproj
+++ b/src/devices/Hts221/Hts221.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Hts221/Hts221.csproj
+++ b/src/devices/Hts221/Hts221.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ina219/Ina219.csproj
+++ b/src/devices/Ina219/Ina219.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Ina219/Ina219.csproj
+++ b/src/devices/Ina219/Ina219.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/KeyMatrix/KeyMatrix.cs
+++ b/src/devices/KeyMatrix/KeyMatrix.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Device.Gpio;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/devices/KeyMatrix/KeyMatrix.csproj
+++ b/src/devices/KeyMatrix/KeyMatrix.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/KeyMatrix/KeyMatrix.csproj
+++ b/src/devices/KeyMatrix/KeyMatrix.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/LidarLiteV3/LidarLiteV3.csproj
+++ b/src/devices/LidarLiteV3/LidarLiteV3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/LidarLiteV3/LidarLiteV3.csproj
+++ b/src/devices/LidarLiteV3/LidarLiteV3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/LiquidLevel/LiquidLevel.csproj
+++ b/src/devices/LiquidLevel/LiquidLevel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/LiquidLevel/LiquidLevel.csproj
+++ b/src/devices/LiquidLevel/LiquidLevel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Lm75/Lm75.csproj
+++ b/src/devices/Lm75/Lm75.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Lm75/Lm75.csproj
+++ b/src/devices/Lm75/Lm75.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Lps25h/Lps25h.csproj
+++ b/src/devices/Lps25h/Lps25h.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Lps25h/Lps25h.csproj
+++ b/src/devices/Lps25h/Lps25h.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Lsm9Ds1/Lsm9Ds1.csproj
+++ b/src/devices/Lsm9Ds1/Lsm9Ds1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Lsm9Ds1/Lsm9Ds1.csproj
+++ b/src/devices/Lsm9Ds1/Lsm9Ds1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Max31856/Max31856.csproj
+++ b/src/devices/Max31856/Max31856.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
     <LangVersion>9</LangVersion>

--- a/src/devices/Max31856/Max31856.csproj
+++ b/src/devices/Max31856/Max31856.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
     <LangVersion>9</LangVersion>

--- a/src/devices/Max31865/Max31865.csproj
+++ b/src/devices/Max31865/Max31865.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Max31865/Max31865.csproj
+++ b/src/devices/Max31865/Max31865.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -10,6 +10,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)/../Common/System/Runtime/CompilerServices/IsExternalInit.cs" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <Compile Include="*.cs" />
     <None Include="README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Max44009/Max44009.csproj
+++ b/src/devices/Max44009/Max44009.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Max44009/Max44009.csproj
+++ b/src/devices/Max44009/Max44009.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Max7219/Max7219.csproj
+++ b/src/devices/Max7219/Max7219.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems> <!--Disabling default items so samples source won't get build by the main library-->
     <RootNamespace>Iot.Device.Max7219</RootNamespace>
   </PropertyGroup>

--- a/src/devices/Max7219/Max7219.csproj
+++ b/src/devices/Max7219/Max7219.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems> <!--Disabling default items so samples source won't get build by the main library-->
     <RootNamespace>Iot.Device.Max7219</RootNamespace>
   </PropertyGroup>

--- a/src/devices/Mbi5027/Mbi5027.csproj
+++ b/src/devices/Mbi5027/Mbi5027.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mbi5027/Mbi5027.csproj
+++ b/src/devices/Mbi5027/Mbi5027.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mcp23xxx/Mcp23xxx.csproj
+++ b/src/devices/Mcp23xxx/Mcp23xxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mcp23xxx/Mcp23xxx.csproj
+++ b/src/devices/Mcp23xxx/Mcp23xxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mcp25xxx/Mcp25xxx.csproj
+++ b/src/devices/Mcp25xxx/Mcp25xxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mcp25xxx/Mcp25xxx.csproj
+++ b/src/devices/Mcp25xxx/Mcp25xxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mcp25xxx/tests/Mcp25xxx.Tests.csproj
+++ b/src/devices/Mcp25xxx/tests/Mcp25xxx.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net48;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net48</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/devices/Mcp25xxx/tests/Mcp25xxx.Tests.csproj
+++ b/src/devices/Mcp25xxx/tests/Mcp25xxx.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net48;</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/devices/Mcp3428/Mcp3428.csproj
+++ b/src/devices/Mcp3428/Mcp3428.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Mcp3428/Mcp3428.csproj
+++ b/src/devices/Mcp3428/Mcp3428.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Mcp3xxx/Mcp3xxx.csproj
+++ b/src/devices/Mcp3xxx/Mcp3xxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Mcp3xxx/Mcp3xxx.csproj
+++ b/src/devices/Mcp3xxx/Mcp3xxx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Mcp9808/Mcp9808.csproj
+++ b/src/devices/Mcp9808/Mcp9808.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mcp9808/Mcp9808.csproj
+++ b/src/devices/Mcp9808/Mcp9808.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Media/Media.csproj
+++ b/src/devices/Media/Media.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/devices/Media/Media.csproj
+++ b/src/devices/Media/Media.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/devices/Media/Media.csproj
+++ b/src/devices/Media/Media.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/devices/Media/SoundDevice/Devices/UnixSoundDevice.cs
+++ b/src/devices/Media/SoundDevice/Devices/UnixSoundDevice.cs
@@ -269,43 +269,43 @@ namespace Iot.Device.Media
             byte[] writeBuffer4 = new byte[4];
 
             writeBuffer4 = Encoding.ASCII.GetBytes(header.Chunk.ChunkId);
-            wavStream.Write(writeBuffer4);
+            wavStream.Write(writeBuffer4, 0, 4);
 
             BinaryPrimitives.WriteUInt32LittleEndian(writeBuffer4, header.Chunk.ChunkSize);
-            wavStream.Write(writeBuffer4);
+            wavStream.Write(writeBuffer4, 0, 4);
 
             writeBuffer4 = Encoding.ASCII.GetBytes(header.Format);
-            wavStream.Write(writeBuffer4);
+            wavStream.Write(writeBuffer4, 0, 4);
 
             writeBuffer4 = Encoding.ASCII.GetBytes(header.SubChunk1.ChunkId);
-            wavStream.Write(writeBuffer4);
+            wavStream.Write(writeBuffer4, 0, 4);
 
             BinaryPrimitives.WriteUInt32LittleEndian(writeBuffer4, header.SubChunk1.ChunkSize);
-            wavStream.Write(writeBuffer4);
+            wavStream.Write(writeBuffer4, 0, 4);
 
             BinaryPrimitives.WriteUInt16LittleEndian(writeBuffer2, header.AudioFormat);
-            wavStream.Write(writeBuffer2);
+            wavStream.Write(writeBuffer2, 0, 2);
 
             BinaryPrimitives.WriteUInt16LittleEndian(writeBuffer2, header.NumChannels);
-            wavStream.Write(writeBuffer2);
+            wavStream.Write(writeBuffer2, 0, 2);
 
             BinaryPrimitives.WriteUInt32LittleEndian(writeBuffer4, header.SampleRate);
-            wavStream.Write(writeBuffer4);
+            wavStream.Write(writeBuffer4, 0, 4);
 
             BinaryPrimitives.WriteUInt32LittleEndian(writeBuffer4, header.ByteRate);
-            wavStream.Write(writeBuffer4);
+            wavStream.Write(writeBuffer4, 0, 4);
 
             BinaryPrimitives.WriteUInt16LittleEndian(writeBuffer2, header.BlockAlign);
-            wavStream.Write(writeBuffer2);
+            wavStream.Write(writeBuffer2, 0, 2);
 
             BinaryPrimitives.WriteUInt16LittleEndian(writeBuffer2, header.BitsPerSample);
-            wavStream.Write(writeBuffer2);
+            wavStream.Write(writeBuffer2, 0, 2);
 
             writeBuffer4 = Encoding.ASCII.GetBytes(header.SubChunk2.ChunkId);
-            wavStream.Write(writeBuffer4);
+            wavStream.Write(writeBuffer4, 0, 4);
 
             BinaryPrimitives.WriteUInt32LittleEndian(writeBuffer4, header.SubChunk2.ChunkSize);
-            wavStream.Write(writeBuffer4);
+            wavStream.Write(writeBuffer4, 0, 4);
         }
 
         private WavHeader ReadWavHeader(Stream wavStream)

--- a/src/devices/Mfrc522/Mfrc522.csproj
+++ b/src/devices/Mfrc522/Mfrc522.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mfrc522/Mfrc522.csproj
+++ b/src/devices/Mfrc522/Mfrc522.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mhz19b/Mhz19b.csproj
+++ b/src/devices/Mhz19b/Mhz19b.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Mhz19b/Mhz19b.csproj
+++ b/src/devices/Mhz19b/Mhz19b.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Mlx90614/Mlx90614.csproj
+++ b/src/devices/Mlx90614/Mlx90614.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mlx90614/Mlx90614.csproj
+++ b/src/devices/Mlx90614/Mlx90614.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/MotorHat/DCMotor3Pwm.cs
+++ b/src/devices/MotorHat/DCMotor3Pwm.cs
@@ -33,7 +33,7 @@ namespace Iot.Device.MotorHat
             set
             {
                 // Make sure the speed is between -1 and 1
-                _speed = Math.Clamp(value, -1, 1);
+                _speed = value < -1 ? -1 : (value > 1) ? 1 : value;
 
                 // The motor Direction is handled configuring in1 and in2 based on speed sign
                 if (_speed > 0)

--- a/src/devices/MotorHat/DCMotor3Pwm.cs
+++ b/src/devices/MotorHat/DCMotor3Pwm.cs
@@ -33,7 +33,7 @@ namespace Iot.Device.MotorHat
             set
             {
                 // Make sure the speed is between -1 and 1
-                _speed = value < -1 ? -1 : (value > 1) ? 1 : value;
+                _speed = MathExtensions.Clamp(value, -1, 1);
 
                 // The motor Direction is handled configuring in1 and in2 based on speed sign
                 if (_speed > 0)

--- a/src/devices/MotorHat/MotorHat.csproj
+++ b/src/devices/MotorHat/MotorHat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/MotorHat/MotorHat.csproj
+++ b/src/devices/MotorHat/MotorHat.csproj
@@ -10,6 +10,7 @@
     <Compile Include="*.cs" />
     <None Include="README.md" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <ProjectReference Include="..\Pca9685\Pca9685.csproj" />
     <ProjectReference Include="..\ServoMotor\ServoMotor.csproj" />
     <ProjectReference Include="..\DCMotor\DCMotor.csproj" />

--- a/src/devices/MotorHat/MotorHat.csproj
+++ b/src/devices/MotorHat/MotorHat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/MotorHat/MotorHat.sln
+++ b/src/devices/MotorHat/MotorHat.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{2AF097CF-AE69-459D-AED7-E105E89CEC89}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MotorHat.Samples", "samples\MotorHat.Samples.csproj", "{747A4F2B-2A9D-4752-8BF6-474F036CC20A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MotorHat.Samples", "samples\MotorHat.Samples.csproj", "{747A4F2B-2A9D-4752-8BF6-474F036CC20A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MotorHat", "MotorHat.csproj", "{5EE11A1B-C4EF-48AF-A0F0-0FD3CAB0A1A4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MotorHat", "MotorHat.csproj", "{5EE11A1B-C4EF-48AF-A0F0-0FD3CAB0A1A4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{D4D71078-48E4-4230-BCD6-1EB977366E00}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{747A4F2B-2A9D-4752-8BF6-474F036CC20A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{5EE11A1B-C4EF-48AF-A0F0-0FD3CAB0A1A4}.Release|x64.Build.0 = Release|Any CPU
 		{5EE11A1B-C4EF-48AF-A0F0-0FD3CAB0A1A4}.Release|x86.ActiveCfg = Release|Any CPU
 		{5EE11A1B-C4EF-48AF-A0F0-0FD3CAB0A1A4}.Release|x86.Build.0 = Release|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Debug|x86.Build.0 = Debug|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Release|x64.Build.0 = Release|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Release|x86.ActiveCfg = Release|Any CPU
+		{D4D71078-48E4-4230-BCD6-1EB977366E00}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{747A4F2B-2A9D-4752-8BF6-474F036CC20A} = {2AF097CF-AE69-459D-AED7-E105E89CEC89}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8878AA7A-35F8-46E1-81E7-24586C21FEF7}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/Mpr121/ChannelStatusesChangedEventArgs.cs
+++ b/src/devices/Mpr121/ChannelStatusesChangedEventArgs.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 
 namespace Iot.Device.Mpr121
 {

--- a/src/devices/Mpr121/Mpr121.cs
+++ b/src/devices/Mpr121/Mpr121.cs
@@ -5,7 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-#if !NETFRAMEWORK
+#if !NETSTANDARD2_0
 using System.Collections.Immutable;
 #endif
 using System.Device.I2c;
@@ -103,7 +103,7 @@ namespace Iot.Device.Mpr121
         public IReadOnlyDictionary<Channels, bool> ReadChannelStatuses()
         {
             RefreshChannelStatuses();
-#if !NETFRAMEWORK
+#if !NETSTANDARD2_0
             return _statuses.ToImmutableDictionary();
 #else
             return new ReadOnlyDictionary<Channels, bool>(_statuses);
@@ -231,7 +231,7 @@ namespace Iot.Device.Mpr121
 
         private void OnChannelStatusesChanged()
         {
-#if !NETFRAMEWORK
+#if !NETSTANDARD2_0
             ChannelStatusesChanged?.Invoke(this, new ChannelStatusesChangedEventArgs(_statuses.ToImmutableDictionary()));
 #else
             ChannelStatusesChanged?.Invoke(this, new ChannelStatusesChangedEventArgs(new ReadOnlyDictionary<Channels, bool>(_statuses)));

--- a/src/devices/Mpr121/Mpr121.cs
+++ b/src/devices/Mpr121/Mpr121.cs
@@ -4,8 +4,12 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+#if !NETFRAMEWORK
 using System.Collections.Immutable;
+#endif
 using System.Device.I2c;
+using System.Linq;
 using System.Threading;
 
 namespace Iot.Device.Mpr121
@@ -99,8 +103,11 @@ namespace Iot.Device.Mpr121
         public IReadOnlyDictionary<Channels, bool> ReadChannelStatuses()
         {
             RefreshChannelStatuses();
-
+#if !NETFRAMEWORK
             return _statuses.ToImmutableDictionary();
+#else
+            return new ReadOnlyDictionary<Channels, bool>(_statuses);
+#endif
         }
 
         /// <summary>
@@ -222,6 +229,13 @@ namespace Iot.Device.Mpr121
             _i2cDevice.Write(data);
         }
 
-        private void OnChannelStatusesChanged() => ChannelStatusesChanged?.Invoke(this, new ChannelStatusesChangedEventArgs(_statuses.ToImmutableDictionary()));
+        private void OnChannelStatusesChanged()
+        {
+#if !NETFRAMEWORK
+            ChannelStatusesChanged?.Invoke(this, new ChannelStatusesChangedEventArgs(_statuses.ToImmutableDictionary()));
+#else
+            ChannelStatusesChanged?.Invoke(this, new ChannelStatusesChangedEventArgs(new ReadOnlyDictionary<Channels, bool>(_statuses)));
+#endif
+        }
     }
 }

--- a/src/devices/Mpr121/Mpr121.csproj
+++ b/src/devices/Mpr121/Mpr121.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Mpr121/Mpr121.csproj
+++ b/src/devices/Mpr121/Mpr121.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Mpu9250/Mpu9250.csproj
+++ b/src/devices/Mpu9250/Mpu9250.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Mpu9250/Mpu9250.csproj
+++ b/src/devices/Mpu9250/Mpu9250.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Nrf24l01/Nrf24l01.cs
+++ b/src/devices/Nrf24l01/Nrf24l01.cs
@@ -159,7 +159,7 @@ namespace Iot.Device.Nrf24l01
 
             Initialize(pinNumberingScheme, outputPower, dataRate, channel, gpioController);
             InitializePipe();
-#if NETCOREAPP2_1
+#if !NET5_0_OR_GREATER
             if (_gpio is null ||
                 Pipe0 is null ||
                 Pipe1 is null ||
@@ -260,7 +260,7 @@ namespace Iot.Device.Nrf24l01
         /// <summary>
         /// Initialize
         /// </summary>
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
         [MemberNotNull(nameof(_gpio))]
 #endif
         private void Initialize(PinNumberingScheme pinNumberingScheme, OutputPower outputPower, DataRate dataRate, byte channel, GpioController? gpioController)
@@ -292,7 +292,7 @@ namespace Iot.Device.Nrf24l01
         /// <summary>
         /// Initialize nRF24L01 Pipe
         /// </summary>
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
         [MemberNotNull(nameof(Pipe0), nameof(Pipe0), nameof(Pipe1), nameof(Pipe2), nameof(Pipe3), nameof(Pipe4), nameof(Pipe5))]
 #endif
         private void InitializePipe()

--- a/src/devices/Nrf24l01/Nrf24l01.csproj
+++ b/src/devices/Nrf24l01/Nrf24l01.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Nrf24l01/Nrf24l01.csproj
+++ b/src/devices/Nrf24l01/Nrf24l01.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.Linux.cs
+++ b/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.Linux.cs
@@ -21,7 +21,7 @@ namespace Iot.Device.OneWire
             }
 
             var tempIdx = data.LastIndexOf("t=");
-            if (tempIdx == -1 || tempIdx + 2 >= data.Length || !int.TryParse(data.AsSpan(tempIdx + 2), out var temp))
+            if (tempIdx == -1 || tempIdx + 2 >= data.Length || !int.TryParse(data.Substring(tempIdx + 2), out var temp))
             {
                 throw new InvalidOperationException("Invalid sensor data format.");
             }
@@ -29,11 +29,13 @@ namespace Iot.Device.OneWire
             return Temperature.FromDegreesCelsius(temp * 0.001);
         }
 
+#if !NETSTANDARD2_0
         private async Task<Temperature> ReadTemperatureInternalAsync()
         {
             var data = await File.ReadAllTextAsync(Path.Combine(OneWireBus.SysfsDevicesPath, BusId, DeviceId, "w1_slave"));
             return ParseTemperature(data);
         }
+#endif
 
         private Temperature ReadTemperatureInternal()
         {

--- a/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.cs
+++ b/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.cs
@@ -59,6 +59,7 @@ namespace Iot.Device.OneWire
             }
         }
 
+#if !NETSTANDARD2_0
         /// <summary>
         /// Reads the current temperature of the device.
         /// Expect this function to be slow (about one second).
@@ -68,6 +69,7 @@ namespace Iot.Device.OneWire
         {
             return ReadTemperatureInternalAsync();
         }
+#endif
 
         /// <summary>
         /// Reads the current temperature of the device.

--- a/src/devices/OneWire/OneWire.csproj
+++ b/src/devices/OneWire/OneWire.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/OneWire/OneWire.csproj
+++ b/src/devices/OneWire/OneWire.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/OneWire/OneWire.csproj
+++ b/src/devices/OneWire/OneWire.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
@@ -12,6 +12,7 @@
     <Compile Include="FamilyBindings\OneWireThermometerDevice.Linux.cs" />
     <None Include="README.md" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/OneWire/OneWire.sln
+++ b/src/devices/OneWire/OneWire.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{DA828065-8BEF-4854-9DFC-311ADB7B3709}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OneWire.Samples", "samples\OneWire.Samples.csproj", "{02DE8DEE-8CD9-45AC-8501-1BD214C6000A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneWire.Samples", "samples\OneWire.Samples.csproj", "{02DE8DEE-8CD9-45AC-8501-1BD214C6000A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OneWire", "OneWire.csproj", "{83B565EF-90B3-4248-827D-0609966ABF70}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneWire", "OneWire.csproj", "{83B565EF-90B3-4248-827D-0609966ABF70}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{93CB1D8D-7B16-46B2-954F-8AB5820670BC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{02DE8DEE-8CD9-45AC-8501-1BD214C6000A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{83B565EF-90B3-4248-827D-0609966ABF70}.Release|x64.Build.0 = Release|Any CPU
 		{83B565EF-90B3-4248-827D-0609966ABF70}.Release|x86.ActiveCfg = Release|Any CPU
 		{83B565EF-90B3-4248-827D-0609966ABF70}.Release|x86.Build.0 = Release|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Debug|x64.Build.0 = Debug|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Debug|x86.Build.0 = Debug|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Release|x64.ActiveCfg = Release|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Release|x64.Build.0 = Release|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Release|x86.ActiveCfg = Release|Any CPU
+		{93CB1D8D-7B16-46B2-954F-8AB5820670BC}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{02DE8DEE-8CD9-45AC-8501-1BD214C6000A} = {DA828065-8BEF-4854-9DFC-311ADB7B3709}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7C88F188-BFCF-49A0-9166-55B2C42FD503}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/OneWire/OneWireBus.Linux.cs
+++ b/src/devices/OneWire/OneWireBus.Linux.cs
@@ -36,10 +36,11 @@ namespace Iot.Device.OneWire
 
         internal static DeviceFamily GetDeviceFamilyInternal(string busId, string devId)
         {
-            int.TryParse(devId.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var devFamily);
+            int.TryParse(devId.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var devFamily);
             return (DeviceFamily)devFamily;
         }
 
+#if !NETSTANDARD2_0
         internal static async Task ScanForDeviceChangesInternalAsync(OneWireBus bus, int numDevices, int numScans)
         {
             if (numDevices > 0)
@@ -49,6 +50,7 @@ namespace Iot.Device.OneWire
 
             await File.WriteAllTextAsync(Path.Combine(SysfsDevicesPath, bus.BusId, "w1_master_search"), numScans.ToString());
         }
+#endif
 
         internal static void ScanForDeviceChangesInternal(OneWireBus bus, int numDevices, int numScans)
         {

--- a/src/devices/OneWire/OneWireBus.cs
+++ b/src/devices/OneWire/OneWireBus.cs
@@ -30,7 +30,7 @@ namespace Iot.Device.OneWire
 
         /// <summary>
         /// Enumerates all devices currently detected on this bus. Platform can update device list
-        /// periodically. To manually trigger an update call <see cref="ScanForDeviceChangesAsync" />.
+        /// periodically. To manually trigger an update call <see cref="ScanForDeviceChanges" />.
         /// </summary>
         /// <param name="family">Family id used to filter enumerated devices.</param>
         /// <returns>A list of discovered devices.</returns>
@@ -42,6 +42,7 @@ namespace Iot.Device.OneWire
             }
         }
 
+#if !NETSTANDARD2_0
         /// <summary>
         /// Start a new scan for device changes on the bus.
         /// </summary>
@@ -49,6 +50,7 @@ namespace Iot.Device.OneWire
         /// <param name="numScans">Number of scans to do to find numDevices devices. Use -1 for platform default.</param>
         /// <returns>Task representing the async work.</returns>
         public Task ScanForDeviceChangesAsync(int numDevices = -1, int numScans = -1) => ScanForDeviceChangesInternalAsync(this, numDevices, numScans);
+#endif
 
         /// <summary>
         /// Start a new scan for device changes on the bus.

--- a/src/devices/Pca95x4/Pca95x4.csproj
+++ b/src/devices/Pca95x4/Pca95x4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Pca95x4/Pca95x4.csproj
+++ b/src/devices/Pca95x4/Pca95x4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Pca9685/Pca9685.cs
+++ b/src/devices/Pca9685/Pca9685.cs
@@ -296,7 +296,17 @@ namespace Iot.Device.Pwm
         private byte FrequencyToPrescale(double freqHz)
         {
             var desiredPrescale = Math.Round(ClockFrequency / 4096 / freqHz - 1);
-            return (byte)Math.Clamp(desiredPrescale, byte.MinValue, byte.MaxValue);
+            if (desiredPrescale < 0)
+            {
+                return 0;
+            }
+
+            if (desiredPrescale > byte.MaxValue)
+            {
+                return byte.MaxValue;
+            }
+
+            return (byte)desiredPrescale;
         }
 
         private double PrescaleToFrequency(byte prescale)

--- a/src/devices/Pca9685/Pca9685.cs
+++ b/src/devices/Pca9685/Pca9685.cs
@@ -296,17 +296,7 @@ namespace Iot.Device.Pwm
         private byte FrequencyToPrescale(double freqHz)
         {
             var desiredPrescale = Math.Round(ClockFrequency / 4096 / freqHz - 1);
-            if (desiredPrescale < 0)
-            {
-                return 0;
-            }
-
-            if (desiredPrescale > byte.MaxValue)
-            {
-                return byte.MaxValue;
-            }
-
-            return (byte)desiredPrescale;
+            return (byte)MathExtensions.Clamp(desiredPrescale, byte.MinValue, byte.MaxValue);
         }
 
         private double PrescaleToFrequency(byte prescale)

--- a/src/devices/Pca9685/Pca9685.csproj
+++ b/src/devices/Pca9685/Pca9685.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Pca9685/Pca9685.csproj
+++ b/src/devices/Pca9685/Pca9685.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Pca9685/Pca9685.csproj
+++ b/src/devices/Pca9685/Pca9685.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Pca9685/Pca9685.sln
+++ b/src/devices/Pca9685/Pca9685.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{23706C17-8A17-4828-A0DA-C8DF324FA99A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pca9685.Sample", "samples\Pca9685.Sample.csproj", "{50251B0C-AE4E-4835-94A6-284063EE9CCE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pca9685.Sample", "samples\Pca9685.Sample.csproj", "{50251B0C-AE4E-4835-94A6-284063EE9CCE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pca9685", "Pca9685.csproj", "{16C14C07-8083-4DBC-B03D-683140627AD7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pca9685", "Pca9685.csproj", "{16C14C07-8083-4DBC-B03D-683140627AD7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{50251B0C-AE4E-4835-94A6-284063EE9CCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{16C14C07-8083-4DBC-B03D-683140627AD7}.Release|x64.Build.0 = Release|Any CPU
 		{16C14C07-8083-4DBC-B03D-683140627AD7}.Release|x86.ActiveCfg = Release|Any CPU
 		{16C14C07-8083-4DBC-B03D-683140627AD7}.Release|x86.Build.0 = Release|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Debug|x64.Build.0 = Debug|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Debug|x86.Build.0 = Debug|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Release|x64.ActiveCfg = Release|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Release|x64.Build.0 = Release|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Release|x86.ActiveCfg = Release|Any CPU
+		{F29CA42D-2246-4FC7-AC22-58CCCDA6C859}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{50251B0C-AE4E-4835-94A6-284063EE9CCE} = {23706C17-8A17-4828-A0DA-C8DF324FA99A}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EA60C5F5-D5E4-4C97-A38A-503951FABED8}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/Pcd8544/Pcd8544.csproj
+++ b/src/devices/Pcd8544/Pcd8544.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Pcd8544/Pcd8544.csproj
+++ b/src/devices/Pcd8544/Pcd8544.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Pcx857x/Pcx857x.csproj
+++ b/src/devices/Pcx857x/Pcx857x.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RootNamespace>Iot.Device.Pcx857x</RootNamespace>
   </PropertyGroup>

--- a/src/devices/Pcx857x/Pcx857x.csproj
+++ b/src/devices/Pcx857x/Pcx857x.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RootNamespace>Iot.Device.Pcx857x</RootNamespace>
   </PropertyGroup>

--- a/src/devices/PiJuice/PiJuice.sln
+++ b/src/devices/PiJuice/PiJuice.sln
@@ -10,7 +10,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{61C1
 		samples\README.md = samples\README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PiJuiceDevice.sample", "samples\PiJuiceDevice.sample.csproj", "{F62EDA5A-5855-4050-A5C4-A116E07498E8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PiJuiceDevice.sample", "samples\PiJuiceDevice.sample.csproj", "{F62EDA5A-5855-4050-A5C4-A116E07498E8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{64FB7912-5242-461D-B4C3-91FF1E4F5B14}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,12 +28,16 @@ Global
 		{F62EDA5A-5855-4050-A5C4-A116E07498E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F62EDA5A-5855-4050-A5C4-A116E07498E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F62EDA5A-5855-4050-A5C4-A116E07498E8}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{F62EDA5A-5855-4050-A5C4-A116E07498E8} = {61C135C2-1483-4B3D-8070-27A0DE4AF808}
+		{64FB7912-5242-461D-B4C3-91FF1E4F5B14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64FB7912-5242-461D-B4C3-91FF1E4F5B14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64FB7912-5242-461D-B4C3-91FF1E4F5B14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64FB7912-5242-461D-B4C3-91FF1E4F5B14}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F62EDA5A-5855-4050-A5C4-A116E07498E8} = {61C135C2-1483-4B3D-8070-27A0DE4AF808}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {13974C73-C93F-4C84-BA79-4E51189A5C68}

--- a/src/devices/PiJuice/PiJuiceDevice.csproj
+++ b/src/devices/PiJuice/PiJuiceDevice.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
 	  <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <Compile Include="$(MSBuildThisFileDirectory)/../Common/System/Runtime/CompilerServices/IsExternalInit.cs" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <Compile Include="*.cs" />
     <Compile Remove="samples\**" />

--- a/src/devices/PiJuice/PiJuiceDevice.csproj
+++ b/src/devices/PiJuice/PiJuiceDevice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
 	  <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Pn5180/Pn5180.cs
+++ b/src/devices/Pn5180/Pn5180.cs
@@ -953,7 +953,7 @@ namespace Iot.Device.Pn5180
         /// <param name="timeoutPollingMilliseconds">The time to poll the card in milliseconds. Card detection will stop once the detection time will be over</param>
         /// <returns>True if a 14443 Type A card has been detected</returns>
         public bool ListenToCardIso14443TypeA(TransmitterRadioFrequencyConfiguration transmitter, ReceiverRadioFrequencyConfiguration receiver,
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
         [NotNullWhen(true)]
 #endif
         out Data106kbpsTypeA? card, int timeoutPollingMilliseconds)
@@ -1112,7 +1112,7 @@ namespace Iot.Device.Pn5180
         /// <param name="timeoutPollingMilliseconds">The time to poll the card in milliseconds. Card detection will stop once the detection time will be over</param>
         /// <returns>True if a 14443 Type B card has been detected</returns>
         public bool ListenToCardIso14443TypeB(TransmitterRadioFrequencyConfiguration transmitter, ReceiverRadioFrequencyConfiguration receiver,
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
         [NotNullWhen(true)]
 #endif
         out Data106kbpsTypeB? card, int timeoutPollingMilliseconds)

--- a/src/devices/Pn5180/Pn5180.csproj
+++ b/src/devices/Pn5180/Pn5180.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Pn5180/Pn5180.csproj
+++ b/src/devices/Pn5180/Pn5180.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Pn532/Pn532.csproj
+++ b/src/devices/Pn532/Pn532.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Pn532/Pn532.csproj
+++ b/src/devices/Pn532/Pn532.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
+++ b/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
+++ b/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
   </ItemGroup>
 
@@ -15,7 +16,6 @@
     <Compile Include="Gpio.cs" />
     <Compile Include="PinMapping.cs" />
     <Compile Include="RgbLedMatrix.cs" />
-    <Compile Include="../Common/Iot/Device/Graphics/BdfFont.cs" />
     <Compile Include="../Interop/Unix/ThreadHelper.cs" />
   </ItemGroup>
 

--- a/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
+++ b/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/RGBLedMatrix/RGBLedMatrix.sln
+++ b/src/devices/RGBLedMatrix/RGBLedMatrix.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{C5A43465-133D-4092-AFD5-DE329B3ED9E4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RGBLedMatrix.sample", "samples\RGBLedMatrix.sample.csproj", "{955539A1-EB0A-4984-9047-BDE955BE89B4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RGBLedMatrix.sample", "samples\RGBLedMatrix.sample.csproj", "{955539A1-EB0A-4984-9047-BDE955BE89B4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RGBLedMatrix", "RGBLedMatrix.csproj", "{40A8EFFD-B81F-4A1E-A41C-27F12848D16D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RGBLedMatrix", "RGBLedMatrix.csproj", "{40A8EFFD-B81F-4A1E-A41C-27F12848D16D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{C9339537-8395-4950-AED4-C58910870439}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{955539A1-EB0A-4984-9047-BDE955BE89B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{40A8EFFD-B81F-4A1E-A41C-27F12848D16D}.Release|x64.Build.0 = Release|Any CPU
 		{40A8EFFD-B81F-4A1E-A41C-27F12848D16D}.Release|x86.ActiveCfg = Release|Any CPU
 		{40A8EFFD-B81F-4A1E-A41C-27F12848D16D}.Release|x86.Build.0 = Release|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Debug|x64.Build.0 = Debug|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Debug|x86.Build.0 = Debug|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Release|x64.ActiveCfg = Release|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Release|x64.Build.0 = Release|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Release|x86.ActiveCfg = Release|Any CPU
+		{C9339537-8395-4950-AED4-C58910870439}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{955539A1-EB0A-4984-9047-BDE955BE89B4} = {C5A43465-133D-4092-AFD5-DE329B3ED9E4}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1209CCFE-EF64-4071-98DF-136D4D9F4E77}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/RadioReceiver/RadioReceiver.csproj
+++ b/src/devices/RadioReceiver/RadioReceiver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/RadioReceiver/RadioReceiver.csproj
+++ b/src/devices/RadioReceiver/RadioReceiver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/RadioTransmitter/RadioTransmitter.csproj
+++ b/src/devices/RadioTransmitter/RadioTransmitter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/RadioTransmitter/RadioTransmitter.csproj
+++ b/src/devices/RadioTransmitter/RadioTransmitter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/RotaryEncoder/RotaryEncoder.csproj
+++ b/src/devices/RotaryEncoder/RotaryEncoder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/RotaryEncoder/RotaryEncoder.csproj
+++ b/src/devices/RotaryEncoder/RotaryEncoder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/RotaryEncoder/ScaledQuadratureEncoder.cs
+++ b/src/devices/RotaryEncoder/ScaledQuadratureEncoder.cs
@@ -92,9 +92,9 @@ namespace Iot.Device.RotaryEncoder
         public ScaledQuadratureEncoder(int pinA, int pinB, PinEventTypes edges, int pulsesPerRotation, GpioController? controller = null, bool shouldDispose = true)
             : base(pinA, pinB, edges, pulsesPerRotation, controller, shouldDispose)
         {
-            _pulseIncrement = (dynamic)1;
-            _rangeMin = (dynamic)0;
-            _rangeMax = (dynamic)100;
+            _pulseIncrement = 1;
+            _rangeMin = 0;
+            _rangeMax = 100;
 
             Value = _rangeMin;
         }
@@ -131,7 +131,7 @@ namespace Iot.Device.RotaryEncoder
             base.OnPulse(blnUp, milliSecondsSinceLastPulse);
 
             // calculate how much to change the value by
-            dynamic valueChange = (blnUp ? (dynamic)_pulseIncrement : -_pulseIncrement) * Acceleration(milliSecondsSinceLastPulse);
+            double valueChange = (blnUp ? _pulseIncrement : -_pulseIncrement) * Acceleration(milliSecondsSinceLastPulse);
 
             // set the value to the new value clamped by the maximum and minumum of the range.
             Value = Math.Max(Math.Min(Value + valueChange, _rangeMax), _rangeMin);

--- a/src/devices/Rtc/Rtc.csproj
+++ b/src/devices/Rtc/Rtc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Rtc/Rtc.csproj
+++ b/src/devices/Rtc/Rtc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Seesaw/Seesaw.csproj
+++ b/src/devices/Seesaw/Seesaw.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Seesaw/Seesaw.csproj
+++ b/src/devices/Seesaw/Seesaw.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/SenseHat/SenseHat.csproj
+++ b/src/devices/SenseHat/SenseHat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -9,6 +9,7 @@
     <Compile Include="*.cs" />
     <None Include="README.md" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <ProjectReference Include="..\Lsm9Ds1\Lsm9Ds1.csproj" />
     <ProjectReference Include="..\Hts221\Hts221.csproj" />
     <ProjectReference Include="..\Lps25h\Lps25h.csproj" />

--- a/src/devices/SenseHat/SenseHat.csproj
+++ b/src/devices/SenseHat/SenseHat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/SenseHat/SenseHat.csproj
+++ b/src/devices/SenseHat/SenseHat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/SenseHat/SenseHat.sln
+++ b/src/devices/SenseHat/SenseHat.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{4FF47933-E49B-4F07-B9CE-2373634907F5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SenseHat.Samples", "samples\SenseHat.Samples.csproj", "{6BE260F6-D6F3-4847-9D6D-97DBF108B038}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SenseHat.Samples", "samples\SenseHat.Samples.csproj", "{6BE260F6-D6F3-4847-9D6D-97DBF108B038}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SenseHat", "SenseHat.csproj", "{2FDCADC5-7D89-4D6F-8362-FE59082210BF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SenseHat", "SenseHat.csproj", "{2FDCADC5-7D89-4D6F-8362-FE59082210BF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6BE260F6-D6F3-4847-9D6D-97DBF108B038}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{2FDCADC5-7D89-4D6F-8362-FE59082210BF}.Release|x64.Build.0 = Release|Any CPU
 		{2FDCADC5-7D89-4D6F-8362-FE59082210BF}.Release|x86.ActiveCfg = Release|Any CPU
 		{2FDCADC5-7D89-4D6F-8362-FE59082210BF}.Release|x86.Build.0 = Release|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Debug|x64.Build.0 = Debug|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Debug|x86.Build.0 = Debug|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Release|x64.ActiveCfg = Release|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Release|x64.Build.0 = Release|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Release|x86.ActiveCfg = Release|Any CPU
+		{5553DE95-3A5B-4063-ADF0-CA1EFFE51234}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{6BE260F6-D6F3-4847-9D6D-97DBF108B038} = {4FF47933-E49B-4F07-B9CE-2373634907F5}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {50C00507-8282-4F7C-89BE-233D11960BB7}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/ServoMotor/ServoMotor.csproj
+++ b/src/devices/ServoMotor/ServoMotor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>    
   </PropertyGroup>
 

--- a/src/devices/ServoMotor/ServoMotor.csproj
+++ b/src/devices/ServoMotor/ServoMotor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>    
   </PropertyGroup>
 

--- a/src/devices/ShiftRegister/ShiftRegister.csproj
+++ b/src/devices/ShiftRegister/ShiftRegister.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/ShiftRegister/ShiftRegister.csproj
+++ b/src/devices/ShiftRegister/ShiftRegister.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Sht3x/Sht3x.csproj
+++ b/src/devices/Sht3x/Sht3x.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Sht3x/Sht3x.csproj
+++ b/src/devices/Sht3x/Sht3x.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Shtc3/Shtc3.csproj
+++ b/src/devices/Shtc3/Shtc3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Shtc3/Shtc3.csproj
+++ b/src/devices/Shtc3/Shtc3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Si7021/Si7021.csproj
+++ b/src/devices/Si7021/Si7021.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Si7021/Si7021.csproj
+++ b/src/devices/Si7021/Si7021.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Sn74hc595/Sn74hc595.csproj
+++ b/src/devices/Sn74hc595/Sn74hc595.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Sn74hc595/Sn74hc595.csproj
+++ b/src/devices/Sn74hc595/Sn74hc595.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/SocketCan/SocketCan.csproj
+++ b/src/devices/SocketCan/SocketCan.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/devices/SocketCan/SocketCan.csproj
+++ b/src/devices/SocketCan/SocketCan.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/devices/SocketCan/SocketCan.csproj
+++ b/src/devices/SocketCan/SocketCan.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksReduced)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/devices/SoftPwm/SoftwarePwm.csproj
+++ b/src/devices/SoftPwm/SoftwarePwm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultItems>false</EnableDefaultItems>    
   </PropertyGroup>

--- a/src/devices/SoftPwm/SoftwarePwm.csproj
+++ b/src/devices/SoftPwm/SoftwarePwm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultItems>false</EnableDefaultItems>    
   </PropertyGroup>

--- a/src/devices/SoftwareSpi/SoftwareSpi.csproj
+++ b/src/devices/SoftwareSpi/SoftwareSpi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/SoftwareSpi/SoftwareSpi.csproj
+++ b/src/devices/SoftwareSpi/SoftwareSpi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Ssd1351/Ssd1351.csproj
+++ b/src/devices/Ssd1351/Ssd1351.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Ssd1351/Ssd1351.csproj
+++ b/src/devices/Ssd1351/Ssd1351.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Ssd13xx/Ssd13xx.csproj
+++ b/src/devices/Ssd13xx/Ssd13xx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <!--Disabling default items so samples source won't get build by the main library-->
   </PropertyGroup>

--- a/src/devices/Ssd13xx/Ssd13xx.csproj
+++ b/src/devices/Ssd13xx/Ssd13xx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <!--Disabling default items so samples source won't get build by the main library-->
   </PropertyGroup>

--- a/src/devices/StUsb4500/StUsb4500.csproj
+++ b/src/devices/StUsb4500/StUsb4500.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/StUsb4500/StUsb4500.csproj
+++ b/src/devices/StUsb4500/StUsb4500.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Tcs3472x/Tcs3472x.cs
+++ b/src/devices/Tcs3472x/Tcs3472x.cs
@@ -81,7 +81,7 @@ namespace Iot.Device.Tcs3472x
             _i2cDevice.WriteByte((byte)(Registers.COMMAND_BIT | Registers.ID));
             ChipId = (TCS3472Type)_i2cDevice.ReadByte();
             _isLongTime = false;
-            IntegrationTime = Math.Clamp(integrationTime, 0.0024, 0.7);
+            IntegrationTime = MathExtensions.Clamp(integrationTime, 0.0024, 0.7);
             SetIntegrationTime(integrationTime);
             Gain = gain;
             PowerOn();
@@ -127,7 +127,7 @@ namespace Iot.Device.Tcs3472x
                 }
 
                 _isLongTime = false;
-                var timeByte = Math.Clamp((int)(0x100 - (timeSeconds / 0.0024)), 0, 255);
+                var timeByte = MathExtensions.Clamp((int)(0x100 - (timeSeconds / 0.0024)), 0, 255);
                 WriteRegister(Registers.ATIME, (byte)timeByte);
                 _integrationTimeByte = (byte)timeByte;
             }
@@ -140,7 +140,7 @@ namespace Iot.Device.Tcs3472x
 
                 _isLongTime = true;
                 var timeByte = (int)(0x100 - (timeSeconds / 0.029));
-                timeByte = Math.Clamp(timeByte, 0, 255);
+                timeByte = MathExtensions.Clamp(timeByte, 0, 255);
                 WriteRegister(Registers.WTIME, (byte)timeByte);
                 _integrationTimeByte = (byte)timeByte;
             }
@@ -211,13 +211,13 @@ namespace Iot.Device.Tcs3472x
             }
 
             int r = (int)(I2cRead16(Registers.RDATAL) * 255 / divide);
-            r = Math.Clamp(r, 0, 255);
+            r = MathExtensions.Clamp(r, 0, 255);
             int g = (int)(I2cRead16(Registers.GDATAL) * 255 / divide);
-            g = Math.Clamp(g, 0, 255);
+            g = MathExtensions.Clamp(g, 0, 255);
             int b = (int)(I2cRead16(Registers.BDATAL) * 255 / divide);
-            b = Math.Clamp(b, 0, 255);
+            b = MathExtensions.Clamp(b, 0, 255);
             int a = (int)(I2cRead16(Registers.CDATAL) * 255 / divide);
-            a = Math.Clamp(a, 0, 255);
+            a = MathExtensions.Clamp(a, 0, 255);
             return Color.FromArgb(a, r, g, b);
         }
 

--- a/src/devices/Tcs3472x/Tcs3472x.csproj
+++ b/src/devices/Tcs3472x/Tcs3472x.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Tcs3472x/Tcs3472x.csproj
+++ b/src/devices/Tcs3472x/Tcs3472x.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="*.cs" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
   </ItemGroup>
 

--- a/src/devices/Tcs3472x/Tcs3472x.sln
+++ b/src/devices/Tcs3472x/Tcs3472x.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{5EA6D313-4BC3-4225-839B-BAEB01B551BE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tcs3472x.sample", "samples\Tcs3472x.sample.csproj", "{24AEBFFC-34C0-4755-A6F0-EA6E2322BB54}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tcs3472x.sample", "samples\Tcs3472x.sample.csproj", "{24AEBFFC-34C0-4755-A6F0-EA6E2322BB54}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tcs3472x", "Tcs3472x.csproj", "{33CAC9DB-76C3-434C-90DF-CFD8C18FF321}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tcs3472x", "Tcs3472x.csproj", "{33CAC9DB-76C3-434C-90DF-CFD8C18FF321}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{AEF50959-E4EF-4253-80CF-22BB30B82FBE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{24AEBFFC-34C0-4755-A6F0-EA6E2322BB54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,8 +45,26 @@ Global
 		{33CAC9DB-76C3-434C-90DF-CFD8C18FF321}.Release|x64.Build.0 = Release|Any CPU
 		{33CAC9DB-76C3-434C-90DF-CFD8C18FF321}.Release|x86.ActiveCfg = Release|Any CPU
 		{33CAC9DB-76C3-434C-90DF-CFD8C18FF321}.Release|x86.Build.0 = Release|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Debug|x64.Build.0 = Debug|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Debug|x86.Build.0 = Debug|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Release|x64.ActiveCfg = Release|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Release|x64.Build.0 = Release|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Release|x86.ActiveCfg = Release|Any CPU
+		{AEF50959-E4EF-4253-80CF-22BB30B82FBE}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{24AEBFFC-34C0-4755-A6F0-EA6E2322BB54} = {5EA6D313-4BC3-4225-839B-BAEB01B551BE}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {421F764B-B1C7-4FD1-ABC2-27304219FDB6}
 	EndGlobalSection
 EndGlobal

--- a/src/devices/Tlc1543/Tlc1543.csproj
+++ b/src/devices/Tlc1543/Tlc1543.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Tlc1543/Tlc1543.csproj
+++ b/src/devices/Tlc1543/Tlc1543.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Tlc1543/samples/Tlc1543.Samples.csproj
+++ b/src/devices/Tlc1543/samples/Tlc1543.Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Tlc1543/samples/Tlc1543.Samples.csproj
+++ b/src/devices/Tlc1543/samples/Tlc1543.Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/devices/Tm1637/Tm1637.csproj
+++ b/src/devices/Tm1637/Tm1637.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Tm1637/Tm1637.csproj
+++ b/src/devices/Tm1637/Tm1637.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Tsl256x/Tsl256x.csproj
+++ b/src/devices/Tsl256x/Tsl256x.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Tsl256x/Tsl256x.csproj
+++ b/src/devices/Tsl256x/Tsl256x.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/UFireIse/UFireIse.cs
+++ b/src/devices/UFireIse/UFireIse.cs
@@ -310,7 +310,7 @@ namespace Iot.Device.UFire
         private void WriteRegister(Register register, float data = 0)
         {
             // μFire ISE (Ion Specific Electrode) is 0 as default
-#if NETFRAMEWORK
+#if NETSTANDARD2_0
             byte[] bytes = BitConverter.GetBytes(data);
             ChangeRegister(register);
             _device.Write(bytes);

--- a/src/devices/UFireIse/UFireIse.cs
+++ b/src/devices/UFireIse/UFireIse.cs
@@ -310,6 +310,12 @@ namespace Iot.Device.UFire
         private void WriteRegister(Register register, float data = 0)
         {
             // μFire ISE (Ion Specific Electrode) is 0 as default
+#if NETFRAMEWORK
+            byte[] bytes = BitConverter.GetBytes(data);
+            ChangeRegister(register);
+            _device.Write(bytes);
+            DelayHelper.DelayMilliseconds(IseCommunicationDelay, allowThreadYield: true);
+#else
             Span<byte> bytes = stackalloc byte[4]
              {
                 0,
@@ -328,6 +334,7 @@ namespace Iot.Device.UFire
             {
                 throw new Exception("Not possible to write bytes");
             }
+#endif
         }
 
         /// <summary>

--- a/src/devices/UFireIse/UFireIse.csproj
+++ b/src/devices/UFireIse/UFireIse.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+   <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/UFireIse/UFireIse.csproj
+++ b/src/devices/UFireIse/UFireIse.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+   <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Uln2003/Uln2003.csproj
+++ b/src/devices/Uln2003/Uln2003.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Uln2003/Uln2003.csproj
+++ b/src/devices/Uln2003/Uln2003.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Vl53L0X/Vl53L0X.cs
+++ b/src/devices/Vl53L0X/Vl53L0X.cs
@@ -77,7 +77,7 @@ namespace Iot.Device.Vl53L0X
             MaxTryReadSingle = 3;
             // Set longer range
             Precision = Precision.LongRange;
-#if NETCOREAPP2_1
+#if !NET5_0_OR_GREATER
             if (Information is null)
             {
                 throw new Exception("Vl53L0X device is not correctly configured.");
@@ -651,7 +651,7 @@ namespace Iot.Device.Vl53L0X
         /// Create the Info class. Initialization and closing sequences
         /// are coming form the official API
         /// </summary>
-#if !NETCOREAPP2_1
+#if NET5_0_OR_GREATER
         [MemberNotNull(nameof(Information))]
 #endif
         private void GetInfo()

--- a/src/devices/Vl53L0X/Vl53L0X.csproj
+++ b/src/devices/Vl53L0X/Vl53L0X.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Vl53L0X/Vl53L0X.csproj
+++ b/src/devices/Vl53L0X/Vl53L0X.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/devices/Ws28xx/Ws28xx.csproj
+++ b/src/devices/Ws28xx/Ws28xx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/devices/Ws28xx/Ws28xx.csproj
+++ b/src/devices/Ws28xx/Ws28xx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksBase)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>


### PR DESCRIPTION
I was attempting to use a binding in a project that still uses .NET Framework (and cannot be migrated just yet) and found that this was not possible. This adds cross-build support for most bindings with only minor tweaks. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1530)