### PR TITLE
Migrate to 1ES hosted pools

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -58,8 +58,8 @@ stages:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: Hosted VS2017
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2017
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017
         variables:
         - HelixApiAccessToken: ''
         - _InternalBuildArgs: ''


### PR DESCRIPTION
We are migrating the build pools to 1ES hosted pools. This PR updates pipeline to use the new pools.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1679)