### PR TITLE
Fix for SysFsDriver when callbacks registered events are not fired, after unregister all registered callbacks.

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -371,6 +371,46 @@ namespace System.Device.Gpio.Tests
         }
 
         [Fact]
+        public void AddCallbackRemoveAllCallbackAndAddCallbackAgainTest()
+        {
+            int callback1FiredTimes = 0, callback2FiredTimes = 0;
+            using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+            {
+                controller.OpenPin(InputPin, PinMode.Input);
+                controller.OpenPin(OutputPin, PinMode.Output);
+                controller.Write(OutputPin, PinValue.Low);
+                Thread.Sleep(WaitMilliseconds);
+
+                for (int i = 1; i < 3; i++)
+                {
+                    controller.RegisterCallbackForPinValueChangedEvent(InputPin, PinEventTypes.Rising, Callback1Rising);
+                    controller.RegisterCallbackForPinValueChangedEvent(InputPin, PinEventTypes.Falling, Callback2Falling);
+
+                    controller.Write(OutputPin, PinValue.High);
+                    Thread.Sleep(WaitMilliseconds);
+                    controller.Write(OutputPin, PinValue.Low);
+                    Thread.Sleep(WaitMilliseconds);
+
+                    controller.UnregisterCallbackForPinValueChangedEvent(InputPin, Callback1Rising);
+                    controller.UnregisterCallbackForPinValueChangedEvent(InputPin, Callback2Falling);
+
+                    Assert.Equal(i, callback1FiredTimes);
+                    Assert.Equal(i, callback2FiredTimes);
+                }
+
+                void Callback1Rising(object sender, PinValueChangedEventArgs e)
+                {
+                    callback1FiredTimes++;
+                }
+
+                void Callback2Falling(object sender, PinValueChangedEventArgs e)
+                {
+                    callback2FiredTimes++;
+                }
+            }
+        }
+
+        [Fact]
         public void WaitForEventCancelAfter10MillisecondsTest()
         {
             using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
@@ -24,13 +24,13 @@ namespace System.Device.Gpio.Drivers
 
         private static readonly int s_pinOffset = ReadOffset();
 
-        private readonly CancellationTokenSource _eventThreadCancellationTokenSource;
         private readonly List<int> _exportedPins = new List<int>();
         private readonly Dictionary<int, UnixDriverDevicePin> _devicePins = new Dictionary<int, UnixDriverDevicePin>();
         private TimeSpan _statusUpdateSleepTime = TimeSpan.FromMilliseconds(1);
         private int _pollFileDescriptor = -1;
         private Thread? _eventDetectionThread;
         private int _pinsToDetectEventsCount;
+        private CancellationTokenSource? _eventThreadCancellationTokenSource;
 
         private static int ReadOffset()
         {
@@ -69,8 +69,6 @@ namespace System.Device.Gpio.Drivers
             {
                 throw new PlatformNotSupportedException($"{GetType().Name} is only supported on Linux/Unix.");
             }
-
-            _eventThreadCancellationTokenSource = new CancellationTokenSource();
         }
 
         /// <summary>
@@ -518,7 +516,11 @@ namespace System.Device.Gpio.Drivers
                 {
                     try
                     {
-                        _eventThreadCancellationTokenSource.Cancel();
+                        if (_eventThreadCancellationTokenSource != null)
+                        {
+                            _eventThreadCancellationTokenSource.Cancel();
+                            _eventThreadCancellationTokenSource.Dispose();
+                        }
                     }
                     catch (ObjectDisposedException)
                     {
@@ -543,8 +545,11 @@ namespace System.Device.Gpio.Drivers
             {
                 try
                 {
-                    _eventThreadCancellationTokenSource.Cancel();
-                    _eventThreadCancellationTokenSource.Dispose();
+                    if (_eventThreadCancellationTokenSource != null)
+                    {
+                        _eventThreadCancellationTokenSource.Cancel();
+                        _eventThreadCancellationTokenSource.Dispose();
+                    }
                 }
                 catch (ObjectDisposedException)
                 {
@@ -618,13 +623,14 @@ namespace System.Device.Gpio.Drivers
                 {
                     IsBackground = true
                 };
+                _eventThreadCancellationTokenSource = new CancellationTokenSource();
                 _eventDetectionThread.Start();
             }
         }
 
         private void DetectEvents()
         {
-            while (_pinsToDetectEventsCount > 0)
+            while (_pinsToDetectEventsCount > 0 && _eventThreadCancellationTokenSource != null)
             {
                 try
                 {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
@@ -630,7 +630,12 @@ namespace System.Device.Gpio.Drivers
 
         private void DetectEvents()
         {
-            while (_pinsToDetectEventsCount > 0 && _eventThreadCancellationTokenSource != null)
+            if (_eventThreadCancellationTokenSource == null)
+            {
+                throw new InvalidOperationException("Cannot start to detect events when CancellationTokenSource is null.");
+            }
+
+            while (_pinsToDetectEventsCount > 0)
             {
                 try
                 {


### PR DESCRIPTION
Fixes #1637

When you registered callbacks in GpioController (when using SysFsDriver), their events are fired as expected.
Then, if you unregistered **all** callbacks, the events are not fired (this is the expected behavior).
Now, If you registered callbacks again (the same or others), their events are not fired. 
This is the bug.

The problem is in SysFsDriver.cs file. The _eventThreadCancellationTokenSource variable is created the first time when SysFsDriver class is also created.
Then, when all callbacks are removed, the _eventThreadCancellationTokenSource variable is canceled.
And, when new callbacks are added, the _eventThreadCancellationTokenSource variable is not recreated.

This fix contains some changes in SysFsDriver.cs file and a test in GpioControllerTestBase.cs file.
Now, when the thread (to listen to the events) is going to start, then the _eventThreadCancellationTokenSource variable is re-created.
The _eventThreadCancellationTokenSource variable is now set as nullable. But, maybe, this fix can be achieved in a better way.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1653)