### PR TITLE
Fix projects with double S.D.G imports

### DIFF
--- a/src/devices/AD5328/AD5328.csproj
+++ b/src/devices/AD5328/AD5328.csproj
@@ -1,20 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />   
-  </ItemGroup>
-
 </Project>

--- a/src/devices/AD5328/samples/AD5328.Samples.csproj
+++ b/src/devices/AD5328/samples/AD5328.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\AD5328.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ads1115/Ads1115.csproj
+++ b/src/devices/Ads1115/Ads1115.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" Link="DelayHelper.cs" />
     <Compile Include="I2cAddress.cs" />
     <Compile Include="ComparatorLatching.cs" />
@@ -20,10 +17,8 @@
     <Compile Include="Register.cs" />
     <Compile Include="Ads1115.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ads1115/samples/Ads1115.Samples.csproj
+++ b/src/devices/Ads1115/samples/Ads1115.Samples.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="ADS1115_circuit.fzz" />
     <None Remove="ADS1115_circuit_bb.png" />
     <None Remove="README.md" />
     <None Remove="res.jpg" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Ads1115.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Adxl345/Adxl345.csproj
+++ b/src/devices/Adxl345/Adxl345.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="GravityRange.cs" />
     <Compile Include="Register.cs" />
     <Compile Include="Adxl345.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Adxl345/samples/Adxl345.Samples.csproj
+++ b/src/devices/Adxl345/samples/Adxl345.Samples.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Adxl345.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="ADXL345_circuit.fzz" />
     <None Remove="ADXL345_circuit_bb.png" />
     <None Remove="README.md" />
     <None Remove="res.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Adxl357/Adxl357.csproj
+++ b/src/devices/Adxl357/Adxl357.csproj
@@ -1,19 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="AccelerometerRange.cs" />
     <Compile Include="Adxl357.cs" />
     <Compile Include="Register.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Adxl357/samples/Adxl357.Samples.csproj
+++ b/src/devices/Adxl357/samples/Adxl357.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Adxl357.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ags01db/Ags01db.csproj
+++ b/src/devices/Ags01db/Ags01db.csproj
@@ -1,19 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Register.cs" />
     <Compile Include="Ags01db.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ags01db/samples/Ags01db.Samples.csproj
+++ b/src/devices/Ags01db/samples/Ags01db.Samples.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Ags01db.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="AGS01DB_circuit.fzz" />
     <None Remove="AGS01DB_circuit_bb.png" />
     <None Remove="README.md" />
     <None Remove="RunningResult.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ahtxx/Ahtxx.csproj
+++ b/src/devices/Ahtxx/Ahtxx.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ahtxx/samples/Ahtxx.Samples.csproj
+++ b/src/devices/Ahtxx/samples/Ahtxx.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Ahtxx.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ak8963/Ak8963.csproj
+++ b/src/devices/Ak8963/Ak8963.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ak8963/samples/ak8963.sample.csproj
+++ b/src/devices/Ak8963/samples/ak8963.sample.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Ak8963.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Amg88xx/Amg88xx.csproj
+++ b/src/devices/Amg88xx/Amg88xx.csproj
@@ -1,21 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <!-- Make the internal classes visible to the unit test assembly -->
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-    <_Parameter1>$(AssemblyName).Tests</_Parameter1>
+      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/src/devices/Amg88xx/samples/Amg88xx.Samples.csproj
+++ b/src/devices/Amg88xx/samples/Amg88xx.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Amg88xx.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Apa102/Apa102.csproj
+++ b/src/devices/Apa102/Apa102.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Arduino/Arduino.csproj
+++ b/src/devices/Arduino/Arduino.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RootNamespace>Iot.Device.Arduino</RootNamespace>
   </PropertyGroup>
-
- <ItemGroup>
+  <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Board\Board.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />

--- a/src/devices/Arduino/samples/Arduino.Monitor.csproj
+++ b/src/devices/Arduino/samples/Arduino.Monitor.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
@@ -7,19 +6,15 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <AssemblyName>Arduino.Monitor</AssemblyName>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />
   </ItemGroup>
-  
   <ItemGroup>
     <Compile Include="CharacterDisplay.cs" />
     <Compile Include="Arduino.Monitor.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <!--Cases used when running in VS, with the solution config either Windows-Debug or Linux-Debug (or -Release) -->
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\..\Bmxx80\Bmxx80.csproj" />
     <ProjectReference Include="..\..\CharacterLcd\CharacterLcd.csproj" />
     <ProjectReference Include="..\..\Common\CommonHelpers.csproj" />
@@ -27,5 +22,4 @@
     <ProjectReference Include="..\..\Mcp3xxx\Mcp3xxx.csproj" />
     <ProjectReference Include="..\Arduino.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Arduino/samples/Arduino.sample.csproj
+++ b/src/devices/Arduino/samples/Arduino.sample.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
@@ -7,22 +6,17 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <AssemblyName>Arduino.sample</AssemblyName>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
     <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />
   </ItemGroup>
-  
   <ItemGroup>
     <Compile Include="Arduino.sample.cs" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\..\Bmxx80\Bmxx80.csproj" />
     <ProjectReference Include="..\..\Common\CommonHelpers.csproj" />
     <ProjectReference Include="..\..\Mcp3xxx\Mcp3xxx.csproj" />
     <ProjectReference Include="..\Arduino.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Arduino/tests/Arduino.Tests.csproj
+++ b/src/devices/Arduino/tests/Arduino.Tests.csproj
@@ -1,21 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile> 
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <!-- We don't want to run hardware test by default -->
-    <VSTestTestCaseFilter Condition="'$(VSTestTestCaseFilter)'==''">requires!=hardware</VSTestTestCaseFilter>    
+    <VSTestTestCaseFilter Condition="'$(VSTestTestCaseFilter)'==''">requires!=hardware</VSTestTestCaseFilter>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Arduino.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />
-    
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bh1745/Bh1745.csproj
+++ b/src/devices/Bh1745/Bh1745.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bh1745/samples/Bh1745.Sample.csproj
+++ b/src/devices/Bh1745/samples/Bh1745.Sample.csproj
@@ -1,18 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Bh1745.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bh1745/samples/Bh1745CustomConfiguration.Sample.csproj
+++ b/src/devices/Bh1745/samples/Bh1745CustomConfiguration.Sample.csproj
@@ -1,18 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Program.CustomConfiguration.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Bh1745.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bh1750fvi/Bh1750fvi.csproj
+++ b/src/devices/Bh1750fvi/Bh1750fvi.csproj
@@ -1,18 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Bh1750fvi.cs" />
     <Compile Include="Command.cs" />
     <Compile Include="I2cAddress.cs" />
     <Compile Include="MeasuringMode.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />

