### PR TITLE
Check copyright header during the build

### DIFF
--- a/eng/StyleCop.Analyzers.ruleset
+++ b/eng/StyleCop.Analyzers.ruleset
@@ -164,10 +164,10 @@
     <Rule Id="SA1626" Action="None" /> <!-- Single-line comments should not use documentation style slashes -->
     <Rule Id="SA1627" Action="None" /> <!-- The documentation text within the \'exception\' tag should not be empty -->
     <Rule Id="SA1629" Action="None" /> <!-- Documentation text should end with a period -->
-    <Rule Id="SA1633" Action="None" /> <!-- File should have header -->
-    <Rule Id="SA1634" Action="None" /> <!-- File Header must show copyright. Our header does not use the expected syntax -->
-    <Rule Id="SA1635" Action="None" /> <!-- Same as SA1634? -->
-    <Rule Id="SA1636" Action="None" /> <!-- File Header copyright tag must match -->
+    <Rule Id="SA1633" Action="Error" /> <!-- File should have header -->
+    <Rule Id="SA1634" Action="None" /> <!-- File Header must show copyright. -->
+    <Rule Id="SA1635" Action="Error" /> <!-- Same as SA1634? -->
+    <Rule Id="SA1636" Action="Error" /> <!-- File Header copyright tag must match -->
     <Rule Id="SA1637" Action="None" /> <!-- File Header must contain file name -->
     <Rule Id="SA1638" Action="Error" />
     <Rule Id="SA1640" Action="None" /> <!-- File header must have valid company text -->
@@ -179,6 +179,6 @@
     <Rule Id="SA1651" Action="Error" />
     <Rule Id="SA1652" Action="Error" />
     <Rule Id="SX1101" Action="Error" /> <!-- Do not prefix local members with this -->
-	<Rule Id="SX1309" Action="Error" /> <!-- Members should be prefixed with _ -->
+    <Rule Id="SX1309" Action="Error" /> <!-- Members should be prefixed with _ -->
   </Rules>
 </RuleSet>

--- a/eng/stylecop.json
+++ b/eng/stylecop.json
@@ -12,7 +12,9 @@
         },
         "documentationRules": {
             "documentInterfaces": true,
-            "documentInternalElements": false
+            "documentInternalElements": false,
+            "copyrightText": "Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.",
+            "xmlHeader": false
         }        
     }
   }

--- a/src/System.Device.Gpio.Tests/RetryHelper.cs
+++ b/src/System.Device.Gpio.Tests/RetryHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/System.Device.Gpio.Tests/TimeoutHelper.cs
+++ b/src/System.Device.Gpio.Tests/TimeoutHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
 
 using System.Threading.Tasks;
 

--- a/src/System.Device.Gpio/Interop/Unix/libbcm_host/Interop.libbcmhost.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libbcm_host/Interop.libbcmhost.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
 
 // Disable these StyleCop rules for this file, as we are using native names here.
 #pragma warning disable SA1300 // Element should begin with upper-case letter

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;

