### PR TITLE
Width is supposed to be height for second parameter

### DIFF
--- a/src/devices/Ssd1351/Ssd1351Imaging.cs
+++ b/src/devices/Ssd1351/Ssd1351Imaging.cs
@@ -16,7 +16,7 @@ namespace Iot.Device.Ssd1351
         /// <param name="bm">The bitmap to be sent to the display controller note that only Pixel Format Format32bppArgb is supported.</param>
         public void SendBitmap(Bitmap bm)
         {
-            SendBitmap(bm, new Point(0, 0), new Rectangle(0, 0, ScreenWidthPx, ScreenWidthPx));
+            SendBitmap(bm, new Point(0, 0), new Rectangle(0, 0, ScreenWidthPx, ScreenHeightPx));
         }
 
         /// <summary>


### PR DESCRIPTION
Stumbled upon this when porting the code to a different display type. I guess it was never caught because this screen is usually 128x128.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1639)