### PR TITLE
Make MotorHat compatible with Waveshare Motor Driver Hat

### DIFF
--- a/src/devices/MotorHat/AdafruitMotorPinProvider.cs
+++ b/src/devices/MotorHat/AdafruitMotorPinProvider.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.MotorHat
+{
+    /// <summary>
+    /// <see cref="MotorPinProvider"/> implementation for AdaFruit/Aliexpress
+    /// </summary>
+    /// <remarks>
+    /// These correspond to motor hat screw terminals M1, M2, M3 and M4.
+    /// </remarks>
+    public class AdafruitMotorPinProvider : IMotorPinProvider
+    {
+        /// <inheritdoc/>
+        public MotorPins GetPinsForMotor(int index)
+        {
+            return index switch
+            {
+                1 => new MotorPins(8, 9, 10),
+                2 => new MotorPins(13, 12, 11),
+                3 => new MotorPins(2, 3, 4),
+                4 => new MotorPins(7, 6, 5),
+                _ => throw new ArgumentException(nameof(index), $"MotorHat Motor must be between 1 and 4 inclusive. {nameof(index)}: {index}")
+            };
+        }
+    }
+}

--- a/src/devices/MotorHat/MotorHat.cs
+++ b/src/devices/MotorHat/MotorHat.cs
@@ -20,6 +20,11 @@ namespace Iot.Device.MotorHat
         public const int I2cAddressBase = 0x60;
 
         /// <summary>
+        /// The <see cref="IMotorPinProvider"/> to use
+        /// </summary>
+        private readonly IMotorPinProvider _pinProvider;
+
+        /// <summary>
         /// Motor Hat is built on top of a PCa9685
         /// </summary>
         private Pca9685 _pca9685;
@@ -34,15 +39,17 @@ namespace Iot.Device.MotorHat
         /// </summary>
         /// <param name="settings">The I2C settings of the MotorHat.</param>
         /// <param name="frequency">The frequency in Hz to set the PWM controller.</param>
+        /// <param name="pinProvider">The <see cref="IMotorPinProvider"/> that provides <see cref="MotorPins"/> for various hats.</param>
         /// <remarks>
         /// The default i2c address is 0x60, but the HAT can be configured in hardware to any address from 0x60 to 0x7f.
         /// The PWM hardware used by this HAT is a PCA9685. It has a total possible frequency range of 24 to 1526 Hz.
         /// Setting the frequency above or below this range will cause PWM hardware to be set at its maximum or minimum setting.
         /// </remarks>
-        public MotorHat(I2cConnectionSettings settings, double frequency = 1600)
+        public MotorHat(I2cConnectionSettings settings, double frequency = 1600, IMotorPinProvider pinProvider = default!)
         {
             I2cDevice device = I2cDevice.Create(settings);
             _pca9685 = new Pca9685(device);
+            _pinProvider = pinProvider ?? MotorPinProvider.Default;
 
             _pca9685.PwmFrequency = frequency;
         }
