### PR TITLE
retry when epoll_wait fails with EINTR

### DIFF
--- a/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_wait.cs
+++ b/src/System.Device.Gpio/Interop/Unix/Libc/Interop.epoll_wait.cs
@@ -8,6 +8,6 @@ using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
-    [DllImport(LibcLibrary)]
+    [DllImport(LibcLibrary, SetLastError = true)]
     internal static extern int epoll_wait(int epfd, out epoll_event events, int maxevents, int timeout);
 }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
@@ -467,7 +467,7 @@ namespace System.Device.Gpio.Drivers
                         continue;
                     }
 
-                    throw new IOException("Error while waiting for pin interrupts.");
+                    throw new IOException($"Error while waiting for pin interrupts. (ErrorCode={errorCode})");
                 }
 
                 if (waitResult > 0)

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
@@ -445,7 +445,15 @@ namespace System.Device.Gpio.Drivers
             }
 
             // Ignore first time because it will always return the current state.
-            Interop.epoll_wait(pollFileDescriptor, out _, 1, 0);
+            while (Interop.epoll_wait(pollFileDescriptor, out _, 1, 0) == -1)
+            {
+                var errorCode = Marshal.GetLastWin32Error();
+                if (errorCode != ERROR_CODE_EINTR)
+                {
+                    // don't retry on unknown error
+                    break;
+                }
+            }
         }
 
         private unsafe bool WasEventDetected(int pollFileDescriptor, int valueFileDescriptor, out int pinNumber, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #971

Implement retry handling for `epoll_wait` in `SysFsDriver.WasEventDetected` similar to `LibGpiodDriverEventHandler` implementation.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1801)