### PR TITLE
Porting the MPU6886 from .NET nanoFramework

### DIFF
--- a/src/devices/Device-Index.md
+++ b/src/devices/Device-Index.md
@@ -60,6 +60,7 @@
 * [MotorHat](MotorHat/README.md)
 * [MPR121 - Proximity Capacitive Touch Sensor Controller](Mpr121/README.md)
 * [MPU6500/MPU9250 - Gyroscope, Accelerometer, Temperature and Magnetometer (MPU9250 only)](Mpu9250/README.md)
+* [MPU6886 - Gyroscope, Accelerometer and Temperature](Mpu6886/README.md)
 * [nRF24L01 - Single Chip 2.4 GHz Transceiver](Nrf24l01/README.md)
 * [NXP/TI PCx857x](Pcx857x/README.md)
 * [On-board LED driver](BoardLed/README.md)

--- a/src/devices/Mpu6886/AccelerometerLowPowerMode.cs
+++ b/src/devices/Mpu6886/AccelerometerLowPowerMode.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Mpu6886
+{
+    /// <summary>
+    /// Averaging filter settings for Low Power Accelerometer mode. (Datasheet page 37)
+    /// </summary>
+    public enum AccelerometerLowPowerMode
+    {
+        /// <summary>
+        /// Average of 4 samples.
+        /// </summary>
+        Average4Samples = 0b0000_0000,
+
+        /// <summary>
+        /// Average of 8 samples.
+        /// </summary>
+        Average8Samples = 0b0001_0000,
+
+        /// <summary>
+        /// Average of 16 samples.
+        /// </summary>
+        Average16Samples = 0b0010_0000,
+
+        /// <summary>
+        /// Average of 32 samples.
+        /// </summary>
+        Average32Samples = 0b0011_0000,
+    }
+}

--- a/src/devices/Mpu6886/AccelerometerScale.cs
+++ b/src/devices/Mpu6886/AccelerometerScale.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Mpu6886
+{
+    /// <summary>
+    /// Accelerometer scale. (Datasheet page 37)
+    /// </summary>
+    public enum AccelerometerScale
+    {
+        /// <summary>
+        /// +- 2G
+        /// </summary>
+        Scale2G = 0b0000_0000,
+
+        /// <summary>
+        /// +- 4G
+        /// </summary>
+        Scale4G = 0b0000_1000,
+
+        /// <summary>
+        /// +- 8G
+        /// </summary>
+        Scale8G = 0b0001_0000,
+
+        /// <summary>
+        /// +- 16G
+        /// </summary>
+        Scale16G = 0b0001_1000
+    }
+}

--- a/src/devices/Mpu6886/AxisEnabled.cs
+++ b/src/devices/Mpu6886/AxisEnabled.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Mpu6886
+{
+    /// <summary>
+    /// Axes to enable
+    /// </summary>
+    [Flags]
+    public enum EnabledAxis
+    {
+        /// <summary>
+        /// Accelerometer X axis.
+        /// </summary>
+        AccelerometerX = 0b0010_0000,
+
+        /// <summary>
+        /// Accelerometer Y axis.
+        /// </summary>
+        AccelerometerY = 0b0001_0000,
+
+        /// <summary>
+        /// Accelerometer Z axis.
+        /// </summary>
+        AccelerometerZ = 0b0000_1000,
+
+        /// <summary>
+        /// Gyroscope X axis.
+        /// </summary>
+        GyroscopeX = 0b0000_0100,
+
+        /// <summary>
+        /// Gyroscope Y axis.
+        /// </summary>
+        GyroscopeY = 0b0000_0010,
+
+        /// <summary>
+        /// Gyroscope Z axis.
+        /// </summary>
+        GyroscopeZ = 0b0000_0001,
+    }
+}

--- a/src/devices/Mpu6886/GyroscopeScale.cs
+++ b/src/devices/Mpu6886/GyroscopeScale.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Mpu6886
+{
+    /// <summary>
+    /// Gyroscope scale. (Datasheet page 37)
+    /// </summary>
+    public enum GyroscopeScale
+    {
+        /// <summary>
+        /// +- 250 dps
+        /// </summary>
+        Scale250dps = 0b0000_0000,
+
+        /// <summary>
+        /// +- 500 dps
+        /// </summary>
+        Scale500dps = 0b0000_1000,
+
+        /// <summary>
+        /// +- 1000 dps
+        /// </summary>
+        Scale1000dps = 0b0001_0000,
+
+        /// <summary>
+        /// +- 2000 dps
+        /// </summary>
+        Scale2000dps = 0b0001_1000
+    }
+}