@@ -71,49 +78,11 @@ namespace Iot.Device.MotorHat
         /// </remarks>
         public DCMotor.DCMotor CreateDCMotor(int motorNumber)
         {
-            if (motorNumber < 1 || motorNumber > 4)
-            {
-                throw new ArgumentOutOfRangeException(nameof(motorNumber), $"Must be between 1 and 4, corresponding with M1, M2, M3 and M4. (Received: {motorNumber}");
-            }
+            var motorPins = _pinProvider.GetPinsForMotor(motorNumber);
 
-            // The PCA9685 PWM controller is used to control the inputs of two dual motor drivers.
-            // These correspond to motor hat screw terminals M1, M2, M3 and M4.
-            // Each motor driver circuit has one speed pin and two IN pins.
-            // The PWM pin expects a PWM input signal. The two IN pins expect a logic 0 or 1 input signal.
-            // The variables speed, in1 and in2 variables identify which PCA9685 PWM output pins will be used to drive this DCMotor.
-            // The speed variable identifies which PCA9685 output pin is used to drive the PWM input on the motor driver.
-            // And the in1 and in2 variables are used to specify which PCA9685 output pins are used to drive the xIN1 and xIN2 input pins of the motor driver.
-            int speedPin, in1Pin, in2Pin;
-
-            switch (motorNumber)
-            {
-                case 1:
-                    speedPin = 8;
-                    in2Pin = 9;
-                    in1Pin = 10;
-                    break;
-                case 2:
-                    speedPin = 13;
-                    in2Pin = 12;
-                    in1Pin = 11;
-                    break;
-                case 3:
-                    speedPin = 2;
-                    in2Pin = 3;
-                    in1Pin = 4;
-                    break;
-                case 4:
-                    speedPin = 7;
-                    in2Pin = 6;
-                    in1Pin = 5;
-                    break;
-                default:
-                    throw new ArgumentException(nameof(motorNumber), $"MotorHat Motor must be between 1 and 4 inclusive. {nameof(motorNumber)}: {motorNumber}");
-            }
-
-            var speedPwm = _pca9685.CreatePwmChannel(speedPin);
-            var in1Pwm = _pca9685.CreatePwmChannel(in1Pin);
-            var in2Pwm = _pca9685.CreatePwmChannel(in2Pin);
+            var speedPwm = _pca9685.CreatePwmChannel(motorPins.SpeedPin);
+            var in1Pwm = _pca9685.CreatePwmChannel(motorPins.In1Pin);
+            var in2Pwm = _pca9685.CreatePwmChannel(motorPins.In2Pin);
 
             _channelsUsed.Add(speedPwm);
             _channelsUsed.Add(in1Pwm);

--- a/src/devices/MotorHat/MotorHat.cs
+++ b/src/devices/MotorHat/MotorHat.cs
@@ -39,13 +39,28 @@ namespace Iot.Device.MotorHat
         /// </summary>
         /// <param name="settings">The I2C settings of the MotorHat.</param>
         /// <param name="frequency">The frequency in Hz to set the PWM controller.</param>
+        /// <remarks>
+        /// The default i2c address is 0x60, but the HAT can be configured in hardware to any address from 0x60 to 0x7f.
+        /// The PWM hardware used by this HAT is a PCA9685. It has a total possible frequency range of 24 to 1526 Hz.
+        /// Setting the frequency above or below this range will cause PWM hardware to be set at its maximum or minimum setting.
+        /// </remarks>
+        public MotorHat(I2cConnectionSettings settings, double frequency = 1600)
+            : this(settings, frequency, MotorPinProvider.Default)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MotorHat"/> class with the specified I2C settings and PWM frequency.
+        /// </summary>
+        /// <param name="settings">The I2C settings of the MotorHat.</param>
+        /// <param name="frequency">The frequency in Hz to set the PWM controller.</param>
         /// <param name="pinProvider">The <see cref="IMotorPinProvider"/> that provides <see cref="MotorPins"/> for various hats.</param>
         /// <remarks>
         /// The default i2c address is 0x60, but the HAT can be configured in hardware to any address from 0x60 to 0x7f.
         /// The PWM hardware used by this HAT is a PCA9685. It has a total possible frequency range of 24 to 1526 Hz.
         /// Setting the frequency above or below this range will cause PWM hardware to be set at its maximum or minimum setting.
         /// </remarks>
-        public MotorHat(I2cConnectionSettings settings, double frequency = 1600, IMotorPinProvider pinProvider = default!)
+        public MotorHat(I2cConnectionSettings settings, double frequency = 1600, IMotorPinProvider? pinProvider = default)
         {
             I2cDevice device = I2cDevice.Create(settings);
             _pca9685 = new Pca9685(device);

--- a/src/devices/MotorHat/MotorPinProvider.cs
+++ b/src/devices/MotorHat/MotorPinProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 
 namespace Iot.Device.MotorHat
 {
@@ -16,7 +19,7 @@ namespace Iot.Device.MotorHat
     }
 
     /// <summary>
-    /// Abstract base class for creating DCMotor instances
+    /// Static class providing known <see cref="IMotorPinProvider"/> instances
     /// </summary>
     public static class MotorPinProvider
     {
@@ -39,55 +42,5 @@ namespace Iot.Device.MotorHat
         /// Default <see cref="IMotorPinProvider"/>
         /// </summary>
         public static readonly IMotorPinProvider Default = AdaFruit;
-    }
-
-    /// <summary>
-    /// <see cref="MotorPinProvider"/> implementation for AdaFruit/Aliexpress
-    /// </summary>
-    /// <remarks>
-    /// These correspond to motor hat screw terminals M1, M2, M3 and M4.
-    /// </remarks>
-    public class AdafruitMotorPinProvider : IMotorPinProvider
-    {
-        /// <summary>
-        /// Gets the <see cref="MotorPins"/> for motor at the specified <paramref name="index"/>
-        /// </summary>
-        /// <param name="index">The index of the motor to get pins for</param>
-        /// <returns></returns>
-        public MotorPins GetPinsForMotor(int index)
-        {
-            return index switch
-            {
-                1 => new MotorPins(8, 9, 10),
-                2 => new MotorPins(13, 12, 11),
-                3 => new MotorPins(2, 3, 4),
-                4 => new MotorPins(7, 6, 5),
-                _ => throw new ArgumentException(nameof(index), $"MotorHat Motor must be between 1 and 4 inclusive. {nameof(index)}: {index}")
-            };
-        }
-    }
-
-    /// <summary>
-    /// <see cref="MotorPinProvider"/> implementation for AdaFruit/Aliexpress
-    /// </summary>
-    /// <remarks>
-    /// These correspond to motor hat screw terminals M1 and M2
-    /// </remarks>
-    public class WaveshareMotorPinProvider : IMotorPinProvider
-    {
-        /// <summary>
-        /// Gets the <see cref="MotorPins"/> for motor at the specified <paramref name="index"/>
-        /// </summary>
-        /// <param name="index">The index of the motor to get pins for</param>
-        /// <returns></returns>
-        public MotorPins GetPinsForMotor(int index)
-        {
-            return index switch
-            {
-                1 => new MotorPins(0, 1, 2),
-                2 => new MotorPins(5, 4, 3),
-                _ => throw new ArgumentException(nameof(index), $"MotorHat Motor must be either 1 or 2. {nameof(index)}: {index}")
-            };
-        }
     }
 }

--- a/src/devices/MotorHat/MotorPinProvider.cs
+++ b/src/devices/MotorHat/MotorPinProvider.cs
@@ -1,0 +1,93 @@
+﻿using System;
+
+namespace Iot.Device.MotorHat
+{
+    /// <summary>
+    /// Represents a provider for <see cref="MotorPins"/>
+    /// </summary>
+    public interface IMotorPinProvider
+    {
+        /// <summary>
+        /// Gets the <see cref="MotorPins"/> for motor at the specified <paramref name="index"/>
+        /// </summary>
+        /// <param name="index">The index of the motor to get pins for</param>
+        /// <returns></returns>
+        public abstract MotorPins GetPinsForMotor(int index);
+    }
+
+    /// <summary>
+    /// Abstract base class for creating DCMotor instances
+    /// </summary>
+    public static class MotorPinProvider
+    {
+        /// <summary>
+        /// <see cref="IMotorPinProvider"/> for AdaFruit motor hat
+        /// </summary>
+        public static readonly IMotorPinProvider AdaFruit = new AdafruitMotorPinProvider();
+
+        /// <summary>
+        /// <see cref="IMotorPinProvider"/> for Aliexpress motor hat
+        /// </summary>
+        public static readonly IMotorPinProvider Aliexpress = AdaFruit;
+
+        /// <summary>
+        /// <see cref="IMotorPinProvider"/> for Waveshare motor hat
+        /// </summary>
+        public static readonly IMotorPinProvider Waveshare = new WaveshareMotorPinProvider();
+
+        /// <summary>
+        /// Default <see cref="IMotorPinProvider"/>
+        /// </summary>
+        public static readonly IMotorPinProvider Default = AdaFruit;
+    }
+
+    /// <summary>
+    /// <see cref="MotorPinProvider"/> implementation for AdaFruit/Aliexpress
+    /// </summary>
+    /// <remarks>
+    /// These correspond to motor hat screw terminals M1, M2, M3 and M4.
+    /// </remarks>
+    public class AdafruitMotorPinProvider : IMotorPinProvider
+    {
+        /// <summary>
+        /// Gets the <see cref="MotorPins"/> for motor at the specified <paramref name="index"/>
+        /// </summary>
+        /// <param name="index">The index of the motor to get pins for</param>
+        /// <returns></returns>
+        public MotorPins GetPinsForMotor(int index)
+        {
+            return index switch
+            {
+                1 => new MotorPins(8, 9, 10),
+                2 => new MotorPins(13, 12, 11),
+                3 => new MotorPins(2, 3, 4),
+                4 => new MotorPins(7, 6, 5),
+                _ => throw new ArgumentException(nameof(index), $"MotorHat Motor must be between 1 and 4 inclusive. {nameof(index)}: {index}")
+            };
+        }
+    }
+
+    /// <summary>
+    /// <see cref="MotorPinProvider"/> implementation for AdaFruit/Aliexpress
+    /// </summary>
+    /// <remarks>
+    /// These correspond to motor hat screw terminals M1 and M2
+    /// </remarks>
+    public class WaveshareMotorPinProvider : IMotorPinProvider
+    {
+        /// <summary>
+        /// Gets the <see cref="MotorPins"/> for motor at the specified <paramref name="index"/>
+        /// </summary>
+        /// <param name="index">The index of the motor to get pins for</param>
+        /// <returns></returns>
+        public MotorPins GetPinsForMotor(int index)
+        {
+            return index switch
+            {
+                1 => new MotorPins(0, 1, 2),
+                2 => new MotorPins(5, 4, 3),
+                _ => throw new ArgumentException(nameof(index), $"MotorHat Motor must be either 1 or 2. {nameof(index)}: {index}")
+            };
+        }
+    }
+}

--- a/src/devices/MotorHat/MotorPins.cs
+++ b/src/devices/MotorHat/MotorPins.cs
@@ -1,4 +1,7 @@
-﻿namespace Iot.Device.MotorHat
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.MotorHat
 {
     /// <summary>
     /// Represents a Motor PinConfiguration

--- a/src/devices/MotorHat/MotorPins.cs
+++ b/src/devices/MotorHat/MotorPins.cs
@@ -1,0 +1,18 @@
+﻿namespace Iot.Device.MotorHat
+{
+    /// <summary>
+    /// Represents a Motor PinConfiguration
+    /// </summary>
+    /// <param name="SpeedPin">The pin controlling the speed of the motor</param>
+    /// <param name="In1Pin">The first pin for controlling direction</param>
+    /// <param name="In2Pin">The second pin for controlling direction</param>
+    /// <remarks>
+    /// The PCA9685 PWM controller is used to control the inputs of two dual motor drivers.
+    /// Each motor driver circuit has one speed pin and two IN pins.
+    /// The PWM pin expects a PWM input signal. The two IN pins expect a logic 0 or 1 input signal.
+    /// The variables SpeedPin, In1Pin and In2Pin variables identify which PCA9685 PWM output pins will be used to drive this DCMotor.
+    /// The speed variable identifies which PCA9685 output pin is used to drive the PWM input on the motor driver.
+    /// And the In1Pin and In2Pin are used to specify which PCA9685 output pins are used to drive the xIN1 and xIN2 input pins of the motor driver.
+    /// </remarks>
+    public record MotorPins(int SpeedPin, int In1Pin, int In2Pin);
+}

--- a/src/devices/MotorHat/README.md
+++ b/src/devices/MotorHat/README.md
@@ -9,6 +9,7 @@ It also provides 4 extra PWM Outputs, that can be used for anything that require
 
 - [Adafruit](https://www.adafruit.com/product/2348)
 - [Aliexpress](http://s.click.aliexpress.com/e/mTB4ZB2s)
+- [Waveshare](https://www.waveshare.com/wiki/Motor_Driver_HAT)
 
 ## Usage
 

--- a/src/devices/MotorHat/WaveshareMotorPinProvider.cs
+++ b/src/devices/MotorHat/WaveshareMotorPinProvider.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.MotorHat
+{
+    /// <summary>
+    /// <see cref="MotorPinProvider"/> implementation for Waveshare
+    /// </summary>
+    /// <remarks>
+    /// These correspond to motor hat screw terminals M1 and M2
+    /// </remarks>
+    public class WaveshareMotorPinProvider : IMotorPinProvider
+    {
+        /// <inheritdoc/>
+        public MotorPins GetPinsForMotor(int index)
+        {
+            return index switch
+            {
+                1 => new MotorPins(0, 1, 2),
+                2 => new MotorPins(5, 4, 3),
+                _ => throw new ArgumentException(nameof(index), $"MotorHat Motor must be either 1 or 2. {nameof(index)}: {index}")
+            };
+        }
+    }
+}


### PR DESCRIPTION
Changes to make the MotorHat class compatible with the [Waveshare Motor Driver Hat](https://www.waveshare.com/wiki/Motor_Driver_HAT) while retaining backwards compatibility with Adafruid/Aliexpress hats.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1764)