### PR TITLE
Add PinValue.IsLow/IsHigh

### DIFF
--- a/src/System.Device.Gpio.Tests/PinValueTests.cs
+++ b/src/System.Device.Gpio.Tests/PinValueTests.cs
@@ -15,6 +15,12 @@ namespace System.Device.Gpio.Tests
         {
             Assert.True(PinValue.High.Equals(1));
             Assert.True(PinValue.Low.Equals(0));
+
+            Assert.True(PinValue.High.IsHigh);
+            Assert.False(PinValue.High.IsLow);
+
+            Assert.True(PinValue.Low.IsLow);
+            Assert.False(PinValue.Low.IsHigh);
         }
 
         [Fact]
@@ -37,6 +43,22 @@ namespace System.Device.Gpio.Tests
         {
             Assert.Equal(PinValue.Low, !PinValue.High);
             Assert.Equal(PinValue.High, !PinValue.Low);
+        }
+
+        [Fact]
+        public void VerifyIsLowOrIsHigh()
+        {
+            Assert.True(((PinValue)0).IsLow);
+            Assert.False(((PinValue)0).IsHigh);
+
+            Assert.True(((PinValue)1).IsHigh);
+            Assert.False(((PinValue)1).IsLow);
+
+            Assert.True(((PinValue)int.MaxValue).IsHigh);
+            Assert.False(((PinValue)int.MaxValue).IsLow);
+
+            Assert.True(((PinValue)int.MinValue).IsHigh);
+            Assert.False(((PinValue)int.MinValue).IsLow);
         }
     }
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/PinValue.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/PinValue.cs
@@ -26,6 +26,18 @@ namespace System.Device.Gpio
         public static PinValue Low => new PinValue(0);
 
         /// <summary>
+        /// Indicates whether the value of the current <see cref="PinValue"/> is <see cref="High"/> or not.
+        /// </summary>
+        /// <value><see langword="true"/> when the value is <see cref="High"/>, <see langword="false"/> when the value is <see cref="Low"/>.</value>
+        public bool IsHigh => _value != 0;
+
+        /// <summary>
+        /// Indicates whether the value of the current <see cref="PinValue"/> is <see cref="Low"/> or not.
+        /// </summary>
+        /// <value><see langword="true"/> when the value is <see cref="Low"/>, <see langword="false"/> when the value is <see cref="High"/>.</value>
+        public bool IsLow => _value == 0;
+
+        /// <summary>
         /// Implicit conversion from int. 0 means <see cref="Low"/>, everything else means <see cref="High"/>.
         /// </summary>
         /// <param name="value">Value to set</param>


### PR DESCRIPTION
`PinValue` struct already have `Equals()`, `==`/`!=`, and explicit type conversion to `bool`.
But these are little bit redundant and confusing in `if` statements like the codes listed below.

So added new property `IsLow`/`IsHigh` to `PinValue` struct in this PR.

Use cases and comparison:
```cs
// vs. Equals()
PinValue signalA, signalB;

if (signalA.Equals(PinValue.High)) // 🙁This looks redundant.
if (signalA.IsHigh) // 😺It's clear.

if (signalA.Equals(PinValue.High) && signalB.Equals(PinValue.Low)) // 🙁This looks redundant.
if (signalA.IsHigh && signalB.IsLow) // 😺It's clear.

// vs. explicit operator bool
// (in case of positive logic and negative logic value)
PinValue positiveLogicSignal, negativeLogicSignal;

if ((bool)positiveLogicSignal) // 😺This looks fine.
if (positiveLogicSignal.IsHigh) // 😺It's more clear.

if (!(bool)negativeLogicSignal) // 🤔This looks confusing. (If the value is high? or low?)
if (negativeLogicSignal.IsLow)  // 😺It's clear.
```

Similar examples:
- BigInteger.Zero/One and BigInteger.IsZero/IsOne (System.Numerics)
- Point.Empty and Point.IsEmpty (System.Drawing)

(Update)
Purpose of this proposal:
- To increase the way to clarify what the code is truely intended to do.
- To increase the way to write the code friendly to the readers. (especially for beginners and Visual Basic users)
- To provide the above two points as library properties, rather than by defining extension methods by the users individually.

(Update2)
Other naming candidates:
- PinValue.IsZero/IsOne
- PinValue.IsFalse/IsTrue


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1576)