### PR TITLE
Added lcd interface to support SPI

### DIFF
--- a/src/devices/CharacterLcd/CharacterLcd.csproj
+++ b/src/devices/CharacterLcd/CharacterLcd.csproj
@@ -18,6 +18,7 @@
     <Compile Include="LcdInterface.Gpio.cs" />
     <Compile Include="LcdInterface.I2c.cs" />
     <Compile Include="LcdInterface.I2c4Bit.cs" />
+    <Compile Include="LcdInterface.Spi.cs" />
     <Compile Include="LcdRgb.cs" />
     <Compile Include="LcdValueUnitDisplay.cs" />
     <Compile Include="LineWrapMode.cs" />
@@ -27,6 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="../Common/CommonHelpers.csproj" />
+    <ProjectReference Include="../Sn74hc595/Sn74hc595.csproj" />
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>

--- a/src/devices/CharacterLcd/LcdInterface.Spi.cs
+++ b/src/devices/CharacterLcd/LcdInterface.Spi.cs
@@ -1,0 +1,175 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Iot.Device.Multiplexing;
+
+namespace Iot.Device.CharacterLcd
+{
+    public abstract partial class LcdInterface : IDisposable
+    {
+        /// <summary>
+        /// This interface allows the control of a character display using SPI protocol.
+        /// The display is controlled using SN74HC595 shift register. This shift register can be controlled
+        /// using a minimum of three pins so this method saves pins on the microcontroller compared to direct GPIO
+        /// connection. This interface adds support for existing products that allow connect to an HD44780 display
+        /// through a shift register e.g. https://www.adafruit.com/product/292
+        /// </summary>
+        private class Spi : LcdInterface
+        {
+            private readonly byte _registerSelectPin;
+            private readonly byte _enablePin;
+            private readonly byte[] _dataPins;
+            private readonly byte _backlightPin;
+
+            private readonly bool _shouldDispose;
+            private Sn74hc595 _shiftRegister;
+            private bool _backlightOn;
+
+            public Spi(int registerSelectPin, int enablePin, int[] dataPins, int backlightPin = -1, Sn74hc595? shiftRegister = null, bool shouldDispose = true)
+            {
+                _registerSelectPin = (byte)(1 << registerSelectPin);
+                _enablePin = (byte)(1 << enablePin);
+
+                // Right now only 4bit mode is supported. 8bit mode would require 16bit shift register or 2x 8bit
+                // because we would need more than 8 output pins to support 8bit mode. This could be implemented in the future.
+                if (dataPins.Length != 4)
+                {
+                    throw new ArgumentException("The length of the array must be 4.", nameof(dataPins));
+                }
+
+                _dataPins = new byte[dataPins.Length];
+
+                for (var i = 0; i < dataPins.Length; i++)
+                {
+                    _dataPins[i] = (byte)(1 << dataPins[i]);
+                }
+
+                if (backlightPin != -1)
+                {
+                    _backlightPin = (byte)(1 << backlightPin);
+                }
+
+                _shouldDispose = shouldDispose || _shiftRegister is null;
+                _shiftRegister = shiftRegister ?? new Sn74hc595(Sn74hc595PinMapping.Minimal);
+
+                _backlightOn = true;
+                Initialize();
+            }
+
+            public override bool EightBitMode => false;
+
+            /// <summary>
+            /// This Display supports enabling/disabling the backlight.
+            /// The text on the display is not affected by disabling the backlight - it is just very hard to read.
+            /// </summary>
+            public override bool BacklightOn
+            {
+                get => _backlightOn;
+                set
+                {
+                    _backlightOn = value;
+                    // Need to send a command to make this happen immediately.
+                    SendCommandAndWait(0);
+                }
+            }
+
+            private byte BacklightFlag
+            {
+                get
+                {
+                    if (BacklightOn)
+                    {
+                        return _backlightPin;
+                    }
+                    else
+                    {
+                        return 0;
+                    }
+                }
+            }
+
+            private void Initialize()
+            {
+                // This sequence (copied from a python example) completely resets the display (if it was
+                // previously erroneously used with 8 bit access, it may not return to normal operation otherwise)
+                SendCommandAndWait(0x3);
+                SendCommandAndWait(0x3);
+                SendCommandAndWait(0x3);
+                SendCommandAndWait(0x2);
+            }
+
+            public override void SendCommand(byte command)
+            {
+                Write4Bits((byte)(0x0 | MapCommandToDataPins((byte)(command >> 4))));
+                Write4Bits((byte)(0x0 | MapCommandToDataPins(command)));
+            }
+
+            public override void SendCommands(ReadOnlySpan<byte> commands)
+            {
+                foreach (byte command in commands)
+                {
+                    SendCommand(command);
+                }
+            }
+
+            public override void SendData(byte value)
+            {
+                Write4Bits((byte)(_registerSelectPin | MapCommandToDataPins((byte)(value >> 4))));
+                Write4Bits((byte)(_registerSelectPin | MapCommandToDataPins(value)));
+            }
+
+            public override void SendData(ReadOnlySpan<byte> values)
+            {
+                foreach (byte value in values)
+                {
+                    SendData(value);
+                }
+            }
+
+            public override void SendData(ReadOnlySpan<char> values)
+            {
+                foreach (byte value in values)
+                {
+                    SendData(value);
+                }
+            }
+
+            private void Write4Bits(byte command)
+            {
+                _shiftRegister.ShiftByte((byte)(command | _enablePin | BacklightFlag));
+                _shiftRegister.ShiftByte((byte)((command & ~_enablePin) | BacklightFlag));
+            }
+
+            // This method iterates through the bits of the 'original' command and sets them to the
+            // appropriate position so that they are shifted out to the correct pins.
+            private byte MapCommandToDataPins(byte command)
+            {
+                byte bits = 0x0;
+
+                for (var i = 0; i < _dataPins.Length; i++)
+                {
+                    var bit = (command >> i) & 1;
+
+                    if (bit == 1)
+                    {
+                        bits = (byte)(bits | _dataPins[i]);
+                    }
+                }
+
+                return bits;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (_shouldDispose)
+                {
+                    _shiftRegister?.Dispose();
+                    _shiftRegister = null!;
+                }
+
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/src/devices/CharacterLcd/LcdInterface.cs
+++ b/src/devices/CharacterLcd/LcdInterface.cs
@@ -6,6 +6,7 @@ using System.Device;
 using System.Device.Gpio;
 using System.Device.I2c;
 using System.Threading;
+using Iot.Device.Multiplexing;
 
 namespace Iot.Device.CharacterLcd
 {
@@ -30,6 +31,23 @@ namespace Iot.Device.CharacterLcd
         public static LcdInterface CreateGpio(int registerSelectPin, int enablePin, int[] dataPins, int backlightPin = -1, float backlightBrightness = 1.0f, int readWritePin = -1, GpioController? controller = null, bool shouldDispose = true)
         {
             return new Gpio(registerSelectPin, enablePin, dataPins, backlightPin, backlightBrightness, readWritePin, controller, shouldDispose);
+        }
+
+        /// <summary>
+        /// Creates an SPI based interface for the LCD.
+        /// </summary>
+        /// <remarks>
+        /// The display is driven using an SN74HC595 shift register. Pin parameters should be set according to which output pin of the shift register they are connected to (0 to 7).
+        /// </remarks>
+        /// <param name="registerSelectPin">The pin that controls the register select.</param>
+        /// <param name="enablePin">The pin that controls the enable switch.</param>
+        /// <param name="dataPins">Collection of pins holding the data that will be printed on the screen.</param>
+        /// <param name="backlightPin">The optional pin that controls the backlight of the display.</param>
+        /// <param name="shiftRegister">The shift register that drives the LCD.</param>
+        /// <param name="shouldDispose">True to dispose the shift register.</param>
+        public static LcdInterface CreateSpi(int registerSelectPin, int enablePin, int[] dataPins, int backlightPin = -1, Sn74hc595? shiftRegister = null, bool shouldDispose = true)
+        {
+            return new Spi(registerSelectPin, enablePin, dataPins, backlightPin, shiftRegister, shouldDispose);
         }
 
         /// <summary>

--- a/src/devices/CharacterLcd/samples/Program.cs
+++ b/src/devices/CharacterLcd/samples/Program.cs
@@ -9,6 +9,7 @@ using Iot.Device.Arduino;
 using Iot.Device.Mcp23xxx;
 using Iot.Device.CharacterLcd;
 using Iot.Device.CharacterLcd.Samples;
+using Iot.Device.Multiplexing;
 using SixLabors.ImageSharp;
 
 // Choose the right setup for your display:
@@ -16,7 +17,8 @@ using SixLabors.ImageSharp;
 // UsingMcp();
 // UsingGroveRgbDisplay();
 // UsingHd44780OverI2C();
-UsingHd44780OverI2CAndArduino();
+// UsingHd44780OverI2CAndArduino();
+UsingShiftRegister();
 
 void UsingGpioPins()
 {
@@ -82,4 +84,17 @@ void UsingHd44780OverI2CAndArduino()
     LargeValueSample.LargeValueDemo(hd44780);
     LcdConsoleSamples.WriteTest(hd44780);
     ExtendedSample.Test(hd44780);
+}
+
+void UsingShiftRegister()
+{
+    int registerSelectPin = 1;
+    int enablePin = 2;
+    int[] dataPins = new int[] { 6, 5, 4, 3 };
+    int backlightPin = 7;
+    using Sn74hc595 sr = new(Sn74hc595PinMapping.Minimal);
+    using LcdInterface lcdInterface = LcdInterface.CreateSpi(registerSelectPin, enablePin, dataPins, backlightPin, sr);
+    using Lcd1602 lcd = new(lcdInterface);
+    lcd.Clear();
+    lcd.Write("Hello World");
 }


### PR DESCRIPTION
Hi, in this pull request I added a new LcdInterface implementation that supports controlling a character lcd using a shift register. To try the sample demo you need to connect an hd44780 type lcd (16x02 used in the sample) to an sn74hc595 shift register the following way:

```
sn74hc595 -> hd44780
       Q0 -> not used
       Q1 -> RS pin
       Q2 -> Enable pin
       Q3 -> D7
       Q4 -> D6
       Q5 -> D5
       Q6 -> D4
       Q7 -> Backlight anode
```

This is the same pinout used on this lcd backpack [product](https://www.adafruit.com/product/292) based on the provided [schematic](https://learn.adafruit.com/i2c-spi-lcd-backpack/downloads). The pins are configurable using the arguments of the `LcdInterface.CreateSpi(int registerSelectPin, int enablePin, int[] dataPins, int backlightPin = -1)` method. I did my tests using a plain sn74hc595 chip a 1602 display on a breadboard.

You can connect the shift register to your microcontroller however you like. The sample uses the `Sn74hc595PinMapping.Minimal` which translates to:

```
Ser = 16    (SR 14   -- data)
SrClk = 20  (SR 11   -- storage register clock)
RClk = 21   (SR 12   -- latch enable to publish storage register)
```

This lcd interface only supports 4bit mode at the moment because we don't have enough output pins on the SN74HC595 shift register to support 8bit mode. For 8bit mode a 16bit shift register is needed or 2 x 8bit daisy chained. Support for that could be added in the future.
Any feedback would be highly appreciated.