### PR TITLE
Make markdown lint only run on PR builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -101,10 +101,11 @@ stages:
         - checkout: self
           clean: true
         # Scan markdown files on style consistency
-        - powershell: |
-            npm install -g markdownlint-cli
-            markdownlint -c  $(System.DefaultWorkingDirectory)/.markdownlint.json $(System.DefaultWorkingDirectory)
-          displayName: 'Execute Markdownlint'
+        - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          - powershell: |
+              npm install -g markdownlint-cli
+              markdownlint -c  $(System.DefaultWorkingDirectory)/.markdownlint.json $(System.DefaultWorkingDirectory)
+            displayName: 'Execute Markdownlint'
         
         # Use utility script to run script command dependent on agent OS.
         - script: build.cmd -ci -sign

--- a/src/devices/Arduino/README.md
+++ b/src/devices/Arduino/README.md
@@ -8,11 +8,13 @@ This binding remotely controls Arduino boards directly from PC Software. It prov
 
 **Supported Board Types**
 The following board types are known to work with this binding. Many others may work as well.
+
 - Arduino AVR based boards: Arduino UNO, Arduino Nano, Arduino Pro Mini
 - 32 Bit Arduino Boards: Arduino Due
 - ESP32 (over serial and Wifi)
 
 Known problems:
+
 - The Arduino Pro Mini (and possibly a few other boards with a similarly slow clock rate) require that the baud rate be set to 57600 or less to work reliably.
 
 ## Desktop Requirements
@@ -40,19 +42,23 @@ When the firmware starts, the on-board-LED flashes a few times, indicating the l
 
 Some of the features of this binding require extended features in the Arduino firmware. These include SPI support and DHT sensor support. These features are only available in the main development branch
 
-**Download for Windows**
+#### Download for Windows
+
 - Go to `C:\users\<username>\documents\arduino\libraries` and delete the "ConfigurableFirmata" folder (save any work if you've changed anything there)
 - Replace it with a clone of [Configurable Firmata](https://github.com/firmata/ConfigurableFirmata).
 
-**Download for Linux**
+#### Download for Linux
+
 To install the current development version of ConfigurableFirmata on linux, perform these steps in a shell:
-```
+
+```sh
 cd ~/Arduino/libraries
 rm -rd ConfigurableFirmata
 git clone https://github.com/firmata/ConfigurableFirmata
 ```
 
-**Final steps**
+#### Final steps
+
 - Make sure you have the "DHT Sensor Library" from Adafruit installed (use the library manager for that).
 - You can now enable the DHT and SPI features at the beginning of the ConfigurableFirmata.ino file. Because the new firmware will have additional features, it is recommended to use the .ino file from the examples folder of the repository. So the best start is to open the file that now lies in `C:\users\<username>\documents\arduino\libraries\ConfigurableFirmata\examples\ConfigurableFirmata\ConfigurableFirmata.ino`. The file has some comments at the top to enable or disable certain modules.
 - Compile and re-upload the sketch.

--- a/src/devices/Ili9341/README.md
+++ b/src/devices/Ili9341/README.md
@@ -1,4 +1,4 @@
-﻿# Ili9341 TFT LCD Controller 
+﻿# Ili9341 TFT LCD Controller
 
 The ILI9341 is a QVGA (Quarter VGA) driver integrated circuit that is used to control 240×320 VGA LCD screens
 


### PR DESCRIPTION
Seems like our internal build machines don't have npm so trying to run the linter there is failing. Since we don't really care about running it in official builds as we only want the protection to be on PRs, this PR is disabling the step for official builds.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1731)