--- a/src/devices/Mpu6886/InterruptEnable.cs
+++ b/src/devices/Mpu6886/InterruptEnable.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+namespace Iot.Device.Mpu6886
+{
+    /// <summary>
+    /// WoM interrupt on axes of accelerometer.
+    /// </summary>
+    [Flags]
+    public enum InterruptEnable
+    {
+        /// <summary>
+        /// All axes disabled.
+        /// </summary>
+        None = 0x0000_0000,
+
+        /// <summary>
+        /// Enable X axis.
+        /// </summary>
+        Xaxis = 0b1000_0000,
+
+        /// <summary>
+        /// Enable Y axis.
+        /// </summary>
+        Yaxis = 0b0100_0000,
+
+        /// <summary>
+        /// Enable Z axis.
+        /// </summary>
+        Zaxis = 0b0010_0000,
+    }
+}

--- a/src/devices/Mpu6886/Mpu6886.cs
+++ b/src/devices/Mpu6886/Mpu6886.cs
@@ -1,0 +1,456 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Device.I2c;
+using System.Device.Model;
+using System.IO;
+using System.Threading;
+using System.Numerics;
+using UnitsNet;
+
+namespace Iot.Device.Mpu6886
+{
+    /// <summary>
+    /// Mpu6886 accelerometer and gyroscope
+    /// </summary>
+    [Interface("Mpu6886 accelerometer and gyroscope")]
+    public class Mpu6886AccelerometerGyroscope : IDisposable
+    {
+        private const float GyroscopeResolution = (float)(2000.0 / 32768.0); // default gyro scale 2000 dps
+        private const float AccelerometerResolution = (float)(8.0 / 32768.0); // default accelerometer res 8G
+
+        /// <summary>
+        /// The default I2C address for the MPU6886 sensor. (Datasheet page 49)
+        /// Mind that the address can be configured as well for 0x69 depending upon the value driven on AD0 pin.
+        /// </summary>
+        public const int DefaultI2cAddress = 0x68;
+
+        /// <summary>
+        /// The secondary I2C address for the MPU6886 sensor. (Datasheet page 49)
+        /// </summary>
+        public const int SecondaryI2cAddress = 0x69;
+
+        private I2cDevice _i2c;
+
+        /// <summary>
+        /// Mpu6886 - Accelerometer and Gyroscope bus
+        /// </summary>
+        public Mpu6886AccelerometerGyroscope(
+            I2cDevice i2cDevice)
+        {
+            _i2c = i2cDevice ?? throw new ArgumentNullException(nameof(i2cDevice));
+
+            Span<byte> readBuffer = stackalloc byte[1];
+
+            _i2c.WriteByte((byte)Mpu6886.Register.WhoAmI);
+            _i2c.Read(readBuffer);
+            if (readBuffer[0] != 0x19)
+            {
+                throw new IOException($"This device does not contain the correct signature 0x19 for a MPU6886");
+            }
+
+            // Initialization sequence
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.PowerManagement1, 0b0000_0000 });
+            Thread.Sleep(10);
+
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.PowerManagement1, 0b0100_0000 });
+            Thread.Sleep(10);
+
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.PowerManagement1, 0b0000_0001 });
+            Thread.Sleep(10);
+
+            AccelerometerScale = AccelerometerScale.Scale8G;
+            GyroscopeScale = GyroscopeScale.Scale2000dps;
+
+            // CONFIG(0x1a) 1khz output
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.Configuration, 0b0000_0001 });
+            Thread.Sleep(1);
+
+            SampleRateDivider = 0b0000_0001;
+            AccelerometerInterruptEnabled = InterruptEnable.None;
+
+            // ACCEL_CONFIG 2(0x1d)
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.AccelerometerConfiguration2, 0b0000_0000 });
+            Thread.Sleep(1);
+
+            // USER_CTRL(0x6a)
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.UserControl, 0b0000_0000 });
+            Thread.Sleep(1);
+
+            // FIFO_EN(0x23)
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.FifoEnable, 0b0000_0000 });
+            Thread.Sleep(1);
+
+            // INT_PIN_CFG(0x37)
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.IntPinBypassEnabled, 0b0010_0010 });
+            Thread.Sleep(1);
+
+            // INT_ENABLE(0x38), "Data ready interrupt enable" bit
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.InteruptEnable, 0b0000_0001 });
+            Thread.Sleep(100);
+
+            // To avoid limiting sensor output to less than 0x7F7F, set this bit to 1. This should be done every time the MPU-6886 is powered up.
+            // Datasheet page 46
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.AccelerometerIntelligenceControl, 0b0000_0010 });
+            Thread.Sleep(10);
+        }
+
+        private Vector3 GetRawAccelerometer()
+        {
+            Span<Byte> vec = stackalloc byte[6];
+            Read(Mpu6886.Register.AccelerometerMeasurementXHighByte, vec);
+
+            short x = (short)(vec[0] << 8 | vec[1]);
+            short y = (short)(vec[2] << 8 | vec[3]);
+            short z = (short)(vec[4] << 8 | vec[5]);
+
+            return new Vector3(x, y, z);
+        }
+
+        private Vector3 GetRawGyroscope()
+        {
+            Span<Byte> vec = stackalloc byte[6];
+            Read(Mpu6886.Register.GyropscopeMeasurementXHighByte, vec);
+
+            short x = (short)(vec[0] << 8 | vec[1]);
+            short y = (short)(vec[2] << 8 | vec[3]);
+            short z = (short)(vec[4] << 8 | vec[5]);
+
+            return new Vector3(x, y, z);
+        }
+
+        private short GetRawInternalTemperature()
+        {
+            Span<Byte> vec = stackalloc byte[2];
+            Read(Mpu6886.Register.TemperatureMeasurementHighByte, vec);
+
+            return (short)(vec[0] << 8 | vec[1]);
+        }
+
+        /// <summary>
+        /// Reads the current accelerometer values from the registers, and compensates them with the accelerometer resolution.
+        /// </summary>
+        /// <returns>Vector of acceleration</returns>
+        public Vector3 GetAccelerometer() => GetRawAccelerometer() * AccelerometerResolution;
+
+        /// <summary>
+        /// Reads the current gyroscope values from the registers, and compensates them with the gyroscope resolution.
+        /// </summary>
+        /// <returns>Vector of the rotation</returns>
+        public Vector3 GetGyroscope() => GetRawGyroscope() * GyroscopeResolution;
+
+        /// <summary>
+        /// Reads the register of the on-chip temperature sensor which represents the MPU-6886 die temperature.
+        /// </summary>
+        /// <returns>Temperature in degrees Celcius</returns>
+        public Temperature GetInternalTemperature()
+        {
+            var rawInternalTemperature = GetRawInternalTemperature();
+
+            // p43 of datasheet describes the room temp. compensation calcuation
+            return new Temperature(rawInternalTemperature / 326.8 + 25.0, UnitsNet.Units.TemperatureUnit.DegreeCelsius);
+        }
+
+        private void WriteByte(Register register, byte data)
+        {
+            Span<Byte> buff = stackalloc byte[2]
+            {
+                (byte)register,
+                data
+            };
+
+            _i2c.Write(buff);
+        }
+
+        private short ReadInt16(Register register)
+        {
+            Span<Byte> val = stackalloc byte[2];
+            Read(register, val);
+            return BinaryPrimitives.ReadInt16LittleEndian(val);
+        }
+
+        private void Read(Register register, Span<byte> buffer)
+        {
+            _i2c.WriteByte((byte)((byte)register));
+            _i2c.Read(buffer);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _i2c?.Dispose();
+            _i2c = null!;
+        }
+
+        /// <summary>
+        /// Calibrate the gyroscope by calculating the offset values and storing them in the GyroscopeOffsetAdjustment registers of the MPU6886.
+        /// </summary>
+        /// <param name="iterations">The number of sample gyroscope values to read</param>
+        /// <returns>The calulated offset vector</returns>
+        public Vector3 Calibrate(int iterations)
+        {
+            GyroscopeOffset = new Vector3(0, 0, 0);
+            Thread.Sleep(2);
+
+            var gyrSum = new double[3];
+
+            for (int i = 0; i < iterations; i++)
+            {
+                var gyr = GetRawGyroscope();
+
+                gyrSum[0] += gyr.X;
+                gyrSum[1] += gyr.Y;
+                gyrSum[2] += gyr.Z;
+
+                Thread.Sleep(2);
+            }
+
+            Vector3 offset = new Vector3((float)(gyrSum[0] / iterations), (float)(gyrSum[1] / iterations), (float)(gyrSum[2] / iterations));
+
+            GyroscopeOffset = offset;
+
+            return offset;
+        }
+
+        /// <summary>
+        /// Gets and sets the gyroscope offset in the GyroscopeOffsetAdjustment registers of the MPU6886.
+        /// Setting the offset can be usefull when a custom callibration calculation is used, instead of the Calibrate function of this class.
+        /// </summary>
+        public Vector3 GyroscopeOffset
+        {
+            get
+            {
+                Span<Byte> vec = stackalloc byte[6];
+                Read(Mpu6886.Register.GyroscopeOffsetAdjustmentXHighByte, vec);
+
+                Vector3 v = new Vector3();
+                v.X = (short)(vec[0] << 8 | vec[1]);
+                v.Y = (short)(vec[2] << 8 | vec[3]);
+                v.Z = (short)(vec[4] << 8 | vec[5]);
+
+                return v;
+            }
+
+            set
+            {
+                Span<Byte> registerAndOffset = stackalloc byte[7];
+                Span<Byte> offsetbyte = stackalloc byte[2];
+
+                registerAndOffset[0] = (byte)Mpu6886.Register.GyroscopeOffsetAdjustmentXHighByte;
+
+                BinaryPrimitives.WriteInt16BigEndian(offsetbyte, (short)value.X);
+                registerAndOffset[1] = offsetbyte[0];
+                registerAndOffset[2] = offsetbyte[1];
+
+                BinaryPrimitives.WriteInt16BigEndian(offsetbyte, (short)value.Y);
+                registerAndOffset[3] = offsetbyte[0];
+                registerAndOffset[4] = offsetbyte[1];
+
+                BinaryPrimitives.WriteInt16BigEndian(offsetbyte, (short)value.Z);
+                registerAndOffset[5] = offsetbyte[0];
+                registerAndOffset[6] = offsetbyte[1];
+
+                _i2c.Write(registerAndOffset);
+            }
+        }
+
+        /// <summary>
+        /// Reset the internal registers and restores the default settings. (Datasheet, page 47)
+        /// </summary>
+        public void Reset()
+        {
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.PowerManagement1, 0b1000_0000 });
+            Thread.Sleep(10);
+        }
+
+        /// <summary>
+        /// Set the chip to sleep mode. (Datasheet, page 47)
+        /// </summary>
+        public void Sleep()
+        {
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.PowerManagement1, 0b0100_0000 });
+            Thread.Sleep(10);
+        }
+
+        /// <summary>
+        /// Disables the sleep mode. (Datasheet, page 47)
+        /// </summary>
+        public void WakeUp()
+        {
+            _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.PowerManagement1, 0b0000_0000 });
+            Thread.Sleep(10);
+        }
+
+        /// <summary>
+        /// Gets and sets the accelerometer full scale. (Datasheet page 37)
+        /// </summary>
+        public AccelerometerScale AccelerometerScale
+        {
+            get
+            {
+                Span<Byte> buffer = stackalloc byte[1];
+                Read(Mpu6886.Register.AccelerometerConfiguration1, buffer);
+                return (AccelerometerScale)(buffer[0] & 0b0001_1000);
+            }
+
+            set
+            {
+                // First read the current register values
+                Span<Byte> currentRegisterValues = stackalloc byte[1];
+                _i2c.WriteByte((byte)Mpu6886.Register.AccelerometerConfiguration1);
+                _i2c.Read(currentRegisterValues);
+
+                byte newvalue = (byte)((currentRegisterValues[0] & 0b1110_0111) | (byte)value); // apply the new scale, we leave all bits except bit 3 and 4 untouched with mask 0b1110_0111
+
+                // write the new register value
+                _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.AccelerometerConfiguration1, newvalue });
+
+                Thread.Sleep(1);
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the gyroscope full scale. (Datasheet page 37)
+        /// </summary>
+        public GyroscopeScale GyroscopeScale
+        {
+            get
+            {
+                Span<Byte> buffer = stackalloc byte[1];
+                Read(Mpu6886.Register.GyroscopeConfiguration, buffer);
+                return (GyroscopeScale)(buffer[0] & 0b0001_1000);
+            }
+
+            set
+            {
+                // First read the current register values
+                Span<Byte> currentRegisterValues = stackalloc byte[1];
+                _i2c.WriteByte((byte)Mpu6886.Register.GyroscopeConfiguration);
+                _i2c.Read(currentRegisterValues);
+
+                byte newvalue = (byte)((currentRegisterValues[0] & 0b1110_0111) | (byte)value); // apply the new scale, we leave all bits except bit 3 and 4 untouched with this mask 0b1110_0111
+
+                // write the new register value
+                _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.GyroscopeConfiguration, newvalue });
+
+                Thread.Sleep(1);
+            }
+        }
+
+        /// <summary>
+        /// Sets the enabled axes of the gyroscope and accelerometer. (Datasheet page 47)
+        /// </summary>
+        public EnabledAxis EnabledAxes
+        {
+            get
+            {
+                Span<Byte> readBuffer = stackalloc byte[1];
+                _i2c.WriteByte((byte)Mpu6886.Register.PowerManagement2);
+                _i2c.Read(readBuffer);
+
+                // bit 1 in the register means disabled, so using bitwise not to flip bits.
+                return (EnabledAxis)(~readBuffer[0] & 0b0011_1111);
+            }
+
+            set
+            {
+                // First read the current register values
+                Span<Byte> currentRegisterValues = stackalloc byte[1];
+                _i2c.WriteByte((byte)Mpu6886.Register.PowerManagement2);
+                _i2c.Read(currentRegisterValues);
+
+                byte newvalue = (byte)((currentRegisterValues[0] & 0b1100_0000) | (byte)value); // apply the new enabled axes, we leave all bits except bit 7 and 6 untouched with mask 0b1100_0000
+
+                // write the new register value
+                // bit 1 in the register means disabled, so using bitwise not to flip bits.
+                _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.PowerManagement2, (byte)~newvalue });
+
+                Thread.Sleep(1);
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the averaging filter settings for low power accelerometer mode. (Datasheet page 37)
+        /// </summary>
+        public AccelerometerLowPowerMode AccelerometerLowPowerMode
+        {
+            get
+            {
+                Span<Byte> currentRegisterValues = stackalloc byte[1];
+                _i2c.WriteByte((byte)Mpu6886.Register.AccelerometerConfiguration2);
+                _i2c.Read(currentRegisterValues);
+
+                byte cleaned = (byte)(currentRegisterValues[0] & 0b0011_0000); // we leave all bits except bit 4 and 5 untouched with this mask
+
+                return (AccelerometerLowPowerMode)cleaned;
+            }
+
+            set
+            {
+                // First read the current register values
+                Span<Byte> currentRegisterValues = stackalloc byte[1];
+                _i2c.WriteByte((byte)Mpu6886.Register.AccelerometerConfiguration2);
+                _i2c.Read(currentRegisterValues);
+
+                byte newvalue = (byte)((currentRegisterValues[0] & 0b1100_1111) | (byte)value); // apply the new enabled axes, we leave all bits except bit 4 and 5 untouched with mask 0b1100_1111
+
+                // write the new register value
+                _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.AccelerometerConfiguration2, newvalue });
+                Thread.Sleep(2);
+            }
+        }
+
+        /// <summary>
+        /// Divides the internal sample rate (see register CONFIG) to generate the sample rate that
+        /// controls sensor data output rate, FIFO sample rate. (Datasheet page 35)
+        /// </summary>
+        public byte SampleRateDivider
+        {
+            get
+            {
+                Span<Byte> readbuffer = stackalloc byte[1];
+                _i2c.WriteByte((byte)Mpu6886.Register.SampleRateDevider);
+                _i2c.Read(readbuffer);
+                return readbuffer[0];
+            }
+
+            set
+            {
+                _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.SampleRateDevider, value });
+                Thread.Sleep(1);
+            }
+        }
+
+        /// <summary>
+        /// The axes on which the interrupt should be enabled.
+        /// </summary>
+        public InterruptEnable AccelerometerInterruptEnabled
+        {
+            get
+            {
+                Span<Byte> readbuffer = stackalloc byte[1];
+                _i2c.WriteByte((byte)Mpu6886.Register.InteruptEnable);
+                _i2c.Read(readbuffer);
+                return (InterruptEnable)(readbuffer[0] & 0b1110_0000);
+            }
+
+            set
+            {
+                // First read the current register values
+                Span<Byte> currentRegisterValues = stackalloc byte[1];
+                _i2c.WriteByte((byte)Mpu6886.Register.InteruptEnable);
+                _i2c.Read(currentRegisterValues);
+
+                byte newvalue = (byte)((currentRegisterValues[0] & 0b0011_1111) | (byte)value); // apply the new enabled axes, we leave all bits except bit 4 and 5 untouched with mask 0b0011_1111
+
+                // write the new register value
+                _i2c.Write(stackalloc byte[] { (byte)Mpu6886.Register.InteruptEnable, newvalue });
+                Thread.Sleep(2);
+
+            }
+        }
+
+    }
+}

