### PR TITLE
SetDataRate method in NRF24L01 fixed.

### DIFF
--- a/src/devices/Nrf24l01/DataRate.cs
+++ b/src/devices/Nrf24l01/DataRate.cs
@@ -9,6 +9,11 @@ namespace Iot.Device.Nrf24l01
     public enum DataRate
     {
         /// <summary>
+        /// 250kbps
+        /// </summary>
+        Rate250kbps = 0x20,
+
+        /// <summary>
         /// 1Mbps
         /// </summary>
         Rate1Mbps = 0x00,
@@ -16,6 +21,6 @@ namespace Iot.Device.Nrf24l01
         /// <summary>
         /// 2Mbps
         /// </summary>
-        Rate2Mbps = 0x01
+        Rate2Mbps = 0x08
     }
 }

--- a/src/devices/Nrf24l01/Nrf24l01.cs
+++ b/src/devices/Nrf24l01/Nrf24l01.cs
@@ -658,7 +658,7 @@ namespace Iot.Device.Nrf24l01
 
             Span<byte> readData = WriteRead(Command.NRF_R_REGISTER, Register.NRF_RF_SETUP, 1);
 
-            byte setting = (byte)(readData[0] & (~0b_0000_1000) | ((byte)rate << 1));
+            byte setting = (byte)(readData[0] & (~0b_0010_1000) | (byte)rate);
 
             Write(Command.NRF_W_REGISTER, Register.NRF_RF_SETUP, setting);
 


### PR DESCRIPTION
I found that SetDataRate() in NRF24L01 module wasn't setting proper bits in register for data rate.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1542)