### PR TITLE
Unify the references for the test projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+  <!-- Hint: This file is only included in projects not in the src/devices subtree. Check the file with the same name
+  there for common includes to all bindings -->
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="$(RepositoryEngineeringDir)Compilers.props" />
   <Import Project="$(RepositoryEngineeringDir)Analyzers.props" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="$(RepositoryEngineeringDir)Compilers.props" />
   <Import Project="$(RepositoryEngineeringDir)Analyzers.props" />
+  <Import Project="$(RepositoryEngineeringDir)Versions.external.props" />
 
   <PropertyGroup>
     <Copyright>$(CopyrightNetFoundation)</Copyright>

--- a/eng/Versions.external.props
+++ b/eng/Versions.external.props
@@ -1,0 +1,19 @@
+<Project>
+  <!-- These references to third-party libraries are included in all projects except System.Device.Gpio -->
+  <ItemGroup Condition="$(MSBuildProjectName)!='System.Device.Gpio'">
+    <PackageReference Include="UnitsNet" Version="4.77.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
+  </ItemGroup>
+
+  <!-- Automatically include these assemblies in all test projects -->
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
+     <PackageReference Include="Moq" Version="4.16.1" />
+     <PackageReference Include="xunit" Version="2.4.1" />
+     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+       <PrivateAssets>all</PrivateAssets>
+       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+  </ItemGroup>
+</Project>

--- a/eng/Versions.external.props
+++ b/eng/Versions.external.props
@@ -1,6 +1,6 @@
 <Project>
   <!-- These references to third-party libraries are included in all projects except System.Device.Gpio -->
-  <ItemGroup Condition="$(MSBuildProjectName)!='System.Device.Gpio'">
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'System.Device.Gpio'">
     <PackageReference Include="UnitsNet" Version="4.77.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
   </ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,11 @@
     <MicrosoftExtensionsLoggingConsolePackageVersion>5.0.0</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>5.0.0</MicrosoftExtensionsLoggingPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>5.0.0</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>16.9.4</MicrosoftNETTestSdkPackageVersion>
     <SixLaborsImageSharpPackageVersion>1.0.2</SixLaborsImageSharpPackageVersion>
+    <MoqPackageVersion>4.16.1</MoqPackageVersion>
+    <xunitPackageVersion>2.4.1</xunitPackageVersion>
+    <xunitrunnervisualstudioPackageVersion>2.4.3</xunitrunnervisualstudioPackageVersion>
+    <xunitrunnerutilityPackageVersion>2.4.1</xunitrunnerutilityPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,15 +12,8 @@
     <SystemThreadingTasksExtensionsPackageVersion>4.5.4</SystemThreadingTasksExtensionsPackageVersion>
     <SystemMemoryPackageVersion>4.5.4</SystemMemoryPackageVersion>
     <SystemRuntimeInteropServicesWindowsRuntimePackageVersion>4.3.0</SystemRuntimeInteropServicesWindowsRuntimePackageVersion>
-    <UnitsNetPackageVersion>4.77.0</UnitsNetPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>5.0.0</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>5.0.0</MicrosoftExtensionsLoggingPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>5.0.0</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <MicrosoftNETTestSdkPackageVersion>16.9.4</MicrosoftNETTestSdkPackageVersion>
-    <SixLaborsImageSharpPackageVersion>1.0.2</SixLaborsImageSharpPackageVersion>
-    <MoqPackageVersion>4.16.1</MoqPackageVersion>
-    <xunitPackageVersion>2.4.1</xunitPackageVersion>
-    <xunitrunnervisualstudioPackageVersion>2.4.3</xunitrunnervisualstudioPackageVersion>
-    <xunitrunnerutilityPackageVersion>2.4.1</xunitrunnerutilityPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Iot.Device.Bindings/Directory.Build.props
+++ b/src/Iot.Device.Bindings/Directory.Build.props
@@ -8,5 +8,4 @@
   </PropertyGroup>
 
   <Import Project="../../Directory.Build.props" />
-  <Import Project="../../eng/Versions.external.props" />
 </Project>

--- a/src/Iot.Device.Bindings/Directory.Build.props
+++ b/src/Iot.Device.Bindings/Directory.Build.props
@@ -7,5 +7,6 @@
     <PackageTags>.NET Core GPIO Pins SPI I2C PWM BCM2835 BCM2837 RPi IoT Device Bindings</PackageTags>
   </PropertyGroup>
 