--- a/src/devices/Mpu6886/Mpu6886.csproj
+++ b/src/devices/Mpu6886/Mpu6886.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
+    <!--Disabling default items so samples source won't get build by the main library-->
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="*.cs" />
+  </ItemGroup>
+</Project>

--- a/src/devices/Mpu6886/Mpu6886.sln
+++ b/src/devices/Mpu6886/Mpu6886.sln
@@ -1,0 +1,53 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{{76F5ABF2-CCBB-4982-A899-71191E5F0C21}}") = "samples", "samples", "{{E7F48408-9EA9-4DF7-9917-2A838B87492D}}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBD}") = "Mpu6886.Samples", "samples\Mpu6886.Samples.csproj", "{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBD}") = "Mpu6886", "Mpu6886.csproj", "{4962D720-70FA-4F4D-AB36-CE618B1B085E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Debug|x64.Build.0 = Debug|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Debug|x86.Build.0 = Debug|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Release|Any CPU.Build.0 = Release|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Release|x64.ActiveCfg = Release|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Release|x64.Build.0 = Release|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Release|x86.ActiveCfg = Release|Any CPU
+		{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}}.Release|x86.Build.0 = Release|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Debug|x64.Build.0 = Debug|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Debug|x86.Build.0 = Debug|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Release|x64.ActiveCfg = Release|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Release|x64.Build.0 = Release|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Release|x86.ActiveCfg = Release|Any CPU
+		{4962D720-70FA-4F4D-AB36-CE618B1B085E}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		#{{4A5D9878-6CA5-4D22-ACE3-8B1516375C7D}} = {{8D894AD0-A14B-4653-BD2A-96C7AF9B3248}}
+	EndGlobalSection
+EndGlobal