--- a/src/devices/Bh1750fvi/samples/Bh1750fvi.Samples.csproj
+++ b/src/devices/Bh1750fvi/samples/Bh1750fvi.Samples.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Bh1750fvi.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="BH1750FVI_Circuit.fzz" />
     <None Remove="BH1750FVI_Circuit_bb.png" />
     <None Remove="README.md" />
     <None Remove="RunningResult.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bmp180/Bmp180.csproj
+++ b/src/devices/Bmp180/Bmp180.csproj
@@ -1,18 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Bmp180.cs" />
     <Compile Include="CalibrationData.cs" />
     <Compile Include="Register.cs" />
     <Compile Include="Sampling.cs" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
-    <None Include="README.md"/>
+    <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bmp180/samples/Bmp180.Sample.csproj
+++ b/src/devices/Bmp180/samples/Bmp180.Sample.csproj
@@ -1,18 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="rpi-bmp180_i2c.fzz" />
-    <None Remove="rpi-bmp180_i2c_bb.png" />    
+    <None Remove="rpi-bmp180_i2c_bb.png" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Bmp180.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bmxx80/Bmxx80.csproj
+++ b/src/devices/Bmxx80/Bmxx80.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Bme280.cs" />
     <Compile Include="Bme680.cs" />
@@ -32,10 +30,8 @@
     <Compile Include="Register\Bme280Register.cs" />
     <Compile Include="Sampling.cs" />
     <Compile Include="StandbyTime.cs" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
   </ItemGroup>

--- a/src/devices/Bmxx80/samples/Bme280.sample.csproj
+++ b/src/devices/Bmxx80/samples/Bme280.sample.csproj
@@ -1,23 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="rpi-bmp280_i2c.fzz" />
     <None Remove="rpi-bmp280_i2c.png" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="Bme280.sample.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Bmxx80.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bmxx80/samples/Bme680.sample.csproj
+++ b/src/devices/Bmxx80/samples/Bme680.sample.csproj
@@ -1,23 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="rpi-bmp280_i2c.fzz" />
     <None Remove="rpi-bmp280_i2c.png" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="Bme680.sample.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Bmxx80.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bmxx80/samples/Bmp280.sample.csproj
+++ b/src/devices/Bmxx80/samples/Bmp280.sample.csproj
@@ -1,23 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="rpi-bmp280_i2c.fzz" />
     <None Remove="rpi-bmp280_i2c.png" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="Bmp280.sample.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Bmxx80.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bmxx80/tests/Bmxx80.Tests.csproj
+++ b/src/devices/Bmxx80/tests/Bmxx80.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net48</TargetFrameworks>
@@ -7,11 +6,7 @@
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Bmxx80.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj">
-    </ProjectReference>
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bno055/Bno055.csproj
+++ b/src/devices/Bno055/Bno055.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="Models/*.cs" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Bno055/samples/Bno055.sample.csproj
+++ b/src/devices/Bno055/samples/Bno055.sample.csproj
@@ -1,16 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Bno055.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Board/Board.csproj
+++ b/src/devices/Board/Board.csproj
@@ -1,19 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <LangVersion>preview</LangVersion>
     <RootNamespace>Iot.Device.Board</RootNamespace>
   </PropertyGroup>
-  
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="..\Interop\Windows\WinUser.cs" Link="WinUser.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\System.Device.Gpio\System.Device.Gpio.csproj" />
   </ItemGroup>
   <!-- Make the internal classes visible to the unit test assembly -->
   <ItemGroup>
@@ -21,5 +15,4 @@
       <_Parameter1>$(AssemblyName).Tests</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
-  
 </Project>

--- a/src/devices/Board/tests/Board.Tests.csproj
+++ b/src/devices/Board/tests/Board.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,11 +6,9 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <RootNamespace>Iot.Device.Board.Tests</RootNamespace>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\..\..\System.Device.Gpio.Tests\MockableGpioDriver.cs" Link="MockableGpioDriver.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Board.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
@@ -21,7 +18,5 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/BrickPi3/BrickPi3.csproj
+++ b/src/devices/BrickPi3/BrickPi3.csproj
@@ -1,16 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <None Include="README.md" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="BrickPi3.cs" />
     <Compile Include="Models\*.cs" />
@@ -18,5 +14,4 @@
     <Compile Include="Movement\*.cs" />
     <Compile Include="Sensors\*.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Buzzer/Buzzer.csproj
+++ b/src/devices/Buzzer/Buzzer.csproj
@@ -1,19 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Buzzer.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)../SoftPwm/SoftwarePwm.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Buzzer/samples/Buzzer.Samples.csproj
+++ b/src/devices/Buzzer/samples/Buzzer.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-      <ProjectReference Include="$(MSBuildThisFileDirectory)../Buzzer.csproj" />
-      <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)../Buzzer.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Card/Ndef/samples/NdefSamples.csproj
+++ b/src/devices/Card/Ndef/samples/NdefSamples.csproj
@@ -1,20 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\..\Mifare\Mifare.csproj" />
     <ProjectReference Include="..\..\..\Pn5180\Pn5180.csproj" />
     <ProjectReference Include="..\..\..\Pn532\Pn532.csproj" />
     <ProjectReference Include="..\..\..\Ft4222\Ft4222.csproj" />
     <ProjectReference Include="..\Ndef.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ccs811/Ccs811.csproj
+++ b/src/devices/Ccs811/Ccs811.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" Link="DelayHelper.cs" />
     <Compile Include="*.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ccs811/samples/Ccs811.Sample.csproj
+++ b/src/devices/Ccs811/samples/Ccs811.Sample.csproj
@@ -1,17 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Ccs811.csproj" />
     <ProjectReference Include="..\..\Ft4222\Ft4222.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/CharacterLcd/CharacterLcd.csproj
+++ b/src/devices/CharacterLcd/CharacterLcd.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\Common\System\Device\DelayHelper.cs" Link="DelayHelper.cs" />
     <Compile Include="Flags.cs" />
@@ -23,14 +21,11 @@
     <Compile Include="LineWrapMode.cs" />
     <Compile Include="Registers.cs" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="../Common/CommonHelpers.csproj" />
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="BigFontMap.txt" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/CharacterLcd/samples/CharacterLcd.Samples.csproj
+++ b/src/devices/CharacterLcd/samples/CharacterLcd.Samples.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../../Mcp23xxx/Mcp23xxx.csproj" />
     <ProjectReference Include="../../Pcx857x/Pcx857x.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\..\Arduino\Arduino.csproj" />
     <ProjectReference Include="..\CharacterLcd.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Charlieplex/Charlieplex.csproj
+++ b/src/devices/Charlieplex/Charlieplex.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
-<ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+  <ItemGroup>
     <ProjectReference Include="../Common/CommonHelpers.csproj" />
     <Compile Include="CharlieplexSegment.cs" />
     <Compile Include="CharlieplexSegmentNode.cs" />
-</ItemGroup>
-
+  </ItemGroup>
 </Project>

