### PR TITLE
Update RaspberryPi3Driver.cs to support Raspberry Pi Zero W

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -138,6 +138,7 @@ namespace System.Device.Gpio.Drivers
                 RaspberryBoardInfo.Model.RaspberryPi3B or
                 RaspberryBoardInfo.Model.RaspberryPi3APlus or
                 RaspberryBoardInfo.Model.RaspberryPi3BPlus or
+                RaspberryBoardInfo.Model.RaspberryPiZeroW or
                 RaspberryBoardInfo.Model.RaspberryPiZero2W or
                 RaspberryBoardInfo.Model.RaspberryPi4 or
                 RaspberryBoardInfo.Model.RaspberryPiComputeModule4 => new RaspberryPi3LinuxDriver(),


### PR DESCRIPTION
Adding support for RaspberrPi Zero W - which is running on mono only currently


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1744)