### PR TITLE
LibGpiodDriver handle TaskCanceledException in Dispose

### DIFF
--- a/src/System.Device.Gpio.Tests/LibGpiodDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/LibGpiodDriverTests.cs
@@ -54,5 +54,20 @@ namespace System.Device.Gpio.Tests
                 controller.ClosePin(InputPin);
             }
         }
+
+        [Fact]
+        public void UnregisterPinValueChangedShallNotThrow()
+        {
+            using var gc = new GpioController(GetTestNumberingScheme(), GetTestDriver());
+            gc.OpenPin(InputPin, PinMode.Input);
+
+            static void PinChanged(object sender, PinValueChangedEventArgs args) { }
+
+            for (var i = 0; i < 1000; i++)
+            {
+                gc.RegisterCallbackForPinValueChangedEvent(InputPin, PinEventTypes.Rising | PinEventTypes.Falling, PinChanged);
+                gc.UnregisterCallbackForPinValueChangedEvent(InputPin, PinChanged);
+            }
+        }
     }
 }

--- a/src/System.Device.Gpio.Tests/LibGpiodDriverTests.cs
+++ b/src/System.Device.Gpio.Tests/LibGpiodDriverTests.cs
@@ -61,7 +61,9 @@ namespace System.Device.Gpio.Tests
             using var gc = new GpioController(GetTestNumberingScheme(), GetTestDriver());
             gc.OpenPin(InputPin, PinMode.Input);
 
-            static void PinChanged(object sender, PinValueChangedEventArgs args) { }
+            static void PinChanged(object sender, PinValueChangedEventArgs args)
+            {
+            }
 
             for (var i = 0; i < 1000; i++)
             {

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
@@ -339,7 +339,7 @@ namespace System.Device.Gpio.Drivers
                     typeOfEventOccured = e.ChangeType;
                 }
 
-                WaitForEventResult(cancellationToken, eventHandler.CancellationTokenSource.Token, ref eventOccurred);
+                WaitForEventResult(cancellationToken, eventHandler.CancellationToken, ref eventOccurred);
                 RemoveCallbackForPinValueChangedEvent(pinNumber, Callback);
 
                 return new WaitForEventResult


### PR DESCRIPTION
Sometimes a `TaskCanceledException` is thrown when calling `GpioController.UnregisterCallbackForPinValueChangedEvent()` when using `LibGpiodDriver`. The exception is thrown inside `LibgpiodDriverEventHandler.Dispose()` method.

Now this exception is handled.
Also possible other exceptions are not wrapped in an `AggregateException` anymore.

Furthermore should the `CancellationTokenSource` be disposed too?

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1825)