### PR TITLE
Adjusting VL53L0X to better support I2C address change

### DIFF
--- a/src/devices/Vl53L0X/README.md
+++ b/src/devices/Vl53L0X/README.md
@@ -47,3 +47,20 @@ SetVcselPulsePeriod(VcselType.VcselPeriodFinalRange, PeriodPulse.Period10);
 ```
 
 Please refer to the documentation to understand the impact of changing the various pulses as well as using the high resolution precision measurement. The sensor can't be precise in long range and in general, the longer it can see, the less precise are the data. High resolution will return a more precise measurement but mainly in short distance.
+
+## Changing the default I2C address
+
+You can adjust the I2C address used for this sensor. Here is a code snippet explaining how to:
+
+```csharp
+// Code snippet to change the address of a sensor
+byte newAddress = 0x28; // You can change for any valid supported address
+I2cDevice connectionToCurrentAddress = I2cDevice.Create(new I2cConnectionSettings(1, Vl53L0X.DefaultI2cAddress));
+Vl53L0X.ChangeI2cAddress(connectionToCurrentAddress, newAddress);
+I2cDevice connectionToChangedAddress = I2cDevice.Create(new I2cConnectionSettings(1, newAddress));
+using Vl53L0X vlWithChangedAddress = new(connectionToChangedAddress);
+// Do what you'd like to do here
+// Soft reset the device to setup the default address again
+vlWithChangedAddress.Reset();
+// Now the address is reset to the default one
+```

--- a/src/devices/Vl53L0X/Vl53L0X.cs
+++ b/src/devices/Vl53L0X/Vl53L0X.cs
@@ -71,7 +71,6 @@ namespace Iot.Device.Vl53L0X
             _i2cDevice = i2cDevice ?? throw new ArgumentNullException(nameof(i2cDevice));
             _shouldDispose = shouldDispose;
             _operationTimeout = operationTimeoutMilliseconds;
-            Reset();
             Init();
             GetInfo();
             MaxTryReadSingle = 3;
@@ -442,9 +441,11 @@ namespace Iot.Device.Vl53L0X
         }
 
         /// <summary>
-        /// Reset the sensor
+        /// Performs a soft reset of the sensor
         /// </summary>
-        private void Reset()
+        /// <remarks>If you change the I2C address and perform a soft reset, the default
+        /// I2C address will be setup again.</remarks>
+        public void Reset()
         {
             WriteRegister((byte)Registers.SOFT_RESET_GO2_SOFT_RESET_N, 0x00);
             Thread.Sleep(5);
@@ -819,7 +820,8 @@ namespace Iot.Device.Vl53L0X
             var tmp = ReadByte(0x92);
             var retSquad = new SpadInfo()
             {
-                Count = (byte)(tmp & 0x7f), TypeIsAperture = (byte)((tmp >> 7) & 0x01) == 0x01
+                Count = (byte)(tmp & 0x7f),
+                TypeIsAperture = (byte)((tmp >> 7) & 0x01) == 0x01
             };
             // Closing sequence
             WriteRegister(0x81, 0x00);

--- a/src/devices/Vl53L0X/samples/Program.cs
+++ b/src/devices/Vl53L0X/samples/Program.cs
@@ -32,3 +32,15 @@ while (!Console.KeyAvailable)
 
     Thread.Sleep(500);
 }
+
+/*
+// Code snippet to change the address of a sensor
+byte newAddress = 0x28; // You can change for any valid supported address
+I2cDevice connectionToCurrentAddress = I2cDevice.Create(new I2cConnectionSettings(1, Vl53L0X.DefaultI2cAddress));
+Vl53L0X.ChangeI2cAddress(connectionToCurrentAddress, newAddress);
+I2cDevice connectionToChangedAddress = I2cDevice.Create(new I2cConnectionSettings(1, newAddress));
+using Vl53L0X vlWithChangedAddress = new(connectionToChangedAddress);
+// Do what you'd like to do here
+// Soft reset the device to setup the default address again
+vlWithChangedAddress.Reset();
+*/


### PR DESCRIPTION
- This PR is about fixing issue #1540 
- It adds as well in the document and commented in the sample the code snippet to change the device default I2C address

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1560)