### PR TITLE
Fix buildTransitive/net5.0/System.Device.Gpio.targets

### DIFF
--- a/src/System.Device.Gpio/buildTransitive/net5.0/System.Device.Gpio.targets
+++ b/src/System.Device.Gpio/buildTransitive/net5.0/System.Device.Gpio.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="EnsureProjectIsTargetingWindowsPlatformIfRequired"
           BeforeTargets="Build"
-          Condition="'($(TargetFramework)' == 'net6.0' Or $(TargetFramework)' == 'net5.0') And
+          Condition="('$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net5.0') And
                      '$(SuppressWindowsPlatformTargetingRequiredError)' == '' And
                      ('$(OutputType)' == 'Exe' Or '$(OutputType)'=='WinExe') And
                      $(RuntimeIdentifier.StartsWith('win'))">


### PR DESCRIPTION
Fixes #1751 

There were a missplaced "(" and a missing apostrophe. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1754)