### PR TITLE
Fixes #1539 Linux-arm LIBGPIOD: PinValueChangedEvent consumes too much CPU

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.cs
@@ -51,7 +51,7 @@ namespace System.Device.Gpio.Drivers
                     TimeSpec timeout = new TimeSpec
                     {
                         TvSec = new IntPtr(0),
-                        TvNsec = new IntPtr(1000000)
+                        TvNsec = new IntPtr(50_000_000)
                     };
 
                     WaitEventResult waitResult = Interop.libgpiod.gpiod_line_event_wait(pinHandle, ref timeout);


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1567)