### PR TITLE
Add support for GPIO on RaspberryPi Compute Module 4 (CM4)

### DIFF
--- a/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/RaspberryPiDriverTests.cs
@@ -33,7 +33,7 @@ namespace System.Device.Gpio.Tests
             if (File.Exists("/proc/device-tree/model"))
             {
                 string model = File.ReadAllText("/proc/device-tree/model", Text.Encoding.ASCII);
-                if (model.Contains("Raspberry Pi 4"))
+                if (model.Contains("Raspberry Pi 4") || model.Contains("Raspberry Pi Compute Module 4"))
                 {
                     return true;
                 }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -138,7 +138,8 @@ namespace System.Device.Gpio.Drivers
                 RaspberryBoardInfo.Model.RaspberryPi3B or
                 RaspberryBoardInfo.Model.RaspberryPi3APlus or
                 RaspberryBoardInfo.Model.RaspberryPi3BPlus or
-                RaspberryBoardInfo.Model.RaspberryPi4 => new RaspberryPi3LinuxDriver(),
+                RaspberryBoardInfo.Model.RaspberryPi4 or
+                RaspberryBoardInfo.Model.RaspberryPiComputeModule4 => new RaspberryPi3LinuxDriver(),
                 RaspberryBoardInfo.Model.RaspberryPiComputeModule3 => new RaspberryPiCm3Driver(),
                 _ => null,
             };

--- a/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
@@ -96,6 +96,11 @@ namespace System.Device.Gpio
             /// Pi 400
             /// </summary>
             RaspberryPi400,
+
+            /// <summary>
+            /// Compute module 4.
+            /// </summary>
+            RaspberryPiComputeModule4,
         }
 
         #region Fields
@@ -153,6 +158,7 @@ namespace System.Device.Gpio
             0x20E0 => Model.RaspberryPi3APlus,
             0x20A0 or 0x2100 => Model.RaspberryPiComputeModule3,
             0x3111 or 0x3112 or 0x3114 => Model.RaspberryPi4,
+            0x3140 => Model.RaspberryPiComputeModule4,
             0x3130 => Model.RaspberryPi400,
             _ => Model.Unknown,
         };


### PR DESCRIPTION
Raspberry Pi Compute Module 4 reports a different board revision than Raspberry Pi 4. There is no official statement mentioning the revision.

The value 0x3140 was found to work, after checking on hardware ([see pinout output here](https://pastebin.com/ant6cNFu)). It is also mentioned in [this forum thread](https://forums.raspberrypi.com/viewtopic.php?f=33&t=249283).

There are no changes needed in the driver itself. CM4 uses the same pins and numbering as RPi4. Only the correct board identification was added.

Tested on Raspbian 10 (buster) and dotnet SDK 5.0.42.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1714)