### PR TITLE
Add Allwinner H616 & Orange Pi Zero 2 support

### DIFF
--- a/src/devices/Gpio/Drivers/OrangePiZero2Driver.cs
+++ b/src/devices/Gpio/Drivers/OrangePiZero2Driver.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Gpio.Drivers
+{
+    /// <summary>
+    /// A GPIO driver for the Orange Pi Zero 2.
+    /// </summary>
+    /// <remarks>
+    /// SoC: Allwinner H616 (sun50iw9p1)
+    /// </remarks>
+    public class OrangePiZero2Driver : Sun50iw9p1Driver
+    {
+        public static readonly int[] _pinNumberConverter = new int[]
+        {
+            -1, -1, -1, MapPinNumber('H', 5), -1, MapPinNumber('H', 4), -1, MapPinNumber('C', 9), MapPinNumber('H', 2), -1,
+            MapPinNumber('H', 3), MapPinNumber('C', 6), MapPinNumber('C', 11), MapPinNumber('C', 5), -1, MapPinNumber('C', 8),
+            MapPinNumber('C', 15), -1, MapPinNumber('C', 14), MapPinNumber('H', 7), -1, MapPinNumber('H', 8), MapPinNumber('C', 7),
+            MapPinNumber('H', 6), MapPinNumber('H', 9), -1, MapPinNumber('C', 10)
+        };
+
+        /// <inheritdoc/>
+        protected override int PinCount => 17;
+
+        /// <inheritdoc/>
+        protected override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            int num = _pinNumberConverter[pinNumber];
+
+            return num != -1 ? num : throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber));
+        }
+    }
+}

--- a/src/devices/Gpio/Drivers/OrangePiZero2Driver.cs
+++ b/src/devices/Gpio/Drivers/OrangePiZero2Driver.cs
@@ -13,7 +13,7 @@ namespace Iot.Device.Gpio.Drivers
     /// </remarks>
     public class OrangePiZero2Driver : Sun50iw9p1Driver
     {
-        public static readonly int[] _pinNumberConverter = new int[]
+        private static readonly int[] _pinNumberConverter = new int[]
         {
             -1, -1, -1, MapPinNumber('H', 5), -1, MapPinNumber('H', 4), -1, MapPinNumber('C', 9), MapPinNumber('H', 2), -1,
             MapPinNumber('H', 3), MapPinNumber('C', 6), MapPinNumber('C', 11), MapPinNumber('C', 5), -1, MapPinNumber('C', 8),

--- a/src/devices/Gpio/Drivers/Sunxi/Sun50iw9p1Driver.cs
+++ b/src/devices/Gpio/Drivers/Sunxi/Sun50iw9p1Driver.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Gpio.Drivers
+{
+    /// <summary>
+    /// A GPIO driver for Allwinner H616.
+    /// </summary>
+    public class Sun50iw9p1Driver : SunxiDriver
+    {
+        /// <inheritdoc/>
+        protected override int CpuxPortBaseAddress => 0x0300B000;
+
+        /// <inheritdoc/>
+        protected override int CpusPortBaseAddress => 0x07022000;
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15957347/152674087-e00b3188-4c3f-4743-9545-d104dc18091f.png)

Benchmarking with Orange Pi Zero 2. The operating system is Armbian focal, Linux kernel version is 4.9.255, and .NET version is 6.0.1.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1790)