--- a/src/devices/Charlieplex/samples/Charlieplex-sample.csproj
+++ b/src/devices/Charlieplex/samples/Charlieplex-sample.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="../Charlieplex.csproj"/>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="../Charlieplex.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Common/CommonHelpers.csproj
+++ b/src/devices/Common/CommonHelpers.csproj
@@ -1,31 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <RootNamespace></RootNamespace>
+    <RootNamespace>
+    </RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="MathExtensions.cs" />
     <Compile Include="Iot/Device/Common/*.cs" />
     <Compile Include="Iot/Device/Graphics/*.cs" />
-    <Compile Include="Iot/Device/Multiplexing/*.cs" />    
+    <Compile Include="Iot/Device/Multiplexing/*.cs" />
     <Compile Include="System/Device/*.cs" />
     <Compile Include="System/Device/Gpio/*.cs" />
     <Compile Include="System/Device/Analog/*.cs" />
     <Compile Include="System/Device/Spi/*.cs" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="FrameworkCompatibilityExtensions.cs" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="IsExternalInit.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Common/tests/Common.Tests.csproj
+++ b/src/devices/Common/tests/Common.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net48</TargetFrameworks>
@@ -7,12 +6,8 @@
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="UnitsNet" Version="$(UnitsNetPackageVersion)" />
     <ProjectReference Include="..\CommonHelpers.csproj" />
-    
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/DCMotor/DCMotor.csproj
+++ b/src/devices/DCMotor/DCMotor.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)../SoftPwm/SoftwarePwm.csproj" />
     <Compile Include="DCMotor.cs" />
     <Compile Include="DCMotor3Pin.cs" />

--- a/src/devices/DCMotor/samples/DCMotor.sample.csproj
+++ b/src/devices/DCMotor/samples/DCMotor.sample.csproj
@@ -1,14 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)../../SoftPwm\SoftwarePwm.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)../DCMotor.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Dhtxx/Dhtxx.csproj
+++ b/src/devices/Dhtxx/Dhtxx.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="CommunicationProtocol.cs" />
     <Compile Include="Devices\Dht10.cs" />
@@ -15,10 +13,7 @@
     <Compile Include="DhtBase.cs" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Dhtxx/samples/DhtSensor.sample.csproj
+++ b/src/devices/Dhtxx/samples/DhtSensor.sample.csproj
@@ -1,18 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Dhtxx.csproj" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\..\Common\CommonHelpers.csproj" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Directory.Build.props
+++ b/src/devices/Directory.Build.props
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(SystemDeviceModelPath)" Condition="'$(MSBuildProjectName)' != '$(SystemDeviceModelProjectName)'" />
-    <ProjectReference Include="$(MainLibraryPath)/System.Device.Gpio.csproj" />
+    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/devices/Display/Display.csproj
+++ b/src/devices/Display/Display.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Alignment.cs" />
     <Compile Include="BlinkRate.cs" />
@@ -16,10 +14,7 @@
     <Compile Include="ISevenSegmentDisplay.cs" />
     <Compile Include="Large4Digit7SegmentDisplay.cs" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Display/samples/Large4Digit7SegmentDisplay.sample.csproj
+++ b/src/devices/Display/samples/Large4Digit7SegmentDisplay.sample.csproj
@@ -1,16 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-        <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Display.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/ExplorerHat/ExplorerHat.csproj
+++ b/src/devices/ExplorerHat/ExplorerHat.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../DCMotor/DCMotor.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="*.cs" />
     <Compile Include="Gpio/*.cs" />
     <Compile Include="Lighting/*.cs" />
     <Compile Include="Motorization/*.cs" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/ExplorerHat/samples/ExplorerHat.Sample.csproj
+++ b/src/devices/ExplorerHat/samples/ExplorerHat.Sample.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)../ExplorerHat.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ft4222/Ft4222.csproj
+++ b/src/devices/Ft4222/Ft4222.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
- <ItemGroup>
+  <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/devices/Ft4222/samples/Ft4222.sample.csproj
+++ b/src/devices/Ft4222/samples/Ft4222.sample.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Ft4222.csproj" />
     <ProjectReference Include="..\..\Bno055\Bno055.csproj" />
     <ProjectReference Include="..\..\Bmxx80\Bmxx80.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/GoPiGo3/GoPiGo3.csproj
+++ b/src/devices/GoPiGo3/GoPiGo3.csproj
@@ -1,22 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="GoPiGo3.cs" />
     <Compile Include="Models\*.cs" />
     <Compile Include="Movements\*.cs" />
     <Compile Include="Sensors\*.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/GoPiGo3/samples/GoPiGo3.sample.csproj
+++ b/src/devices/GoPiGo3/samples/GoPiGo3.sample.csproj
@@ -1,16 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\GoPiGo3.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Gpio/Iot.Device.Gpio.csproj
+++ b/src/devices/Gpio/Iot.Device.Gpio.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="../Interop/Unix/Interop.Libraries.cs" />
     <Compile Include="../Interop/Unix/Libc/Interop.libc.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Remove="samples\**" />
     <EmbeddedResource Remove="samples\**" />
     <None Remove="samples\**" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/GrovePi/GrovePiDevice.csproj
+++ b/src/devices/GrovePi/GrovePiDevice.csproj
@@ -1,21 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
     <None Include="README.md" />
   </ItemGroup>
-
-<ItemGroup>
+  <ItemGroup>
     <Compile Include="GrovePi.cs" />
     <Compile Include="Models\*.cs" />
     <Compile Include="Sensors\*.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/GrovePi/samples/GrovePiDevice.sample.csproj
+++ b/src/devices/GrovePi/samples/GrovePiDevice.sample.csproj
@@ -1,16 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\GrovePiDevice.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Hcsr04/Hcsr04.csproj
+++ b/src/devices/Hcsr04/Hcsr04.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Hcsr04.cs" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Hcsr04/samples/Hcsr04.Samples.csproj
+++ b/src/devices/Hcsr04/samples/Hcsr04.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Hcsr04.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Hcsr501/Hcsr501.csproj
+++ b/src/devices/Hcsr501/Hcsr501.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Hcsr501.cs" />
     <Compile Include="Hcsr501ValueChangedEventArgs.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Hcsr501/samples/Hcsr501.Samples.csproj
+++ b/src/devices/Hcsr501/samples/Hcsr501.Samples.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="circuit.fzz" />
     <None Remove="circuit_bb.png" />
@@ -12,13 +10,7 @@
     <None Remove="res.gif" />
     <None Remove="Hcsr501Setting.png" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Hcsr501.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Hmc5883l/Hmc5883l.csproj
+++ b/src/devices/Hmc5883l/Hmc5883l.csproj
@@ -1,12 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Gain.cs" />
     <Compile Include="MeasurementConfiguration.cs" />
     <Compile Include="MeasuringMode.cs" />
@@ -15,12 +12,9 @@
     <Compile Include="Hmc5883l.cs" />
     <Compile Include="SamplesAmount.cs" />
     <Compile Include="Status.cs" />
