### PR TITLE
Adjusting to add missing resources for BuildHAT

### DIFF
--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -42,6 +42,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="../devices/CharacterLcd/BigFontMap.txt" />
+    <EmbeddedResource Include="../devices/BuildHat/data/firmware.bin" />
+    <EmbeddedResource Include="../devices/BuildHat/data/signature.bin"/>
+    <EmbeddedResource Include="../devices/BuildHat/data/version" />
   </ItemGroup>
   <!-- This target will call into each device binding project to get out the source files for the framework we are building
   and then it will add the results to the Compile item group. -->


### PR DESCRIPTION
- Fixes #1837
- Tested on the generated dll from the build command with the same code as the sample
