### PR TITLE
Adding MacOS CI and Official build.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ stages:
       condition: always()
       inputs:
         pathToPublish: $(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/
-        artifactName: BuildLogs
+        artifactName: BuildLogs-Windows-$(BuildConfiguration)
         artifactType: container
 
     - task: CopyFiles@2
@@ -126,7 +126,33 @@ stages:
       condition: always()
       inputs:
         pathToPublish: $(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/
-        artifactName: BuildLogs
+        artifactName: BuildLogs-Linux-$(BuildConfiguration)
+        artifactType: container
+
+  - job: MacOS
+    displayName: MacOS Build
+    pool:
+      vmImage: macOS-latest
+
+    strategy:
+      matrix:
+        Build_Release:
+          BuildConfiguration: Release
+        Build_Debug:
+          BuildConfiguration: Debug
+
+    steps:
+    - script: ./build.sh --ci
+        --configuration $(BuildConfiguration)
+        --prepareMachine
+      displayName: Build
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Build logs
+      condition: always()
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/
+        artifactName: BuildLogs-MacOS-$(BuildConfiguration)
         artifactType: container
 
 - stage: CodeSign


### PR DESCRIPTION
@pgrawehr found that we don't currently run builds on Mac ever since we moved to the new AzDO instance. This is adding that build coverage back as well as fixing a tiny issue that causes that all binlogs currently go into the same artifacts path making them override each other.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1770)