-
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Hmc5883l/samples/Hmc5883l.Samples.csproj
+++ b/src/devices/Hmc5883l/samples/Hmc5883l.Samples.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Hmc5883l.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="HMC5883L_circuit.fzz" />
     <None Remove="HMC5883L_circuit_bb.png" />
     <None Remove="README.md" />
     <None Remove="RunningResult.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Hts221/Hts221.csproj
+++ b/src/devices/Hts221/Hts221.csproj
@@ -1,14 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Hts221/samples/Hts221.Samples.csproj
+++ b/src/devices/Hts221/samples/Hts221.Samples.csproj
@@ -1,15 +1,10 @@
-﻿
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-      <ProjectReference Include="../Hts221.csproj" />
-      <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="../Hts221.csproj" />
     <ProjectReference Include="..\..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ina219/Ina219.csproj
+++ b/src/devices/Ina219/Ina219.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" Link="DelayHelper.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ina219/samples/Ina219.Samples.csproj
+++ b/src/devices/Ina219/samples/Ina219.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Ina219.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/KeyMatrix/KeyMatrix.csproj
+++ b/src/devices/KeyMatrix/KeyMatrix.csproj
@@ -1,18 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="KeyMatrix.cs" />
     <Compile Include="KeyMatrixEvent.cs" />
   </ItemGroup>
-
-  <ItemGroup>    
+  <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
-  
 </Project>

--- a/src/devices/KeyMatrix/samples/KeyMatrix.Sample.csproj
+++ b/src/devices/KeyMatrix/samples/KeyMatrix.Sample.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\KeyMatrix.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/LidarLiteV3/LidarLiteV3.csproj
+++ b/src/devices/LidarLiteV3/LidarLiteV3.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="*.cs" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" Link="DelayHelper.cs" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/LidarLiteV3/samples/LidarLiteV3.Sample.csproj
+++ b/src/devices/LidarLiteV3/samples/LidarLiteV3.Sample.csproj
@@ -1,14 +1,9 @@
-﻿
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-  	<ProjectReference Include="../LidarLiteV3.csproj" />
-  	<ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="../LidarLiteV3.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/LiquidLevel/LiquidLevel.csproj
+++ b/src/devices/LiquidLevel/LiquidLevel.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Remove="samples\**" />
     <None Include="README.md" />
-	  <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-  
 </Project>

--- a/src/devices/LiquidLevel/samples/LiquidLevelSwitch.Sample.csproj
+++ b/src/devices/LiquidLevel/samples/LiquidLevelSwitch.Sample.csproj
@@ -1,23 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="rpi-llc200d3sh.fzz" />
     <None Remove="rpi-llc200d3sh_bb.png" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="LiquidLevelSwitch.sample.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\LiquidLevel.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-  
 </Project>

--- a/src/devices/LiquidLevel/samples/Llc200d3sh.Sample.csproj
+++ b/src/devices/LiquidLevel/samples/Llc200d3sh.Sample.csproj
@@ -1,23 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="rpi-llc200d3sh.fzz" />
     <None Remove="rpi-llc200d3sh_bb.png" />
   </ItemGroup>
-  
   <ItemGroup>
     <Compile Include="Llc200d3sh.sample.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\LiquidLevel.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-  
 </Project>

--- a/src/devices/Lm75/Lm75.csproj
+++ b/src/devices/Lm75/Lm75.csproj
@@ -1,16 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Register.cs" />
     <Compile Include="Lm75.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />

--- a/src/devices/Lm75/samples/Lm75.Samples.csproj
+++ b/src/devices/Lm75/samples/Lm75.Samples.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Lm75.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="LM75_circuit.fzz" />
     <None Remove="LM75_circuit_bb.png" />
     <None Remove="README.md" />
     <None Remove="RunningResult.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Lps25h/Lps25h.csproj
+++ b/src/devices/Lps25h/Lps25h.csproj
@@ -1,14 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Lps25h/samples/Lps25h.Samples.csproj
+++ b/src/devices/Lps25h/samples/Lps25h.Samples.csproj
@@ -1,15 +1,10 @@
-﻿
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-      <ProjectReference Include="../Lps25h.csproj" />
-      <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="../Lps25h.csproj" />
     <ProjectReference Include="..\..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Lsm9Ds1/Lsm9Ds1.csproj
+++ b/src/devices/Lsm9Ds1/Lsm9Ds1.csproj
@@ -1,14 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Samples.csproj
+++ b/src/devices/Lsm9Ds1/samples/Lsm9Ds1.Samples.csproj
@@ -1,14 +1,9 @@
-﻿
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-      <ProjectReference Include="../Lsm9Ds1.csproj" />
-      <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="../Lsm9Ds1.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Max31856/Max31856.csproj
+++ b/src/devices/Max31856/Max31856.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Max31856/samples/Max31856.Samples.csproj
+++ b/src/devices/Max31856/samples/Max31856.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Max31856.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Max31865/Max31865.csproj
+++ b/src/devices/Max31865/Max31865.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="*.cs" />
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Max31865/samples/Max31865.Samples.csproj
+++ b/src/devices/Max31865/samples/Max31865.Samples.csproj
@@ -1,19 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="MAX31865_circuit.fzz" />
     <None Remove="MAX31865_circuit_bb.png" />
     <None Include="README.md" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\Max31865.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Max44009/Max44009.csproj
+++ b/src/devices/Max44009/Max44009.csproj
@@ -1,21 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="IntegrationTime.cs" />
     <Compile Include="Max44009.cs" />
     <Compile Include="Register.cs" />
     <Compile Include="WorkingMode.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Max44009/samples/Max44009.Samples.csproj
+++ b/src/devices/Max44009/samples/Max44009.Samples.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Max44009.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="MAX44009_circuit.fzz" />
     <None Remove="MAX44009_circuit_bb.png" />
     <None Remove="README.md" />
     <None Remove="RunningResult.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Max7219/Max7219.csproj
+++ b/src/devices/Max7219/Max7219.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
-    <EnableDefaultItems>false</EnableDefaultItems> <!--Disabling default items so samples source won't get build by the main library-->
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <!--Disabling default items so samples source won't get build by the main library-->
     <RootNamespace>Iot.Device.Max7219</RootNamespace>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Max7219.cs" />
     <Compile Include="MatrixGraphics.cs" />
     <Compile Include="IFont.cs" />
@@ -17,5 +15,4 @@
     <Compile Include="Fonts.cs" />
     <Compile Include="FixedSizeFont.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Max7219/samples/Max7219.sample.csproj
+++ b/src/devices/Max7219/samples/Max7219.sample.csproj
@@ -1,16 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)/../Max7219.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mbi5027/Mbi5027.csproj
+++ b/src/devices/Mbi5027/Mbi5027.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="../ShiftRegister/ShiftRegister.csproj" />
     <Compile Include="Mbi5027.cs" />
     <Compile Include="Mbi5027PinMapping.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mbi5027/samples/Mbi5027-driver.csproj