--- a/src/System.Device.Gpio/System/Device/Gpio/WaitEventResult.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/WaitEventResult.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
 
 namespace System.Device.Gpio
 {

--- a/src/devices/Arduino/ArduinoI2cBus.cs
+++ b/src/devices/Arduino/ArduinoI2cBus.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Device.I2c;
 using System.Linq;

--- a/src/devices/Arduino/CommandError.cs
+++ b/src/devices/Arduino/CommandError.cs
@@ -1,4 +1,7 @@
-﻿namespace Iot.Device.Arduino
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Arduino
 {
     /// <summary>
     /// Possible results of sending a Firmata command

--- a/src/devices/Board/CustomBoard.cs
+++ b/src/devices/Board/CustomBoard.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Device.Gpio;
 using System.Device.I2c;

--- a/src/devices/Board/I2cBusExtensions.cs
+++ b/src/devices/Board/I2cBusExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Device.I2c;
 using System.IO;

--- a/src/devices/Board/samples/Program.cs
+++ b/src/devices/Board/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Board/tests/I2cBusManagerTest.cs
+++ b/src/devices/Board/tests/I2cBusManagerTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Device.I2c;
 using System.Text;

--- a/src/devices/Board/tests/I2cDummyBus.cs
+++ b/src/devices/Board/tests/I2cDummyBus.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Device.I2c;
 using System.Text;

--- a/src/devices/Card/CardTransceiver.cs
+++ b/src/devices/Card/CardTransceiver.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/devices/CharacterLcd/CharacterLcdExtensions.cs
+++ b/src/devices/CharacterLcd/CharacterLcdExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/devices/CharacterLcd/LcdValueUnitDisplay.cs
+++ b/src/devices/CharacterLcd/LcdValueUnitDisplay.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/CharacterLcd/samples/LargeValueSample.cs
+++ b/src/devices/CharacterLcd/samples/LargeValueSample.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/devices/CharacterLcd/tests/LcdConsoleTests.cs
+++ b/src/devices/CharacterLcd/tests/LcdConsoleTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;

--- a/src/devices/CharacterLcd/tests/LcdValueUnitDisplayTests.cs
+++ b/src/devices/CharacterLcd/tests/LcdValueUnitDisplayTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;

--- a/src/devices/Charlieplex/CharlieplexSegment.cs
+++ b/src/devices/Charlieplex/CharlieplexSegment.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Device.Gpio;
 using System.Diagnostics;
 using System.Threading;

--- a/src/devices/Charlieplex/CharlieplexSegmentNode.cs
+++ b/src/devices/Charlieplex/CharlieplexSegmentNode.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Device.Gpio;
 using System.Diagnostics;
 using System.Threading;

--- a/src/devices/Charlieplex/samples/Program.cs
+++ b/src/devices/Charlieplex/samples/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Linq;
 using System.Threading;
 using Iot.Device.Multiplexing;

--- a/src/devices/Charlieplex/tests/CharlieplexLayout.cs
+++ b/src/devices/Charlieplex/tests/CharlieplexLayout.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using Iot.Device.Multiplexing;
 using Xunit;
 

--- a/src/devices/Common/Iot/Device/Common/ValueArray.cs
+++ b/src/devices/Common/Iot/Device/Common/ValueArray.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/devices/Common/Iot/Device/Multiplexing/GpioOutputSegment.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/GpioOutputSegment.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device.Gpio;

--- a/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
+++ b/src/devices/Common/Iot/Device/Multiplexing/tests/OutputSegmentTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Threading;
 using System.Device.Gpio;
 using Iot.Device.Multiplexing.Utility;

--- a/src/devices/Common/samples/MyTestComponent.cs
+++ b/src/devices/Common/samples/MyTestComponent.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/devices/GoPiGo3/Models/GrovePort.cs
+++ b/src/devices/GoPiGo3/Models/GrovePort.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/devices/KeyMatrix/KeyMatrix.cs
+++ b/src/devices/KeyMatrix/KeyMatrix.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/KeyMatrix/KeyMatrixEvent.cs
+++ b/src/devices/KeyMatrix/KeyMatrixEvent.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Device.Gpio;
 

--- a/src/devices/KeyMatrix/samples/Program.cs
+++ b/src/devices/KeyMatrix/samples/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxFxSidhTests.cs
+++ b/src/devices/Mcp25xxx/tests/Register/AcceptanceFilter/RxFxSidhTests.cs
@@ -1,4 +1,5 @@
-﻿// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Iot.Device.Mcp25xxx.Register;
 using Iot.Device.Mcp25xxx.Register.AcceptanceFilter;

--- a/src/devices/Media/VideoDevice/samples/MjpegStream/Camera.cs
+++ b/src/devices/Media/VideoDevice/samples/MjpegStream/Camera.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Drawing;

--- a/src/devices/Media/VideoDevice/samples/MjpegStream/Controllers/Image.cs
+++ b/src/devices/Media/VideoDevice/samples/MjpegStream/Controllers/Image.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers;

--- a/src/devices/Media/VideoDevice/samples/MjpegStream/Program.cs
+++ b/src/devices/Media/VideoDevice/samples/MjpegStream/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/devices/Media/VideoDevice/samples/MjpegStream/Startup.cs
+++ b/src/devices/Media/VideoDevice/samples/MjpegStream/Startup.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/devices/Nmea0183/Identification.Extra.cs
+++ b/src/devices/Nmea0183/Identification.Extra.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 
 namespace Iot.Device.Nmea0183
 {

--- a/src/devices/Nmea0183/Sentences/NavigationStatus.cs
+++ b/src/devices/Nmea0183/Sentences/NavigationStatus.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/devices/Nmea0183/Sentences/RotationSource.cs
+++ b/src/devices/Nmea0183/Sentences/RotationSource.cs
@@ -1,4 +1,7 @@
-﻿namespace Iot.Device.Nmea0183.Sentences
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Nmea0183.Sentences
 {
     /// <summary>
     /// Source for the engine revolution data

--- a/src/devices/Nmea0183/samples/SimpleParser/SimpleParser.cs
+++ b/src/devices/Nmea0183/samples/SimpleParser/SimpleParser.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO.Ports;

--- a/src/devices/PiJuice/Models/BatteryChargingTemperatureFault.cs
+++ b/src/devices/PiJuice/Models/BatteryChargingTemperatureFault.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/BatteryChemistry.cs
+++ b/src/devices/PiJuice/Models/BatteryChemistry.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/BatteryExtendedProfile.cs
+++ b/src/devices/PiJuice/Models/BatteryExtendedProfile.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using UnitsNet;
 

--- a/src/devices/PiJuice/Models/BatteryOrigin.cs
+++ b/src/devices/PiJuice/Models/BatteryOrigin.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/BatteryProfile.cs
+++ b/src/devices/PiJuice/Models/BatteryProfile.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using UnitsNet;
 

--- a/src/devices/PiJuice/Models/BatteryProfileSource.cs
+++ b/src/devices/PiJuice/Models/BatteryProfileSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/BatteryProfileStatus.cs
+++ b/src/devices/PiJuice/Models/BatteryProfileStatus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma warning disable CS1591, CS1572, CS1573
 

--- a/src/devices/PiJuice/Models/BatteryState.cs
+++ b/src/devices/PiJuice/Models/BatteryState.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/BatteryTemperatureSense.cs
+++ b/src/devices/PiJuice/Models/BatteryTemperatureSense.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/Button.cs
+++ b/src/devices/PiJuice/Models/Button.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/ButtonEventType.cs
+++ b/src/devices/PiJuice/Models/ButtonEventType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/ChargingConfig.cs
+++ b/src/devices/PiJuice/Models/ChargingConfig.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma warning disable CS1591, CS1572, CS1573
 

--- a/src/devices/PiJuice/Models/FaultStatus.cs
+++ b/src/devices/PiJuice/Models/FaultStatus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma warning disable CS1591, CS1572, CS1573
 

--- a/src/devices/PiJuice/Models/IdEepromAddress.cs
+++ b/src/devices/PiJuice/Models/IdEepromAddress.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/LED.cs
+++ b/src/devices/PiJuice/Models/LED.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/LEDBlink.cs
+++ b/src/devices/PiJuice/Models/LEDBlink.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Drawing;

--- a/src/devices/PiJuice/Models/LEDConfig.cs
+++ b/src/devices/PiJuice/Models/LEDConfig.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Drawing;
 

--- a/src/devices/PiJuice/Models/LEDFunction.cs
+++ b/src/devices/PiJuice/Models/LEDFunction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/PiJuiceCommand.cs
+++ b/src/devices/PiJuice/Models/PiJuiceCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/PiJuiceInfo.cs
+++ b/src/devices/PiJuice/Models/PiJuiceInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/devices/PiJuice/Models/PowerInState.cs
+++ b/src/devices/PiJuice/Models/PowerInState.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/PowerInput.cs
+++ b/src/devices/PiJuice/Models/PowerInput.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using UnitsNet;
 

--- a/src/devices/PiJuice/Models/PowerInputType.cs
+++ b/src/devices/PiJuice/Models/PowerInputType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/PowerRegulatorMode.cs
+++ b/src/devices/PiJuice/Models/PowerRegulatorMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/RelativeStateOfChangeEstimationType.cs
+++ b/src/devices/PiJuice/Models/RelativeStateOfChangeEstimationType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/RunPin.cs
+++ b/src/devices/PiJuice/Models/RunPin.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/Status.cs
+++ b/src/devices/PiJuice/Models/Status.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma warning disable CS1591, CS1572, CS1573
 

--- a/src/devices/PiJuice/Models/SystemPowerSwitch.cs
+++ b/src/devices/PiJuice/Models/SystemPowerSwitch.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Iot.Device.PiJuiceDevice.Models
 {

--- a/src/devices/PiJuice/Models/WakeUpOnCharge.cs
+++ b/src/devices/PiJuice/Models/WakeUpOnCharge.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using UnitsNet;
 

--- a/src/devices/PiJuice/PiJuice.cs
+++ b/src/devices/PiJuice/PiJuice.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Device;

--- a/src/devices/PiJuice/PiJuiceConfig.cs
+++ b/src/devices/PiJuice/PiJuiceConfig.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/PiJuice/PiJuicePower.cs
+++ b/src/devices/PiJuice/PiJuicePower.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/PiJuice/PiJuiceStatus.cs
+++ b/src/devices/PiJuice/PiJuiceStatus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers.Binary;

--- a/src/devices/PiJuice/samples/PiJuiceDevice.sample.cs
+++ b/src/devices/PiJuice/samples/PiJuiceDevice.sample.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Device.I2c;
 using System.Threading;
 using Iot.Device.PiJuiceDevice;

--- a/src/devices/Ssd13xx/samples/Ssd1306Extensions.cs
+++ b/src/devices/Ssd13xx/samples/Ssd1306Extensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using SixLabors.ImageSharp;

--- a/src/devices/Tlc1543/samples/Tlc1543.Sample.cs
+++ b/src/devices/Tlc1543/samples/Tlc1543.Sample.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/devices/UFireIse/UFireIse.cs
+++ b/src/devices/UFireIse/UFireIse.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the.NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/devices/UFireIse/UFireOrp.cs
+++ b/src/devices/UFireIse/UFireOrp.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the.NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Device.I2c;

--- a/src/devices/Uln2003/StepperMode.cs
+++ b/src/devices/Uln2003/StepperMode.cs
@@ -1,4 +1,7 @@
-﻿namespace Iot.Device.Uln2003
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Uln2003
 {
     /// <summary>
     /// The 28BYJ-48 motor has 512 full engine rotations to rotate the drive shaft once.

--- a/src/devices/Uln2003/Uln2003.cs
+++ b/src/devices/Uln2003/Uln2003.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Device.Gpio;
 using System.Diagnostics;
 


### PR DESCRIPTION
This removes necessity to check for copyright headers in the PRs. It's probably the most frequent comment we're putting on the PRs overall and it should no longer be needed.

Note: I'm not sure exact difference between SA1633, SA1635 and SA1636 but if any of them is set to None I'm not seeing any errors or only partial (I've tried 3 combinations: no header, incorrect header, header with extra stuff after)

cc: @richlander 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1829)