### PR TITLE
Debouncing implementation and test

### DIFF
--- a/src/devices/Button/ButtonBase.cs
+++ b/src/devices/Button/ButtonBase.cs
@@ -71,7 +71,7 @@ namespace Iot.Device.Button
         /// Initialization of the button.
         /// </summary>
         public ButtonBase()
-            : this(TimeSpan.FromTicks(DefaultDoublePressTicks), TimeSpan.FromMilliseconds(DefaultHoldingMilliseconds), TimeSpan.Zero)
+            : this(TimeSpan.FromTicks(DefaultDoublePressTicks), TimeSpan.FromMilliseconds(DefaultHoldingMilliseconds))
         {
         }
 
@@ -81,7 +81,7 @@ namespace Iot.Device.Button
         /// <param name="doublePress">Max ticks between button presses to count as doublepress.</param>
         /// <param name="holding">Min ms a button is pressed to count as holding.</param>
         /// <param name="debounceTime">The amount of time during which the transitions are ignored, or zero</param>
-        public ButtonBase(TimeSpan doublePress, TimeSpan holding, TimeSpan debounceTime)
+        public ButtonBase(TimeSpan doublePress, TimeSpan holding, TimeSpan debounceTime = default(TimeSpan))
         {
             _doublePressTicks = doublePress.Ticks;
             _holdingMs = (long)holding.TotalMilliseconds;

--- a/src/devices/Button/GpioButton.cs
+++ b/src/devices/Button/GpioButton.cs
@@ -14,6 +14,7 @@ namespace Iot.Device.Button
     {
         private GpioController _gpioController;
         private PinMode _pinMode;
+        private TimeSpan _debounceTime;
 
         private int _buttonPin;
         private bool _shouldDispose;
@@ -27,8 +28,10 @@ namespace Iot.Device.Button
         /// <param name="pinMode">Pin mode of the system.</param>
         /// <param name="gpio">Gpio Controller.</param>
         /// <param name="shouldDispose">True to dispose the GpioController.</param>
-        public GpioButton(int buttonPin, GpioController? gpio = null, bool shouldDispose = true, PinMode pinMode = PinMode.InputPullUp)
-            : this(buttonPin, TimeSpan.FromTicks(DefaultDoublePressTicks), TimeSpan.FromMilliseconds(DefaultHoldingMilliseconds), gpio, shouldDispose, pinMode)
+        /// <param name="debounceTime">The amount of time during which the transitions are ignored, or zero</param>
+        public GpioButton(int buttonPin, GpioController? gpio = null, bool shouldDispose = true, PinMode pinMode = PinMode.InputPullUp,
+            TimeSpan debounceTime = default(TimeSpan))
+            : this(buttonPin, TimeSpan.FromTicks(DefaultDoublePressTicks), TimeSpan.FromMilliseconds(DefaultHoldingMilliseconds), gpio, shouldDispose, pinMode, debounceTime)
         {
         }
 
@@ -41,13 +44,15 @@ namespace Iot.Device.Button
         /// <param name="holding">Min ms a button is pressed to count as holding.</param>
         /// <param name="gpio">Gpio Controller.</param>
         /// <param name="shouldDispose">True to dispose the GpioController.</param>
-        public GpioButton(int buttonPin, TimeSpan doublePress, TimeSpan holding, GpioController? gpio = null, bool shouldDispose = true, PinMode pinMode = PinMode.InputPullUp)
-            : base(doublePress, holding)
+        /// <param name="debounceTime">The amount of time during which the transitions are ignored, or zero</param>
+        public GpioButton(int buttonPin, TimeSpan doublePress, TimeSpan holding, GpioController? gpio = null, bool shouldDispose = true, PinMode pinMode = PinMode.InputPullUp, TimeSpan debounceTime = default(TimeSpan))
+            : base(doublePress, holding, debounceTime)
         {
             _gpioController = gpio ?? new GpioController();
             _shouldDispose = shouldDispose;
             _buttonPin = buttonPin;
             _pinMode = pinMode;
+            _debounceTime = debounceTime;
 
             if (_pinMode == PinMode.Input | _pinMode == PinMode.InputPullDown | _pinMode == PinMode.InputPullUp)
             {

--- a/src/devices/Button/tests/ButtonTests.cs
+++ b/src/devices/Button/tests/ButtonTests.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Threading;
+
 using Xunit;
 
 namespace Iot.Device.Button.Tests
@@ -245,5 +247,46 @@ namespace Iot.Device.Button.Tests
 
             Assert.False(pressed);
         }
+
+        [Fact]
+        public void If_Button_Is_Pressed_Too_Fast_Debouncing_Removes_Events()
+        {
+            bool holding = false;
+            bool doublePressed = false;
+            int pressedCounter = 0;
+
+            TestButton button = new TestButton(TimeSpan.FromMilliseconds(100));
+
+            button.Press += (sender, e) =>
+            {
+                pressedCounter++;
+            };
+
+            button.Holding += (sender, e) =>
+            {
+                holding = true;
+            };
+
+            button.DoublePress += (sender, e) =>
+            {
+                doublePressed = true;
+            };
+
+            button.PressButton();
+            button.ReleaseButton();
+            button.PressButton();
+            button.ReleaseButton();
+            button.PressButton();
+            button.ReleaseButton();
+            button.PressButton();
+            button.ReleaseButton();
+            button.PressButton();
+            button.ReleaseButton();
+
+            Assert.Equal(1, pressedCounter);
+            Assert.False(holding);
+            Assert.False(doublePressed);
+        }
+
     }
 }

--- a/src/devices/Button/tests/ButtonTests.cs
+++ b/src/devices/Button/tests/ButtonTests.cs
@@ -255,7 +255,7 @@ namespace Iot.Device.Button.Tests
             bool doublePressed = false;
             int pressedCounter = 0;
 
-            TestButton button = new TestButton(TimeSpan.FromMilliseconds(100));
+            TestButton button = new TestButton(TimeSpan.FromMilliseconds(1000));
 
             button.Press += (sender, e) =>
             {

--- a/src/devices/Button/tests/TestButton.cs
+++ b/src/devices/Button/tests/TestButton.cs
@@ -13,7 +13,7 @@ namespace Iot.Device.Button.Tests
         }
 
         public TestButton(TimeSpan debounceTime)
-            : base(TimeSpan.FromTicks(15000000), TimeSpan.FromMilliseconds(2000), debounceTime)
+            : base(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(2000), debounceTime)
         {
         }
 

--- a/src/devices/Button/tests/TestButton.cs
+++ b/src/devices/Button/tests/TestButton.cs
@@ -1,12 +1,19 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Iot.Device.Button.Tests
 {
     public class TestButton : ButtonBase
     {
         public TestButton()
             : base()
+        {
+        }
+
+        public TestButton(TimeSpan debounceTime)
+            : base(TimeSpan.FromTicks(15000000), TimeSpan.FromMilliseconds(2000), debounceTime)
         {
         }
 


### PR DESCRIPTION
This PR adds support for debouncing to the Button device.
Issue: https://github.com/dotnet/iot/issues/1719
Tested on a Raspberry PI 3B+


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1720)