### PR TITLE
Added support for new Raspberry Pi 4 board revision b03115

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
@@ -163,7 +163,7 @@ namespace System.Device.Gpio
             0x20D3 => Model.RaspberryPi3BPlus,
             0x20E0 => Model.RaspberryPi3APlus,
             0x20A0 or 0x2100 => Model.RaspberryPiComputeModule3,
-            0x3111 or 0x3112 or 0x3114 => Model.RaspberryPi4,
+            0x3111 or 0x3112 or 0x3114 or 0x3115 => Model.RaspberryPi4,
             0x3140 => Model.RaspberryPiComputeModule4,
             0x3130 => Model.RaspberryPi400,
             _ => Model.Unknown,


### PR DESCRIPTION
Fixes #1798 

The newly discovered Raspberry Pi 4 board revision b03115 is now supported by the board detection logic.

There is still an ongoing discussion at #1798 on how such new revisions should be handled in the future or how the logic should be changed / opened for extensibility.
However, this (trivial) patch fixes the issue for the moment (i.e. makes such new boards useable) until the aforementioned discussion leads to a greater change.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1808)