### PR TITLE
Fixes  #1626

### DIFF
--- a/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
@@ -56,11 +56,8 @@ namespace Iot.Device.Multiplexing.Utility
         /// Does not display output.
         /// </summary>
         public void Write(byte value)
-        {
             // Write to 8 right-most segment values
-            int offset = _length - 8;
-            WriteByteAsValues(value, offset);
-        }
+            => WriteByteAsValues(value, 0);
 
         /// <summary>
         /// Writes discrete underlying bits to a virtual output.


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->

When using a segment with bigger length than the given value, it writes wrong bytes (as if the offset was being calculated from the left). As mentioned in the #1626 issue:
```
VirtualOutputSegment segment = new(12);
segment.Write(0b_1001_0110);

// Result (offset to the left side of the byte value)
// segment index: | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11
//         value: | 0 | 0 | 0 | 0 | 0 | 1 | 1 | 0 | 1 | 0 |  0 |  1

// Expected result (offset to the right side of the byte value)
// segment index: | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11
//         value: | 0 | 1 | 1 | 0 | 1 | 0 | 0 | 1 | 0 | 0 |  0 |  0
``