+++ b/src/devices/Mbi5027/samples/Mbi5027-driver.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="../Mbi5027.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp23xxx/Mcp23xxx.csproj
+++ b/src/devices/Mcp23xxx/Mcp23xxx.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="..\Common\System\Device\Gpio\PinVector32.cs" Link="PinVector32.cs" />
     <Compile Include="BankStyle.cs" />
     <Compile Include="I2cAdapter.cs" />
@@ -26,9 +23,7 @@
     <Compile Include="Register.cs" />
     <Compile Include="SpiAdapter.cs" />
   </ItemGroup>
-
-  <ItemGroup>    
+  <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp23xxx/samples/Mcp23xxx.Samples.csproj
+++ b/src/devices/Mcp23xxx/samples/Mcp23xxx.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Mcp23xxx.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp23xxx/tests/Mcp23xxx.Tests.csproj
+++ b/src/devices/Mcp23xxx/tests/Mcp23xxx.Tests.csproj
@@ -1,18 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Mcp23xxx.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp25xxx/Mcp25xxx.csproj
+++ b/src/devices/Mcp25xxx/Mcp25xxx.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="InstructionFormat.cs" />
     <Compile Include="Mcp25xxx.cs" />
     <Compile Include="Mcp2515.cs" />
@@ -18,5 +15,4 @@
     <Compile Include="Register\**\*.cs" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp25xxx/samples/Mcp25xxx.Samples.csproj
+++ b/src/devices/Mcp25xxx/samples/Mcp25xxx.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Mcp25xxx.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp25xxx/tests/Mcp25xxx.Tests.csproj
+++ b/src/devices/Mcp25xxx/tests/Mcp25xxx.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net48</TargetFrameworks>
@@ -7,10 +6,7 @@
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Mcp25xxx.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp3428/Mcp3428.csproj
+++ b/src/devices/Mcp3428/Mcp3428.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp3428/samples/Mcp3428.Samples.csproj
+++ b/src/devices/Mcp3428/samples/Mcp3428.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-      <ProjectReference Include="../Mcp3428.csproj" />
-      <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="../Mcp3428.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp3xxx/Mcp3xxx.csproj
+++ b/src/devices/Mcp3xxx/Mcp3xxx.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp3xxx/samples/Mcp3008.Sample.csproj
+++ b/src/devices/Mcp3xxx/samples/Mcp3008.Sample.csproj
@@ -1,17 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Mcp3xxx.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\SoftwareSpi\SoftwareSpi.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mcp9808/Mcp9808.csproj
+++ b/src/devices/Mcp9808/Mcp9808.csproj
@@ -1,16 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Register.cs" />
     <Compile Include="Mcp9808.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
   </ItemGroup>

--- a/src/devices/Mcp9808/samples/Mcp9808.Samples.csproj
+++ b/src/devices/Mcp9808/samples/Mcp9808.Samples.csproj
@@ -1,17 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Mcp9808.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mfrc522/Mfrc522.csproj
+++ b/src/devices/Mfrc522/Mfrc522.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Card\CardRfid.csproj" />
     <ProjectReference Include="..\Card\Mifare\Mifare.csproj" />
@@ -19,5 +15,4 @@
     <Compile Include="RegisterElement\*.cs" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mfrc522/samples/Mfrc522.Sample.csproj
+++ b/src/devices/Mfrc522/samples/Mfrc522.Sample.csproj
@@ -1,20 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>.net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\..\Card\Ultralight\Ultralight.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Mfrc522.csproj" />
     <ProjectReference Include="..\..\Ft4222\Ft4222.csproj" />
     <ProjectReference Include="..\..\Card\CardRfid.csproj" />
     <ProjectReference Include="..\..\Card\Mifare\Mifare.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mhz19b/Mhz19b.csproj
+++ b/src/devices/Mhz19b/Mhz19b.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
     <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mhz19b/samples/Mhz19b.Samples.csproj
+++ b/src/devices/Mhz19b/samples/Mhz19b.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Mhz19b.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mlx90614/Mlx90614.csproj
+++ b/src/devices/Mlx90614/Mlx90614.csproj
@@ -1,16 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Mlx90614.cs" />
     <Compile Include="Register.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
 </Project>

--- a/src/devices/Mlx90614/samples/Mlx90614.Sample.csproj
+++ b/src/devices/Mlx90614/samples/Mlx90614.Sample.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Mlx90614.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/MotorHat/MotorHat.csproj
+++ b/src/devices/MotorHat/MotorHat.csproj
@@ -1,19 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <ProjectReference Include="..\Pca9685\Pca9685.csproj" />
     <ProjectReference Include="..\ServoMotor\ServoMotor.csproj" />
     <ProjectReference Include="..\DCMotor\DCMotor.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/MotorHat/samples/MotorHat.Samples.csproj
+++ b/src/devices/MotorHat/samples/MotorHat.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../MotorHat.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mpr121/Mpr121.csproj
+++ b/src/devices/Mpr121/Mpr121.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Channels.cs" />
     <Compile Include="ChannelStatusesChangedEventArgs.cs" />
@@ -13,7 +11,5 @@
     <Compile Include="Mpr121Configuration.cs" />
     <Compile Include="Registers.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mpr121/samples/Mpr121.Samples.csproj
+++ b/src/devices/Mpr121/samples/Mpr121.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-      <ProjectReference Include="../Mpr121.csproj" />
-      <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="../Mpr121.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mpu9250/Mpu9250.csproj
+++ b/src/devices/Mpu9250/Mpu9250.csproj
@@ -1,24 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
     <Compile Include="*.cs" />
     <None Include="README.md" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" Link="DelayHelper.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Ak8963\Ak8963.csproj" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Mpu9250/samples/Mpu9250.sample.csproj
+++ b/src/devices/Mpu9250/samples/Mpu9250.sample.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Mpu9250.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Nrf24l01/Nrf24l01.csproj
+++ b/src/devices/Nrf24l01/Nrf24l01.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Command.cs" />
     <Compile Include="DataRate.cs" />
     <Compile Include="DataReceivedEventArgs.cs" />
@@ -17,8 +14,7 @@
     <Compile Include="Register.cs" />
     <Compile Include="WorkingMode.cs" />
   </ItemGroup>
-
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>

--- a/src/devices/Nrf24l01/samples/Nrf24l01.Samples.csproj
+++ b/src/devices/Nrf24l01/samples/Nrf24l01.Samples.csproj
@@ -1,16 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Nrf24l01.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="NRF_circuit.fzz" />
     <None Remove="NRF_circuit_bb.jpg" />
     <None Remove="README.md" />

--- a/src/devices/OneWire/OneWire.csproj
+++ b/src/devices/OneWire/OneWire.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="FamilyBindings\OneWireThermometerDevice.cs" />
     <Compile Include="FamilyBindings\OneWireThermometerDevice.Linux.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Pca95x4/Pca95x4.csproj
