### PR TITLE
updating byte arrays to Span<byte> for consistency

### DIFF
--- a/src/devices/Ssd13xx/Ssd1306.cs
+++ b/src/devices/Ssd13xx/Ssd1306.cs
@@ -42,7 +42,7 @@ namespace Iot.Device.Ssd13xx
         /// <param name="command">The command to send to the display controller.</param>
         private void SendCommand(ICommand command)
         {
-            byte[]? commandBytes = command?.GetBytes();
+            Span<byte> commandBytes = command?.GetBytes();
 
             if (commandBytes is not { Length: >0 })
             {

--- a/src/devices/Ssd13xx/Ssd13xx.cs
+++ b/src/devices/Ssd13xx/Ssd13xx.cs
@@ -54,9 +54,9 @@ namespace Iot.Device.Ssd13xx
         /// Send data to the display controller.
         /// </summary>
         /// <param name="data">The data to send to the display controller.</param>
-        public virtual void SendData(byte[] data)
+        public virtual void SendData(Span<byte> data)
         {
-            if (data is null)
+            if (data.IsEmpty)
             {
                 throw new ArgumentNullException(nameof(data));
             }


### PR DESCRIPTION
Found a mix of byte[] and Span<byte> usage.  Updated to use Span<byte> consistently.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1541)