### PR TITLE
Offset in VirtualOutputSegment.Write(byte value) shouldn't be calculated (is always 0).

### DIFF
--- a/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
@@ -80,7 +80,6 @@ namespace Iot.Device.Multiplexing.Utility
                 WriteByteAsValues(value[i], offset);
             }
         }
-        }
 
         private void WriteByteAsValues(byte value, int offset)
         {

--- a/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
@@ -66,9 +66,9 @@ namespace Iot.Device.Multiplexing.Utility
         public void Write(ReadOnlySpan<byte> value)
         {
             // Scenarios
-            // values can be shorter than byteLength
-            // values can be longer than byteLength
-            // values can be same as byteLength
+            // values can be shorter than byteLength e.g. (1 * 8) - 16 = -8 < 0
+            // values can be longer than byteLength e.g. (3 * 8) - 16 = 8 > 0
+            // values can be same as byteLength e.g. (2 * 8) - 16 = 0
             if (value.Length * 8 > _length)
             {
                 throw new ArgumentException($"The bytes provided exceed the length of the {nameof(IOutputSegment)}.");

--- a/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
@@ -66,20 +66,20 @@ namespace Iot.Device.Multiplexing.Utility
         public void Write(ReadOnlySpan<byte> value)
         {
             // Scenarios
-            // values can be shorter than byteLength e.g. (1 * 8) - 16 = -8 < 0
-            // values can be longer than byteLength  e.g. (3 * 8) - 16 =  8 > 0
-            // values can be same as byteLength      e.g. (2 * 8) - 16 =      0
-            int offset = (value.Length * 8) - _length;
-            if (offset > 0)
+            // values can be shorter than byteLength
+            // values can be longer than byteLength
+            // values can be same as byteLength
+            if (value.Length * 8 > _length)
             {
-                throw new Exception($"The bytes provided exceed the length of the {nameof(IOutputSegment)}.");
+                throw new ArgumentException($"The bytes provided exceed the length of the {nameof(IOutputSegment)}.");
             }
 
             for (int i = 0; i < value.Length; i++)
             {
-                int index = value.Length - i - 1;
-                WriteByteAsValues(value[index], offset + (i * 8));
+                int offset = i * 8;
+                WriteByteAsValues(value[i], offset);
             }
+        }
         }
 
         private void WriteByteAsValues(byte value, int offset)

--- a/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/VirtualOutputSegment.cs
@@ -56,11 +56,7 @@ namespace Iot.Device.Multiplexing.Utility
         /// Does not display output.
         /// </summary>
         public void Write(byte value)
-        {
-            // Write to 8 right-most segment values
-            int offset = _length - 8;
-            WriteByteAsValues(value, offset);
-        }
+            => WriteByteAsValues(value, 0);
 
         /// <summary>
         /// Writes discrete underlying bits to a virtual output.

--- a/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
@@ -61,28 +61,47 @@ namespace Iot.Device.Multiplexing
         }
 
         [Fact]
-        public void SegmentValuesWriteLongByte()
+        public void SegmentWriteLongByte()
         {
+            // Scenario: values same as byteLength
             VirtualOutputSegment segment = new(16);
-            segment.Write(new byte[] { 0b_1101_0110, 0b_1111_0010 });
+            segment.Write(new byte[] { 0b_1001_0110, 0b_1111_0000 });
+            var expected = new PinValue[] { 0, 1, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1 };
 
-            Assert.True(
-                segment[0] == 0 &&
-                segment[1] == 1 &&
-                segment[2] == 0 &&
-                segment[3] == 0 &&
-                segment[4] == 1 &&
-                segment[5] == 1 &&
-                segment[6] == 1 &&
-                segment[7] == 1 &&
-                segment[8] == 0 &&
-                segment[9] == 1 &&
-                segment[10] == 1 &&
-                segment[11] == 0 &&
-                segment[12] == 1 &&
-                segment[13] == 0 &&
-                segment[14] == 1 &&
-                segment[15] == 1);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], segment[i]);
+            }
+        }
+
+        [Fact]
+        public void SegmentWriteLongByteValueLonger()
+        {
+            // Scenario: values longer than byteLength
+            VirtualOutputSegment segment = new(12);
+            byte[] value = new byte[] { 0b_1001_0110, 0b_1111_0000 };
+
+            Assert.Throws<ArgumentException>(() => segment.Write(value));
+        }
+
+        [Fact]
+        public void SegmentWriteLongByteValueShorter()
+        {
+            // Scenario: values shorter than byteLength
+            VirtualOutputSegment segment = new(24);
+            byte[] value = new byte[] { 0b_1001_0110, 0b_1111_0000 };
+            segment.Write(value);
+            var expected = new PinValue[]
+            { 
+                0, 1, 1, 0, 1, 0, 0, 1,
+                0, 0, 0, 0, 1, 1, 1, 1,
+                0, 0, 0, 0, 0, 0, 0, 0
+            };
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], segment[i]);
+            }
         }
 
         [Fact]

--- a/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
@@ -37,15 +37,12 @@ namespace Iot.Device.Multiplexing
             VirtualOutputSegment segment = new(12);
             segment.Write(0b_1001_0110);
 
