### PR TITLE
Disable SPI CS when it isn't used

### DIFF
--- a/src/System.Device.Gpio/System/Device/Spi/Devices/UnixSpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/Devices/UnixSpiDevice.cs
@@ -118,7 +118,11 @@ namespace System.Device.Spi
         {
             UnixSpiMode mode = SpiModeToUnixSpiMode(_settings.Mode);
 
-            if (_settings.ChipSelectLineActiveState == PinValue.High)
+            if (_settings.ChipSelectLine == -1)
+            {
+                mode |= UnixSpiMode.SPI_NO_CS;
+            }
+            else if (_settings.ChipSelectLineActiveState == PinValue.High)
             {
                 mode |= UnixSpiMode.SPI_CS_HIGH;
             }


### PR DESCRIPTION
In applications where the chip-select line is controlled 'manually', the driver interferes by re-/setting the chip-select line as well. This behaviour is disabled by configuring the devices mode with the `SPI_NO_CS`-flag set.

<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->