--- a/src/devices/Mpu6886/README.md
+++ b/src/devices/Mpu6886/README.md
@@ -1,0 +1,121 @@
+﻿# Mpu6886 - accelerometer and gyroscope
+
+The MPU-6886 is a 6-axis motion tracking sensor that combines a 3-axis gyroscope and a 3-axis accelerometer including the following features:
+
+- gyroscope programmable FSR of ±250 dps, ±500 dps, ±1000 dps, and ±2000 dps
+- accelerometer with programmable FSR of ±2g, ±4g, ±8g, and ±16g
+
+## Documentation
+
+- [Datasheet](https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/MPU-6886-000193%2Bv1.1_GHIC_en.pdf), register descriptions start at page 32.
+
+## Usage
+
+Create the `Mpu6886` class and pass the I2C device. By default the I2C address for this sensor is `0x68`.
+
+```csharp
+I2cConnectionSettings settings = new(busId: 1, deviceAddress: Mpu6886AccelerometerGyroscope.DefaultI2cAddress);
+using (Mpu6886AccelerometerGyroscope ag = new(I2cDevice.Create(settings)))
+{
+    Console.WriteLine("Start calibration ...");
+    var offset = ag.Calibrate(1000);
+    Console.WriteLine($"Calibration done, calculated offsets {offset.X} {offset.Y} {offset.Y}");
+
+    Console.WriteLine($"Internal temperature: {ag.GetInternalTemperature().DegreesCelsius} C");
+
+    while (!Console.KeyAvailable)
+    {
+        var acc = ag.GetAccelerometer();
+        var gyr = ag.GetGyroscope();
+        Console.WriteLine($"Accelerometer data x:{acc.X} y:{acc.Y} z:{acc.Z}");
+        Console.WriteLine($"Gyroscope data x:{gyr.X} y:{gyr.Y} z:{gyr.Z}\n");
+        Thread.Sleep(100);
+    }
+}
+```
+
+### Sample output
+
+```text
+Start calibration ...
+Calibration done, calculated offsets 49.189 -86.21099999 -86.21099999
+Internal temperature: 64.21664626 C
+Accelerometer data x:-0.041503906 y:0 z:1.056884765
+Gyroscope data x:4.94384765 y:-8.60595703 z:-15.68603515
+
+Accelerometer data x:-0.040771484 y:-0.0051269531 z:1.062988281
+Gyroscope data x:4.94384765 y:-7.56835937 z:-15.014648437
+
+Accelerometer data x:-0.046630859 y:-0.0068359375 z:1.055175781
+Gyroscope data x:3.60107421 y:-7.62939453 z:-15.1977539
+
+Accelerometer data x:-0.049560546 y:-0 z:1.061279296
+Gyroscope data x:4.39453125 y:-7.32421875 z:-14.28222656
+```
+
+See [samples](samples) for a complete sample application.
+
+## Calibration
+
+The gyroscope can be calibrated using the `Calibrate` function. With the `iterations` parameter
+you can specify how many values should be read from the sensor to calculate an average (1000 iterations seems
+to be a good number). During the calibration you want to keep the sensor still and in a fixed position (e.g. lying
+flat on a table). The `Calibrate` function will write the values to the corresponding compensation registers
+of the sensor, values are corrected when retrieved automatically.
+
+The return value of the `Calibrate` method gives a vector containing the 3 (for the X,Y and Z axes) calculated
+compensation values.
+
+```csharp
+var offset = ag.Calibrate(1000);
+Debug.WriteLine($"Calibration done, calculated offsets {offset.X} {offset.Y} {offset.Y}");
+```
+
+It is possible to write directly to the compensation registers using the `SetGyroscopeOffset` function. You might
+want to do this when you create your own custom calibration method, or you retrieve existing calibration data from
+a persisted data store or memory location.
+
+⚠ **When the devices reboots, the offset registers are cleared.** So if you don't persist the calibration data yourself
+you will have to run the calibration method every time the device boots.
+
+## Sleep mode
+
+The sensor can be put in sleep mode by calling the `Sleep` function. After that the `WakeUp` function should be called.
+
+## Setting scales
+
+Both for the gyroscope and accelerometer you can set the desired scales using the `AccelerometerScale` and `GyroscopeScale`
+properties.
+
+```csharp
+// Set the scale of the accelerometer to 2G
+ag.AccelerometerScale = AccelerometerScale.Scale2G;
+```
+
+## Setting enabled axes
+
+By default all gyroscope and accelerometer axes are enabled. If desired you can specify explicitly which axes should be enabled.
+In that case, all other axes will be disabled. When an axis is disabled, data can still be read for that axis but the values will not
+change anymore.
+
+```csharp
+// Enable only the X axis of the gyroscope and accelerometer
+ag.EnabledAxes = EnabledAxis.GyroscopeX | EnabledAxis.AccelerometerX;
+```
+
+## Features not implemented
+
+The following features are enabled in the MPU6886 but not yet implemented in this driver:
+
+- registers `0x05` to `0x0b`: low noise to low power offset
+- registers `0x0d` to `0x0F`: self test
+- register `0x1a`: FIFO mode, DLPF (digital low pass filter)
+- register `0x1d` bit 0 to 3: DLPF
+- register `0x1e` bit 4 to 6: averaging filter for low power mode
+- registers `0x20` to `0x22`: threshold for wake-on motion
+- register `0x36`: fsync interrupt status
+- register `0x37`: INT/DRDY pin config
+- register `0x39` and `0x3a`: FIFO watermark interrupt
+- register `0x60` and `0x61`: FIFO watermark interrupt
+- register `0x68`: signal path reset
+- register `0x69`: acc. intelligence control

