### PR TITLE
Swapped ArgumentException parameter order

### DIFF
--- a/src/devices/CharacterLcd/LcdInterface.Gpio.cs
+++ b/src/devices/CharacterLcd/LcdInterface.Gpio.cs
@@ -62,7 +62,7 @@ namespace Iot.Device.CharacterLcd
                 }
                 else if (dataPins.Length != 4)
                 {
-                    throw new ArgumentException(nameof(dataPins), "The length of the array must be 4 or 8.");
+                    throw new ArgumentException("The length of the array must be 4 or 8.", nameof(dataPins));
                 }
 
                 _shouldDispose = shouldDispose || controller is null;


### PR DESCRIPTION
Hello, fixed a small issue where `ArgumentException` constructor parameters where passed the wrong way around. `ArgumentException` constructor signature is: [ArgumentException(string message, string paramName)](https://docs.microsoft.com/en-us/dotnet/api/system.argumentexception.-ctor?view=net-5.0#System_ArgumentException__ctor_System_String_System_String_). This was suggested by Visual Studio code analysis based on rule [CA2208](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2208).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1588)