+++ b/src/devices/Pca95x4/Pca95x4.csproj
@@ -1,22 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Pca95x4.cs" />
     <Compile Include="Register.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/src/devices/Pca95x4/samples/Pca95x4.Samples.csproj
+++ b/src/devices/Pca95x4/samples/Pca95x4.Samples.csproj
@@ -1,16 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Pca95x4.csproj" />
   </ItemGroup>
-  
 </Project>

--- a/src/devices/Pca9685/Pca9685.csproj
+++ b/src/devices/Pca9685/Pca9685.csproj
@@ -1,23 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="../Common/System/Device/DelayHelper.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Pca9685/samples/Pca9685.Sample.csproj
+++ b/src/devices/Pca9685/samples/Pca9685.Sample.csproj
@@ -1,16 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\Iot.Device.Bindings\Iot.Device.Bindings.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Pcd8544/Pcd8544.csproj
+++ b/src/devices/Pcd8544/Pcd8544.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Common/CommonHelpers.csproj" />
     <ProjectReference Include="../CharacterLcd/CharacterLcd.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
 </Project>

--- a/src/devices/Pcd8544/samples/Pcd8544.samples.csproj
+++ b/src/devices/Pcd8544/samples/Pcd8544.samples.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Pcd8544.csproj" />
     <ProjectReference Include="..\..\Ft4222\Ft4222.csproj" />
-    <ProjectReference Include="..\..\SoftPwm\SoftwarePwm.csproj" />    
+    <ProjectReference Include="..\..\SoftPwm\SoftwarePwm.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="me.bmp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -23,5 +19,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/devices/Pcx857x/Pcx857x.csproj
+++ b/src/devices/Pcx857x/Pcx857x.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RootNamespace>Iot.Device.Pcx857x</RootNamespace>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="..\Common\System\Device\Gpio\PinVector32.cs" Link="PinVector32.cs" />
     <Compile Include="..\Common\System\Device\Gpio\PinVector64.cs" Link="PinVector64.cs" />
     <Compile Include="Pca8574.cs" />
@@ -18,9 +15,7 @@
     <Compile Include="Pcx8575.cs" />
     <Compile Include="Pcx857x.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
+++ b/src/devices/Pcx857x/tests/Pcx857x.Tests.csproj
@@ -1,18 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Pcx857x.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/PiJuice/PiJuiceDevice.csproj
+++ b/src/devices/PiJuice/PiJuiceDevice.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
-	  <EnableDefaultItems>false</EnableDefaultItems>
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <Compile Include="*.cs" />
     <Compile Remove="samples\**" />
@@ -14,5 +11,4 @@
     <None Include="README.md" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" />
   </ItemGroup>
-  
 </Project>

--- a/src/devices/PiJuice/samples/PiJuiceDevice.sample.csproj
+++ b/src/devices/PiJuice/samples/PiJuiceDevice.sample.csproj
@@ -1,18 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-	<EnableDefaultItems>false</EnableDefaultItems>
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="PiJuiceDevice.sample.cs" />
   </ItemGroup>
-  
-    <ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\PiJuiceDevice.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-  
 </Project>

--- a/src/devices/Pn5180/Pn5180.csproj
+++ b/src/devices/Pn5180/Pn5180.csproj
@@ -1,20 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
-  <ItemGroup>    
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj">
-      <AdditionalProperties>$(AdditionalProperties);RuntimeIdentifier=linux</AdditionalProperties>
-    </ProjectReference>
+  <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Card\CardRfid.csproj" />
     <ProjectReference Include="..\Card\Mifare\Mifare.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Pn5180/samples/Pn5180sample.csproj
+++ b/src/devices/Pn5180/samples/Pn5180sample.csproj
@@ -1,12 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\..\Card\CreditCard\CreditCardProcessing.csproj" />
     <ProjectReference Include="..\..\Card\Mifare\Mifare.csproj" />
     <ProjectReference Include="..\..\Card\Ultralight\Ultralight.csproj" />

--- a/src/devices/Pn532/Pn532.csproj
+++ b/src/devices/Pn532/Pn532.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
     <Compile Include="*.cs" />
@@ -14,10 +11,8 @@
     <Compile Include="ListPassive\*.cs" />
     <Compile Include="AsTarget\*.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Card\CardRfid.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Pn532/samples/Pn532sample.csproj
+++ b/src/devices/Pn532/samples/Pn532sample.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\Card\CreditCard\CreditCardProcessing.csproj" />
     <ProjectReference Include="..\..\Card\Mifare\Mifare.csproj" />
@@ -17,5 +13,4 @@
     <ProjectReference Include="..\..\Card\Ultralight\Ultralight.csproj" />
     <ProjectReference Include="..\Pn532.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
+++ b/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
@@ -1,22 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="Gpio.cs" />
     <Compile Include="PinMapping.cs" />
     <Compile Include="RgbLedMatrix.cs" />
     <Compile Include="../Interop/Unix/ThreadHelper.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/RadioReceiver/RadioReceiver.csproj
+++ b/src/devices/RadioReceiver/RadioReceiver.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Devices\Tea5767\FrequencyRange.cs" />
     <Compile Include="Devices\Tea5767\SearchDirection.cs" />
     <Compile Include="Devices\Tea5767\Tea5767.cs" />
     <Compile Include="RadioReceiverBase.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/RadioReceiver/samples/RadioReceiver.Samples.csproj
+++ b/src/devices/RadioReceiver/samples/RadioReceiver.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\RadioReceiver.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/RadioTransmitter/RadioTransmitter.csproj
+++ b/src/devices/RadioTransmitter/RadioTransmitter.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Devices\Kt0803\BassBoost.cs" />
     <Compile Include="RadioTransmitterBase.cs" />
     <Compile Include="Devices\Kt0803\Region.cs" />
@@ -15,5 +12,4 @@
     <Compile Include="Devices\Kt0803\Register.cs" />
     <Compile Include="Devices\Kt0803\TransmissionPower.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/RadioTransmitter/samples/RadioTransmitter.Samples.csproj
+++ b/src/devices/RadioTransmitter/samples/RadioTransmitter.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\RadioTransmitter.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/RotaryEncoder/RotaryEncoder.csproj
+++ b/src/devices/RotaryEncoder/RotaryEncoder.csproj
@@ -1,17 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj">
-      <AdditionalProperties>$(AdditionalProperties);RuntimeIdentifier=linux</AdditionalProperties>
-    </ProjectReference>
   </ItemGroup>
-
 </Project>

--- a/src/devices/RotaryEncoder/samples/RotaryEncoder.Samples.csproj
+++ b/src/devices/RotaryEncoder/samples/RotaryEncoder.Samples.csproj
@@ -1,15 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../RotaryEncoder.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj">
-      <AdditionalProperties>$(AdditionalProperties);RuntimeIdentifier=linux</AdditionalProperties>
-    </ProjectReference>
   </ItemGroup>
-
 </Project>