-  <Import Project="..\..\Directory.Build.props" />
+  <Import Project="../../Directory.Build.props" />
+  <Import Project="../../eng/Versions.external.props" />
 </Project>

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -29,10 +29,8 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
     <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-    <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <PackageReference Include="System.Management" Version="$(SystemManagementPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="$(SixLaborsImageSharpPackageVersion)" />
   </ItemGroup>
 
   <!-- This target will call into each device binding project to get out the source files for the framework we are building

--- a/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
+++ b/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
@@ -4,14 +4,20 @@
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Iot.Device.Bindings\Iot.Device.Bindings.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
+     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+     <PackageReference Include="xunit" Version="$(xunitPackageVersion)" />
+     <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioPackageVersion)">
+       <PrivateAssets>all</PrivateAssets>
+       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.utility" Version="$(xunitrunnerutilityPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
+++ b/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
@@ -12,12 +12,7 @@
   </ItemGroup>
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
      <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-     <PackageReference Include="xunit" Version="$(xunitPackageVersion)" />
-     <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioPackageVersion)">
-       <PrivateAssets>all</PrivateAssets>
-       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+
     <PackageReference Include="xunit.runner.utility" Version="$(xunitrunnerutilityPackageVersion)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
+++ b/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
@@ -9,10 +9,7 @@
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Iot.Device.Bindings\Iot.Device.Bindings.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
      <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-
-    <PackageReference Include="xunit.runner.utility" Version="$(xunitrunnerutilityPackageVersion)" />
+     <PackageReference Include="xunit.runner.utility" Version="$(xunitrunnerutilityPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
+++ b/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
@@ -3,13 +3,14 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
+    <!-- Keep quiet about duplicate package references from props files -->
+    <NoWarn>$(NoWarn);NETSDK1023</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Iot.Device.Bindings\Iot.Device.Bindings.csproj" />
-     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-     <PackageReference Include="xunit.runner.utility" Version="$(xunitrunnerutilityPackageVersion)" />
   </ItemGroup>
+  <Import Project="../../eng/Versions.external.props" />
+
 </Project>

--- a/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
+++ b/src/System.Device.Gpio.Tests/System.Device.Gpio.Tests.csproj
@@ -11,6 +11,5 @@
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Iot.Device.Bindings\Iot.Device.Bindings.csproj" />
   </ItemGroup>
-  <Import Project="../../eng/Versions.external.props" />
 
 </Project>

--- a/src/devices/Amg88xx/tests/Amg88xx.Tests.csproj
+++ b/src/devices/Amg88xx/tests/Amg88xx.Tests.csproj
@@ -7,9 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../Amg88xx.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Arduino/tests/Arduino.Tests.csproj
+++ b/src/devices/Arduino/tests/Arduino.Tests.csproj
@@ -13,21 +13,9 @@
     <ProjectReference Include="../Arduino.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>    
+    
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/src/devices/Bmxx80/tests/Bmxx80.Tests.csproj
+++ b/src/devices/Bmxx80/tests/Bmxx80.Tests.csproj
@@ -9,12 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <ProjectReference Include="..\Bmxx80.csproj" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj">
     </ProjectReference>

--- a/src/devices/Card/Ndef/tests/Ndef.Tests.csproj
+++ b/src/devices/Card/Ndef/tests/Ndef.Tests.csproj
@@ -6,9 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/devices/CharacterLcd/tests/CharacterLcd.Tests.csproj
+++ b/src/devices/CharacterLcd/tests/CharacterLcd.Tests.csproj
@@ -9,9 +9,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../CharacterLcd.csproj"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Charlieplex/tests/Charlieplex.Tests.csproj
+++ b/src/devices/Charlieplex/tests/Charlieplex.Tests.csproj
@@ -8,9 +8,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../Charlieplex.csproj"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.csproj
+++ b/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.csproj
@@ -6,9 +6,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../../../../CommonHelpers.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Common/tests/Common.Tests.csproj
+++ b/src/devices/Common/tests/Common.Tests.csproj
@@ -9,13 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <ProjectReference Include="..\CommonHelpers.csproj" />
     

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -19,5 +19,18 @@
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <PackageReference Include="SixLabors.ImageSharp" Version="$(SixLaborsImageSharpPackageVersion)" />
     <ProjectReference Include="$(SystemDeviceModelPath)" Condition="'$(MSBuildProjectName)' != '$(SystemDeviceModelProjectName)'" />
