### PR TITLE
VirtualOutputSegment write bytes in the correct order

### DIFF
--- a/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
@@ -81,7 +81,8 @@ namespace Iot.Device.Multiplexing.Utility
 
             for (int i = 0; i < value.Length; i++)
             {
-                WriteByteAsValues(value[i], offset + (i * 8));
+                int index = value.Length - i - 1;
+                WriteByteAsValues(value[index], offset + (i * 8));
             }
         }
 


### PR DESCRIPTION
Hello, in this PR I'm attempting to fix the following issue: https://github.com/dotnet/iot/issues/1544
I assumed that the unit test is correct and that `void Write(ReadOnlySpan<byte> value)` method needed to be fixed.

Also, while looking at this I found another possible bug which I explain here: https://github.com/dotnet/iot/issues/1626. If it's a bug indeed I can try to fix that in this PR as well.