--- a/src/devices/Rtc/Rtc.csproj
+++ b/src/devices/Rtc/Rtc.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="..\Common\Iot\Device\Common\NumberHelper.cs" />
     <Compile Include="Devices\Ds1307\Ds1307.cs" />
     <Compile Include="Devices\Ds1307\Ds1307Register.cs" />
@@ -21,5 +18,4 @@
     <Compile Include="Devices\Pcf8563\Pcf8563Register.cs" />
     <Compile Include="RtcBase.cs" />
   </ItemGroup>
-  
 </Project>

--- a/src/devices/Rtc/samples/Rtc.Samples.csproj
+++ b/src/devices/Rtc/samples/Rtc.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Rtc.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Seesaw/Seesaw.csproj
+++ b/src/devices/Seesaw/Seesaw.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\Common\System\Device\DelayHelper.cs" Link="DelayHelper.cs" />    
+    <Compile Include="..\Common\System\Device\DelayHelper.cs" Link="DelayHelper.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Seesaw/samples/Seesaw.Sample.BlinkingLights.csproj
+++ b/src/devices/Seesaw/samples/Seesaw.Sample.BlinkingLights.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <EnableDefaultItems>false</EnableDefaultItems>    
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Seesaw.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Seesaw.Sample.BlinkingLights.cs" />
     <Compile Include="../../../../samples/led-more-blinking-lights/TimeEnvelope.cs" />
     <Compile Include="Volume.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Seesaw/samples/Seesaw.Sample.Capabilities.csproj
+++ b/src/devices/Seesaw/samples/Seesaw.Sample.Capabilities.csproj
@@ -1,19 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Seesaw.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Seesaw.Sample.Capabilities.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="README.md" />
-  </ItemGroup>  
-  
+  </ItemGroup>
 </Project>

--- a/src/devices/Seesaw/samples/Seesaw.Sample.SoilSensor.csproj
+++ b/src/devices/Seesaw/samples/Seesaw.Sample.SoilSensor.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <EnableDefaultItems>false</EnableDefaultItems>    
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Seesaw.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-    <Compile Include="Seesaw.Sample.SoilSensor.cs" />    
+    <Compile Include="Seesaw.Sample.SoilSensor.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/SenseHat/SenseHat.csproj
+++ b/src/devices/SenseHat/SenseHat.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <ProjectReference Include="..\Lsm9Ds1\Lsm9Ds1.csproj" />
     <ProjectReference Include="..\Hts221\Hts221.csproj" />
     <ProjectReference Include="..\Lps25h\Lps25h.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/SenseHat/samples/SenseHat.Samples.csproj
+++ b/src/devices/SenseHat/samples/SenseHat.Samples.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-      <ProjectReference Include="../SenseHat.csproj" />
-      <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="../SenseHat.csproj" />
     <ProjectReference Include="..\..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/SensorHub/SensorHub.csproj
+++ b/src/devices/SensorHub/SensorHub.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <!-- for unit tests-->
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/src/devices/SensorHub/samples/SensorHub.Samples.csproj
+++ b/src/devices/SensorHub/samples/SensorHub.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../SensorHub.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/ServoMotor/ServoMotor.csproj
+++ b/src/devices/ServoMotor/ServoMotor.csproj
@@ -1,18 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
-    <EnableDefaultItems>false</EnableDefaultItems>    
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="ServoMotor.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)../SoftPwm/SoftwarePwm.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/ServoMotor/samples/ServoMotor.Sample.csproj
+++ b/src/devices/ServoMotor/samples/ServoMotor.Sample.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\ServoMotor.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/ServoMotor/tests/ServoMotor.Tests.csproj
+++ b/src/devices/ServoMotor/tests/ServoMotor.Tests.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../ServoMotor.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-  
 </Project>

--- a/src/devices/ShiftRegister/ShiftRegister.csproj
+++ b/src/devices/ShiftRegister/ShiftRegister.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="../Common/CommonHelpers.csproj" />
     <Compile Include="ShiftRegister.cs" />
     <Compile Include="ShiftRegisterPinMapping.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/ShiftRegister/samples/ShiftRegister-driver.csproj
+++ b/src/devices/ShiftRegister/samples/ShiftRegister-driver.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="../ShiftRegister.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Sht3x/Sht3x.csproj
+++ b/src/devices/Sht3x/Sht3x.csproj
@@ -1,21 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="I2cAddress.cs" />
     <Compile Include="Resolution.cs" />
     <Compile Include="Register.cs" />
     <Compile Include="Sht3x.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Sht3x/samples/Sht3x.Samples.csproj
+++ b/src/devices/Sht3x/samples/Sht3x.Samples.csproj
@@ -1,21 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Sht3x.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="SHT3x_circuit.fzz" />
     <None Remove="SHT3x_circuit_bb.jpg" />
     <None Remove="README.md" />
     <None Remove="RunningResult.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Shtc3/Shtc3.csproj
+++ b/src/devices/Shtc3/Shtc3.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" Link="DelayHelper.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Shtc3/samples/Shtc3.Samples.csproj
+++ b/src/devices/Shtc3/samples/Shtc3.Samples.csproj
@@ -1,19 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
     <None Remove="RunningResult.jpg" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\..\..\System.Device.Gpio\System.Device.Gpio.csproj" />
     <ProjectReference Include="..\..\Common\CommonHelpers.csproj" />
     <ProjectReference Include="..\Shtc3.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Si7021/Si7021.csproj
+++ b/src/devices/Si7021/Si7021.csproj
@@ -1,20 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Si7021.cs" />
     <Compile Include="Register.cs" />
     <Compile Include="Resolution.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="README.md" />
     <None Remove="sensor.jpg" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Si7021/samples/Si7021.Samples.csproj
+++ b/src/devices/Si7021/samples/Si7021.Samples.csproj
@@ -1,17 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Si7021.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\..\Common\CommonHelpers.csproj" />
   </ItemGroup>
-
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="Si7021_I2c_Read_Temp_Humidity.fzz" />
     <None Remove="Si7021_I2c_Read_Temp_Humidity.png" />
     <None Remove="README.md" />

--- a/src/devices/Sn74hc595/Sn74hc595.csproj
+++ b/src/devices/Sn74hc595/Sn74hc595.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="../ShiftRegister/ShiftRegister.csproj" />
     <Compile Include="Sn74hc595.cs" />
     <Compile Include="Sn74hc595PinMapping.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Sn74hc595/samples/Sn74hc595-driver.csproj
+++ b/src/devices/Sn74hc595/samples/Sn74hc595-driver.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="../Sn74hc595.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/SocketCan/SocketCan.csproj
+++ b/src/devices/SocketCan/SocketCan.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/SoftPwm/SoftwarePwm.csproj
+++ b/src/devices/SoftPwm/SoftwarePwm.csproj
@@ -1,19 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <EnableDefaultItems>false</EnableDefaultItems>    
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="SoftwarePwmChannel.cs" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" Link="DelayHelper.cs" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/SoftPwm/samples/SoftPwm.sample.csproj
+++ b/src/devices/SoftPwm/samples/SoftPwm.sample.csproj
@@ -1,17 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\SoftwarePwm.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/SoftwareSpi/SoftwareSpi.csproj
+++ b/src/devices/SoftwareSpi/SoftwareSpi.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ssd1351/Ssd1351.csproj
+++ b/src/devices/Ssd1351/Ssd1351.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Command\*.cs" />
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
   </ItemGroup>