--- a/src/devices/Mpu6886/Register.cs
+++ b/src/devices/Mpu6886/Register.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Mpu6886
+{
+    // Register for Accelerometer and Gyroscope
+    internal enum Register : byte
+    {
+        Address = 0x68, // MPU6886_ADDRESS
+        WhoAmI = 0x75, // MPU6886_WHOAMI
+        AccelerometerIntelligenceControl = 0x69, // MPU6886_ACCEL_INTEL_CTRL
+        SampleRateDevider = 0x19, // MPU6886_SMPLRT_DIV
+        IntPinBypassEnabled = 0x37, // MPU6886_INT_PIN_CFG
+        InteruptEnable = 0x38, // MPU6886_INT_ENABLE
+        AccelerometerMeasurementXHighByte = 0x3B, // MPU6886_ACCEL_XOUT_H
+        AccelerometerMeasurementXLowByte = 0x3C, // MPU6886_ACCEL_XOUT_L
+        AccelerometerMeasurementYHighByte = 0x3D, // MPU6886_ACCEL_YOUT_H
+        AccelerometerMeasurementYLowByte = 0x3E, // MPU6886_ACCEL_YOUT_L
+        AccelerometerMeasurementZHighByte = 0x3F, // MPU6886_ACCEL_ZOUT_H
+        AccelerometerMeasurementZLowByte = 0x40, // MPU6886_ACCEL_ZOUT_L
+
+        TemperatureMeasurementHighByte = 0x41, // MPU6886_TEMP_OUT_H
+        TemperatureMeasurementLowByte = 0x42, // MPU6886_TEMP_OUT_L
+
+        GyropscopeMeasurementXHighByte = 0x43, // MPU6886_GYRO_XOUT_H
+        GyropscopeMeasurementXLowByte = 0x44, // MPU6886_GYRO_XOUT_L
+        GyropscopeMeasurementYHighByte = 0x45, // MPU6886_GYRO_YOUT_H
+        GyropscopeMeasurementYLowByte = 0x46, // MPU6886_GYRO_YOUT_L
+        GyropscopeMeasurementZHighByte = 0x47, // MPU6886_GYRO_ZOUT_H
+        GyropscopeMeasurementZLowByte = 0x48, // MPU6886_GYRO_ZOUT_L
+
+        UserControl = 0x6A, // MPU6886_USER_CTRL
+        PowerManagement1 = 0x6B, // MPU6886_PWR_MGMT_1
+        PowerManagement2 = 0x6C, // MPU6886_PWR_MGMT_2
+        Configuration = 0x1A, // MPU6886_CONFIG
+        GyroscopeConfiguration = 0x1B, // MPU6886_GYRO_CONFIG
+        AccelerometerConfiguration1 = 0x1C, // MPU6886_ACCEL_CONFIG1
+        AccelerometerConfiguration2 = 0x1D, // MPU6886_ACCEL_CONFIG2
+        FifoEnable = 0x23, // MPU6886_FIFO_EN
+
+        GyroscopeOffsetAdjustmentXHighByte = 0x13, // X-GYRO OFFSET ADJUSTMENT REGISTER � HIGH BYTE
+        GyroscopeOffsetAdjustmentXLowByte = 0x14, // X-GYRO OFFSET ADJUSTMENT REGISTER � LOW BYTE
+        GyroscopeOffsetAdjustmentYHighByte = 0x15, // Y-GYRO OFFSET ADJUSTMENT REGISTER � HIGH BYTE
+        GyroscopeOffsetAdjustmentYLowByte = 0x16, // Y-GYRO OFFSET ADJUSTMENT REGISTER � LOW BYTE
+        GyroscopeOffsetAdjustmentZHighByte = 0x17, // Z-GYRO OFFSET ADJUSTMENT REGISTER � HIGH BYTE
+        GyroscopeOffsetAdjustmentZLowByte = 0x18, // Z-GYRO OFFSET ADJUSTMENT REGISTER � LOW BYTE
+    }
+}