+	
+    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+  </ItemGroup>
+    <!-- Automatically include these assemblies in all test projects -->
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
+     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+     <PackageReference Include="xunit" Version="$(xunitPackageVersion)" />
+     <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioPackageVersion)">
+       <PrivateAssets>all</PrivateAssets>
+       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.utility" Version="$(xunitrunnerutilityPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -19,8 +19,8 @@
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <PackageReference Include="SixLabors.ImageSharp" Version="$(SixLaborsImageSharpPackageVersion)" />
     <ProjectReference Include="$(SystemDeviceModelPath)" Condition="'$(MSBuildProjectName)' != '$(SystemDeviceModelProjectName)'" />
-	
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+
+    <ProjectReference Include="$(MainLibraryPath)/System.Device.Gpio.csproj" />
   </ItemGroup>
     <!-- Automatically include these assemblies in all test projects -->
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="../../eng/Compilers.props" />
   <Import Project="../../eng/Versions.props" />
   <Import Project="../../eng/Analyzers.props" />
+  <Import Project="../../eng/Versions.external.props" />
   <PropertyGroup>
     <!-- Most projects should use this value to build for all possible target frameworks -->
     <DefaultBindingTfms>net5.0;netcoreapp2.1;netstandard2.0;</DefaultBindingTfms>
@@ -16,21 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="$(SixLaborsImageSharpPackageVersion)" />
     <ProjectReference Include="$(SystemDeviceModelPath)" Condition="'$(MSBuildProjectName)' != '$(SystemDeviceModelProjectName)'" />
-
     <ProjectReference Include="$(MainLibraryPath)/System.Device.Gpio.csproj" />
   </ItemGroup>
-    <!-- Automatically include these assemblies in all test projects -->
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
-     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-     <PackageReference Include="xunit" Version="$(xunitPackageVersion)" />
-     <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioPackageVersion)">
-       <PrivateAssets>all</PrivateAssets>
-       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.utility" Version="$(xunitrunnerutilityPackageVersion)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-  </ItemGroup>
+
 </Project>

--- a/src/devices/Mcp23xxx/tests/Mcp23xxx.Tests.csproj
+++ b/src/devices/Mcp23xxx/tests/Mcp23xxx.Tests.csproj
@@ -8,9 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
 

--- a/src/devices/Mcp25xxx/tests/Mcp25xxx.Tests.csproj
+++ b/src/devices/Mcp25xxx/tests/Mcp25xxx.Tests.csproj
@@ -9,12 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <ProjectReference Include="../Mcp25xxx.csproj" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>

--- a/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
+++ b/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
@@ -8,9 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
 

--- a/src/devices/ServoMotor/tests/ServoMotor.Tests.csproj
+++ b/src/devices/ServoMotor/tests/ServoMotor.Tests.csproj
@@ -9,13 +9,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../ServoMotor.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
   

--- a/src/devices/Ssd13xx/tests/Ssd13xx.Tests.csproj
+++ b/src/devices/Ssd13xx/tests/Ssd13xx.Tests.csproj
@@ -8,10 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.csproj
+++ b/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
     <LangVersion>9</LangVersion>

--- a/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/tests/_DeviceBinding_Not_Required.Tests.csproj
+++ b/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/tests/_DeviceBinding_Not_Required.Tests.csproj
@@ -13,10 +13,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../_DeviceBinding.csproj" />
-
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
 </Project>

--- a/tools/templates/Directory.Build.props
+++ b/tools/templates/Directory.Build.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="../../src/devices/Directory.Build.props" />
+  <PropertyGroup>
+    <!-- The template generates some warnings since the binding name doesn't start with an uppercase letter.
+    It is safe to suppress since this will only happen when building the template, but not the actual binding. -->
+    <NoWarn>$(NoWarn);SA1300;SA1412</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/tools/templates/Directory.Build.targets
+++ b/tools/templates/Directory.Build.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="../../src/devices/Directory.Build.targets" />
+</Project>


### PR DESCRIPTION
This uses a common place to include the default references required for unit test projects (xunit, Microsoft.NET.Test.Sdk, Moq, etc.)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1558)