-  
 </Project>

--- a/src/devices/Ssd1351/samples/Ssd1351.Samples.csproj
+++ b/src/devices/Ssd1351/samples/Ssd1351.Samples.csproj
@@ -1,24 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />    
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Ssd1351.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="images\*.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-
 </Project>

--- a/src/devices/Ssd13xx/Ssd13xx.csproj
+++ b/src/devices/Ssd13xx/Ssd13xx.csproj
@@ -1,24 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <!--Disabling default items so samples source won't get build by the main library-->
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Commands\*.cs" />
     <Compile Include="Commands\Ssd1327Commands\*.cs" />
     <Compile Include="Commands\Ssd1306Commands\*.cs" />
     <Compile Include="*.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/src/devices/Ssd13xx/samples/Ssd13xx.Samples.csproj
+++ b/src/devices/Ssd13xx/samples/Ssd13xx.Samples.csproj
@@ -1,23 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Ssd13xx.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="images\*.bmp">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ssd13xx/tests/Ssd13xx.Tests.csproj
+++ b/src/devices/Ssd13xx/tests/Ssd13xx.Tests.csproj
@@ -1,18 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Ssd13xx.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/StUsb4500/StUsb4500.csproj
+++ b/src/devices/StUsb4500/StUsb4500.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="Enumerations\StUsb4500Register.cs" />
@@ -20,7 +18,5 @@
     <Compile Include="Objects\UsbPdMessageHeader.cs" />
     <Compile Include="Objects\VariableSupplyObject.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/StUsb4500/samples/StUsb4500.Samples.csproj
+++ b/src/devices/StUsb4500/samples/StUsb4500.Samples.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../StUsb4500.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Tcs3472x/Tcs3472x.csproj
+++ b/src/devices/Tcs3472x/Tcs3472x.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Common\CommonHelpers.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Tcs3472x/samples/Tcs3472x.sample.csproj
+++ b/src/devices/Tcs3472x/samples/Tcs3472x.sample.csproj
@@ -1,16 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Tcs3472x.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Tlc1543/Tlc1543.csproj
+++ b/src/devices/Tlc1543/Tlc1543.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="../Common/System/Device/DelayHelper.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Tlc1543/samples/Tlc1543.Samples.csproj
+++ b/src/devices/Tlc1543/samples/Tlc1543.Samples.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../Tlc1543.csproj" />
     <ProjectReference Include="../../SoftwareSpi/SoftwareSpi.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Tm1637/Tm1637.csproj
+++ b/src/devices/Tm1637/Tm1637.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="..\Common\System\Device\DelayHelper.cs" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Tm1637/samples/Tm1637.sample.csproj
+++ b/src/devices/Tm1637/samples/Tm1637.sample.csproj
@@ -1,16 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-        <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Tm1637.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Tsl256x/Tsl256x.csproj
+++ b/src/devices/Tsl256x/Tsl256x.csproj
@@ -1,15 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
 </Project>

--- a/src/devices/Tsl256x/samples/Tsl256x.sample.csproj
+++ b/src/devices/Tsl256x/samples/Tsl256x.sample.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <ProjectReference Include="..\Tsl256x.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/UFireIse/UFireIse.csproj
+++ b/src/devices/UFireIse/UFireIse.csproj
@@ -1,22 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-   <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="../Common/System/Device/DelayHelper.cs" />
   </ItemGroup>
-  
-    <ItemGroup>
+  <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/src/devices/UFireIse/samples/UFireIse.Sample.csproj
+++ b/src/devices/UFireIse/samples/UFireIse.Sample.csproj
@@ -1,16 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\Iot.Device.Bindings\Iot.Device.Bindings.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Uln2003/Uln2003.csproj
+++ b/src/devices/Uln2003/Uln2003.csproj
@@ -1,20 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <Compile Include="Uln2003.cs" />
     <Compile Include="StepperMode.cs" />
   </ItemGroup>
-
-  <ItemGroup> 
+  <ItemGroup>
     <None Remove="README.md" />
     <None Remove="SM28BYJ48.png" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Uln2003/samples/Uln2003.Samples.csproj
+++ b/src/devices/Uln2003/samples/Uln2003.Samples.csproj
@@ -1,19 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
- <ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)/../Uln2003.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
-  <ItemGroup> 
-      <None Remove="README.md" />
-      <None Remove="Uln2003.png" />
-      <None Remove="Uln2003.fzz" />
+  <ItemGroup>
+    <None Remove="README.md" />
+    <None Remove="Uln2003.png" />
+    <None Remove="Uln2003.fzz" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Vl53L0X/Vl53L0X.csproj
+++ b/src/devices/Vl53L0X/Vl53L0X.csproj
@@ -1,14 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Vl53L0X/samples/Vl53L0X.sample.csproj
+++ b/src/devices/Vl53L0X/samples/Vl53L0X.sample.csproj
@@ -1,16 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Vl53L0X.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ws28xx/Ws28xx.csproj
+++ b/src/devices/Ws28xx/Ws28xx.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="../Common/Iot/Device/Graphics/BitmapImage.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/devices/Ws28xx/samples/Ws28xx.Samples.csproj
+++ b/src/devices/Ws28xx/samples/Ws28xx.Samples.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-   <PropertyGroup>
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-      <ProjectReference Include="../Ws28xx.csproj" />
-      <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
+    <ProjectReference Include="../Ws28xx.csproj" />
   </ItemGroup>
-
 </Project>

--- a/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.csproj
+++ b/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/_DeviceBinding.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/samples/_DeviceBinding.Samples.csproj
+++ b/tools/templates/DeviceBindingTemplate/dotnet_new_device-binding_csharp/samples/_DeviceBinding.Samples.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../_DeviceBinding.csproj" />
-    <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@Ellerbach reported today that VS had yellow warning signs in references in most of the binding projects. 
![image](https://user-images.githubusercontent.com/13854455/132057122-5f878d82-5796-4f50-95bb-f865fb36cd4e.png)

The reason why that was happening is because System.Device.Gpio project reference was added twice to all bindings, one global import, and one individual import per project. This PR is removing all of the individual imports in favor of just keeping the one global import, and I have validated that after doing this, the problem no longer repros:
![image](https://user-images.githubusercontent.com/13854455/132057273-37255cb3-81fe-40e2-8d9f-9db4ae061699.png)

Changes to projects where made using a small program I wrote which uses the MSBuild project model to make the changes, which is why most new-lines are being removed from .csprojs as a side effect.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1654)