--- a/src/devices/Mpu6886/category.txt
+++ b/src/devices/Mpu6886/category.txt
@@ -1,0 +1,2 @@
+accelerometer
+gyroscope

--- a/src/devices/Mpu6886/samples/Mpu6886.Samples.csproj
+++ b/src/devices/Mpu6886/samples/Mpu6886.Samples.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Mpu6886.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/devices/Mpu6886/samples/Program.cs
+++ b/src/devices/Mpu6886/samples/Program.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Device.I2c;
+using Iot.Device.Mpu6886;
+
+I2cConnectionSettings settings = new(busId: 1, deviceAddress: Mpu6886AccelerometerGyroscope.DefaultI2cAddress);
+using (Mpu6886AccelerometerGyroscope ag = new(I2cDevice.Create(settings)))
+{
+    Console.WriteLine("Start calibration ...");
+    var offset = ag.Calibrate(1000);
+    Console.WriteLine($"Calibration done, calculated offsets {offset.X} {offset.Y} {offset.Y}");
+
+    Console.WriteLine($"Internal temperature: {ag.GetInternalTemperature().DegreesCelsius} C");
+
+    while (!Console.KeyAvailable)
+    {
+        var acc = ag.GetAccelerometer();
+        var gyr = ag.GetGyroscope();
+        Console.WriteLine($"Accelerometer data x:{acc.X} y:{acc.Y} z:{acc.Z}");
+        Console.WriteLine($"Gyroscope data x:{gyr.X} y:{gyr.Y} z:{gyr.Z}\n");
+        Thread.Sleep(100);
+    }
+}


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->
This is a port of the MPU6886 binding (gyroscope & accelerometer) from the .NET nanoFramework ([link to binding](https://github.com/nanoframework/nanoFramework.IoT.Device/tree/develop/devices/Mpu6886)).