### PR TITLE
Branding changes for 2.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,4 +213,4 @@ stages:
             inputs:
               command: push
               publishVstsFeed: 'IoT/nightly_iot_builds'
-              packagesToPush: '$(Pipeline.Workspace)/SignedPackages/*nupkg'
+              packagesToPush: '$(Pipeline.Workspace)/SignedPackages/*.nupkg'

--- a/src/Iot.Device.Bindings/Directory.Build.props
+++ b/src/Iot.Device.Bindings/Directory.Build.props
@@ -2,15 +2,15 @@
   <!-- Packaging related properties -->
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>1</MinorVersion>
+    <MinorVersion>2</MinorVersion>
     <Description>This package provides a set of Device Bindings that use System.Device.Gpio package to communicate with a microcontroller.</Description>
     <PackageTags>.NET Core GPIO Pins SPI I2C PWM BCM2835 BCM2837 RPi IoT Device Bindings</PackageTags>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>2.1.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageDownload Include="Iot.Device.Bindings" Version="[2.0.0]" />
+    <PackageDownload Include="Iot.Device.Bindings" Version="[2.1.0]" />
   </ItemGroup>
 
   <Import Project="../../Directory.Build.props" />

--- a/src/System.Device.Gpio/Directory.Build.props
+++ b/src/System.Device.Gpio/Directory.Build.props
@@ -2,16 +2,16 @@
   <!-- Packaging related properties -->
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>1</MinorVersion>
+    <MinorVersion>2</MinorVersion>
     <Description>The System.Device.Gpio package supports general-purpose I/O (GPIO) pins, PWM, I2C, SPI and related interfaces for interacting with low level hardware pins to control hardware sensors, displays and input devices on single-board-computers; Raspberry Pi, BeagleBoard, HummingBoard, ODROID, and other single-board-computers that are supported by Linux and Windows 10 IoT Core OS can be used with .NET Core and System.Device.Gpio.  On Windows 10 IoT Core OS, the library wraps the Windows.Devices.Gpio.dll assembly.  On Linux, the library supports three driver modes: libgpiod for fast full-featured GPIO access on all Linux distros since version 4.8 of the Linux kernel; slower and limited-functionality GPIO access via the deprecated Sysfs interface (/sys/class/gpio) when running on older Linux distro versions with a Linux kernel older than version 4.8; and lastly board-specific Linux drivers that access GPIO addresses in /dev/mem for fasted performance at the trade-off of being able to run on very specific versions of single-board-computers.  In the future, the board-specific Linux drivers may be removed in favor of only supporting libgpiod and sysfs Linux interfaces.  In addition to System.Device.Gpio, the optional IoT.Device.Bindings NuGet package contains device bindings for many sensors, displays, and input devices that can be used with System.Device.Gpio.
     </Description>
     <PackageTags>.NET Core GPIO Pins SPI I2C PWM BCM2835 RPi IoT</PackageTags>
-    <PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>2.1.0</PackageValidationBaselineVersion>
     <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageDownload Include="System.Device.Gpio" Version="[2.0.0]" />
+    <PackageDownload Include="System.Device.Gpio" Version="[2.1.0]" />
   </ItemGroup>
 
   <Import Project="..\..\Directory.Build.props" />


### PR DESCRIPTION
2.1 has now shipped. These are the required branding changes for the 2.2 out of main branch. I'm also includding a small fix to publish step in our yaml that was causing the nightly feed to not get the System.Device.Gpio packages pushed (thanks @pgrawehr for the report)

cc: @Ellerbach @pgrawehr @raffaeler @krwq @richlander 

I will publish the Github release notes for 2.1 soon.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1810)