-            Assert.True(
-                segment[0] == 0 &&
-                segment[1] == 1 &&
-                segment[2] == 1 &&
-                segment[3] == 0 &&
-                segment[4] == 1 &&
-                segment[5] == 0 &&
-                segment[6] == 0 &&
-                segment[7] == 1);
+            var expected = new PinValue[] { 0, 1, 1, 0, 1, 0, 0, 1 };
+
+            for (int i = 0; i<expected.Length; i++)
+            {
+                Assert.Equal(expected[i], segment[i]);
+            }
         }
 
         [Fact]
@@ -54,15 +51,12 @@ namespace Iot.Device.Multiplexing
             VirtualOutputSegment segment = new(8);
             segment.Write(0b_1001_0110);
 
-            Assert.True(
-                segment[0] == 0 &&
-                segment[1] == 1 &&
-                segment[2] == 1 &&
-                segment[3] == 0 &&
-                segment[4] == 1 &&
-                segment[5] == 0 &&
-                segment[6] == 0 &&
-                segment[7] == 1);
+            var expected = new PinValue[] { 0, 1, 1, 0, 1, 0, 0, 1 };
+
+            for (int i = 0; i<expected.Length; i++)
+            {
+                Assert.Equal(expected[i], segment[i]);
+            }
         }
 
         [Fact]

--- a/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
@@ -92,7 +92,7 @@ namespace Iot.Device.Multiplexing
             byte[] value = new byte[] { 0b_1001_0110, 0b_1111_0000 };
             segment.Write(value);
             var expected = new PinValue[]
-            { 
+            {
                 0, 1, 1, 0, 1, 0, 0, 1,
                 0, 0, 0, 0, 1, 1, 1, 1,
                 0, 0, 0, 0, 0, 0, 0, 0

--- a/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
@@ -29,6 +29,24 @@ namespace Iot.Device.Multiplexing
                 segment[2] == 0 &&
                 segment[3] == 1);
         }
+        
+        [Fact]
+        public void SegmentValuesWriteByteOffset()
+        {
+            // segment length > written value
+            VirtualOutputSegment segment = new(12);
+            segment.Write(0b_1001_0110);
+
+            Assert.True(
+                segment[0] == 0 &&
+                segment[1] == 1 &&
+                segment[2] == 1 &&
+                segment[3] == 0 &&
+                segment[4] == 1 &&
+                segment[5] == 0 &&
+                segment[6] == 0 &&
+                segment[7] == 1);
+        }
 
         [Fact]
         public void SegmentValuesWriteByte()

--- a/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using Iot.Device.Multiplexing.Utility;
+using System.Device.Gpio;
 using Xunit;
 
 namespace Iot.Device.Multiplexing
@@ -29,7 +30,7 @@ namespace Iot.Device.Multiplexing
                 segment[2] == 0 &&
                 segment[3] == 1);
         }
-        
+
         [Fact]
         public void SegmentValuesWriteByteOffset()
         {
@@ -39,7 +40,7 @@ namespace Iot.Device.Multiplexing
 
             var expected = new PinValue[] { 0, 1, 1, 0, 1, 0, 0, 1 };
 
-            for (int i = 0; i<expected.Length; i++)
+            for (int i = 0; i < expected.Length; i++)
             {
                 Assert.Equal(expected[i], segment[i]);
             }
@@ -53,7 +54,7 @@ namespace Iot.Device.Multiplexing
 
             var expected = new PinValue[] { 0, 1, 1, 0, 1, 0, 0, 1 };
 
-            for (int i = 0; i<expected.Length; i++)
+            for (int i = 0; i < expected.Length; i++)
             {
                 Assert.Equal(expected[i], segment[i]);
             }

--- a/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
-using Iot.Device.Multiplexing.Utility;
 using System.Device.Gpio;
+using Iot.Device.Multiplexing.Utility;
 using Xunit;
 
 namespace Iot.Device.Multiplexing


### PR DESCRIPTION
Fixes #1626

The #1627 didn't fix the #1626 issue. Since the PR was merged and it had conflict with mine, I'm redoing my changes.

The offset in VirtualOutputSegment.Write(byte value) is calculated with following formula:
```c#
int offset = _length - 8;
```
when in reality it should always be 0.

I tested my code with the same tests as last time:
```c#
[Fact]
public void VirtualOutputSegmentWriteByteOffset()
{
    // segment length > written value
    MyOptSeg segment = new(12);
    segment.Write(0b_1001_0110);

    Assert.True(
        segment[0] == 0 &&
        segment[1] == 1 &&
        segment[2] == 1 &&
        segment[3] == 0 &&
        segment[4] == 1 &&
        segment[5] == 0 &&
        segment[6] == 0 &&
        segment[7] == 1);
} // passed

[Fact]
public void VirtualOutputSegmentWriteByte()
{
    MyOptSeg segment = new(8);
    segment.Write(0b_1001_0110);

    Assert.True(
        segment[0] == 0 &&
        segment[1] == 1 &&
        segment[2] == 1 &&
        segment[3] == 0 &&
        segment[4] == 1 &&
        segment[5] == 0 &&
        segment[6] == 0 &&
        segment[7] == 1);
} // passed
```


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1684)