### PR TITLE
unexport when exported before only

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
@@ -145,8 +145,10 @@ namespace System.Device.Gpio.Drivers
                         _devicePins.Remove(pinNumber);
                     }
 
-                    File.WriteAllText(Path.Combine(GpioBasePath, "unexport"), pinOffset.ToString(CultureInfo.InvariantCulture));
-                    _exportedPins.Remove(pinNumber);
+                    if (_exportedPins.Remove(pinNumber))
+                    {
+                        File.WriteAllText(Path.Combine(GpioBasePath, "unexport"), pinOffset.ToString(CultureInfo.InvariantCulture));
+                    }
                 }
                 catch (UnauthorizedAccessException e)
                 {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
@@ -145,6 +145,7 @@ namespace System.Device.Gpio.Drivers
                         _devicePins.Remove(pinNumber);
                     }
 
+                    // If this controller wasn't the one that opened the pin, then Remove will return false, so we don't need to close it.
                     if (_exportedPins.Remove(pinNumber))
                     {
                         File.WriteAllText(Path.Combine(GpioBasePath, "unexport"), pinOffset.ToString(CultureInfo.InvariantCulture));


### PR DESCRIPTION
I have a board where the pins are exported outside the application and I cannot unexport them (permissions).
Thus on disposing of `GpioController` an `UnauthorizedAccessException` is thrown.

This PR changes the handling by checking if the pin was exported first.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1795)