### PR TITLE
Prepare SerialPort development branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,12 +4,14 @@ trigger:
     include:
     - main
     - release/3.0
+    - feature-*
     
 pr:
   branches:
     include:
     - main
     - release/3.0
+    - feature-*
 
 variables:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Disabling the check for End of live TFMs since we still target netcoreapp 2.1 -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
-    <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>serialport</PreReleaseVersionLabel>
     <MicrosoftDotNetGenAPIPackageVersion>7.0.0-beta.22157.6</MicrosoftDotNetGenAPIPackageVersion>
     <!-- dotnet/corefx dependencies -->
     <SystemDrawingCommonPackageVersion>5.0.3</SystemDrawingCommonPackageVersion>


### PR DESCRIPTION
These changes will make it so that we have official builds from the SerialPort branch as well as CI validation, and it will also ensure that the created packages from this branch are labaled as "serialport" as opposed to "prerelease" in order to avoid collisions in our nightly feed.

cc: @krwq @pgrawehr @raffaeler @Ellerbach 
