### PR TITLE
Improve performance for large SPI buffer transfers

### DIFF
--- a/src/devices/Arduino/ArduinoBoard.cs
+++ b/src/devices/Arduino/ArduinoBoard.cs
@@ -80,10 +80,8 @@ namespace Iot.Device.Arduino
         /// </remarks>
         /// <param name="serialPortStream">A stream to an Arduino/Firmata device</param>
         public ArduinoBoard(Stream serialPortStream)
+        : this(serialPortStream, false)
         {
-            _dataStream = serialPortStream ?? throw new ArgumentNullException(nameof(serialPortStream));
-            StreamUsesHardwareFlowControl = false;
-            _logger = this.GetCurrentClassLogger();
         }
 
         /// <summary>
@@ -797,6 +795,12 @@ namespace Iot.Device.Arduino
                 {
                     // Ignore
                 }
+            }
+
+            if (_firmata != null)
+            {
+                // Can end the next possible moment (otherwise might just throw a bunch of warnings before actually terminating anyway)
+                _firmata.InputThreadShouldExit = true;
             }
 
             _isDisposed = true;

--- a/src/devices/Arduino/ArduinoI2cBus.cs
+++ b/src/devices/Arduino/ArduinoI2cBus.cs
@@ -15,6 +15,7 @@ namespace Iot.Device.Arduino
         private readonly ArduinoBoard _board;
         private readonly int _busId;
         private readonly HashSet<int> _usedAddresses;
+        private bool _busInitialized;
 
         public ArduinoI2cBus(ArduinoBoard board, int busId)
         {
@@ -29,6 +30,18 @@ namespace Iot.Device.Arduino
             if (_usedAddresses.Contains(deviceAddress))
             {
                 throw new InvalidOperationException($"Device number {deviceAddress} is already in use");
+            }
+
+            if (!_busInitialized)
+            {
+                // Ensure the corresponding pins are set to I2C (not strictly necessary, but consistent)
+                foreach (SupportedPinConfiguration supportedPinConfiguration in _board.SupportedPinConfigurations.Where(x => x.PinModes.Contains(SupportedMode.I2c)))
+                {
+                    _board.Firmata.SetPinMode(supportedPinConfiguration.Pin, SupportedMode.I2c);
+                }
+
+                _board.Firmata.SendI2cConfigCommand();
+                _busInitialized = true;
             }
 
             var device = new ArduinoI2cDevice(_board, this, new I2cConnectionSettings(_busId, deviceAddress));

--- a/src/devices/Arduino/ArduinoSpiDevice.cs
+++ b/src/devices/Arduino/ArduinoSpiDevice.cs
@@ -50,7 +50,7 @@ namespace Iot.Device.Arduino
 
         public override void Write(ReadOnlySpan<byte> buffer)
         {
-            Board.Firmata.SpiWrite(ConnectionSettings.ChipSelectLine, buffer);
+            Board.Firmata.SpiWrite(ConnectionSettings.ChipSelectLine, buffer, !Board.StreamUsesHardwareFlowControl);
         }
 
         public override void TransferFullDuplex(ReadOnlySpan<byte> writeBuffer, Span<byte> readBuffer)

--- a/src/devices/Arduino/BlockingUnorderedCollection.cs
+++ b/src/devices/Arduino/BlockingUnorderedCollection.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Iot.Device.Arduino
+{
+    /// <summary>
+    /// Represents a collection that removes objects based on a certain pattern
+    /// </summary>
+    internal class BlockingUnorderedCollection<T>
+    {
+        private object _lock = new object();
+        private List<T?> _container = new List<T?>();
+
+        public BlockingUnorderedCollection()
+        {
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _container.Count;
+                }
+            }
+        }
+
+        public void Add(T? elem)
+        {
+            lock (_lock)
+            {
+                _container.Add(elem);
+                Monitor.PulseAll(_lock);
+            }
+        }
+
+        /// <summary>
+        /// Waits until an element is in the queue that matches the given predicate.
+        /// Checking the predicate should be fast.
+        /// </summary>
+        /// <param name="predicate">The predicate to test</param>
+        /// <param name="timeout">The overall timeout</param>
+        /// <param name="element">Returns the element found, if any</param>
+        /// <returns>True if an element was found within the timeout, false otherwise</returns>
+        public bool TryRemoveElement(Func<T?, bool> predicate, TimeSpan timeout, out T? element)
+        {
+            bool lockTaken = false;
+            Stopwatch sw = Stopwatch.StartNew();
+            element = default;
+            try
+            {
+                Monitor.TryEnter(_lock, timeout, ref lockTaken);
+                if (lockTaken)
+                {
+                    // The critical section.
+                    while (true)
+                    {
+                        if (sw.Elapsed > timeout)
+                        {
+                            return false;
+                        }
+
+                        // Cannot use FirstOrDefault here, because we need to be able to distinguish between
+                        // finding nothing and finding an empty (null, default) element
+                        for (var index = 0; index < _container.Count; index++)
+                        {
+                            T? elem = _container[index];
+                            if (predicate(elem))
+                            {
+                                _container.RemoveAt(index);
+                                element = elem;
+                                return true;
+                            }
+                        }
+
+                        TimeSpan remaining = timeout - sw.Elapsed;
+                        if (remaining <= TimeSpan.Zero || !Monitor.Wait(_lock, remaining))
+                        {
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            finally
+            {
+                // Ensure that the lock is released.
+                if (lockTaken)
+                {
+                    Monitor.Exit(_lock);
+                }
+            }
+        }
+    }
+}

--- a/src/devices/Arduino/BlockingUnorderedCollection.cs
+++ b/src/devices/Arduino/BlockingUnorderedCollection.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/src/devices/Arduino/Encoder7Bit.cs
+++ b/src/devices/Arduino/Encoder7Bit.cs
@@ -1,12 +1,18 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#pragma warning disable CS1591
 namespace Iot.Device.Arduino
 {
+    /// <summary>
+    /// This class is used to encode larger chunks of data for transmission using the Firmata protocol.
+    /// It converts each block of 7 bytes into a block of 8 bytes, keeping the top bit 0.
+    /// </summary>
     public static class Encoder7Bit
     {
         /// <summary>
@@ -26,11 +32,23 @@ namespace Iot.Device.Arduino
             return (int)Math.Ceiling(((inputBytes) * 8.0) / 7);
         }
 
+        /// <summary>
+        /// Encode a sequence of bytes
+        /// </summary>
+        /// <param name="data">The data to encode</param>
+        /// <returns>The encoded data</returns>
         public static byte[] Encode(ReadOnlySpan<byte> data)
         {
             return Encode(data, 0, data.Length);
         }
 
+        /// <summary>
+        /// Encodes a sequence of bytes
+        /// </summary>
+        /// <param name="data">The data to encode</param>
+        /// <param name="startIndex">The start index in the data</param>
+        /// <param name="length">The length of the data</param>
+        /// <returns>The encoded data</returns>
         public static byte[] Encode(ReadOnlySpan<byte> data, int startIndex, int length)
         {
             int shift = 0;
@@ -73,6 +91,11 @@ namespace Iot.Device.Arduino
             return retBytes;
         }
 
+        /// <summary>
+        /// Decodes the given data sequence
+        /// </summary>
+        /// <param name="inData">The data to decode</param>
+        /// <returns>The decoded data</returns>
         public static byte[] Decode(ReadOnlySpan<byte> inData)
         {
             byte[] outBytes = new byte[Num8BitOutBytes(inData.Length)];

--- a/src/devices/Arduino/Encoder7Bit.cs
+++ b/src/devices/Arduino/Encoder7Bit.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#pragma warning disable CS1591
+namespace Iot.Device.Arduino
+{
+    public static class Encoder7Bit
+    {
+        /// <summary>
+        /// Calculates the number of bytes generated during decode (the result is smaller than the input)
+        /// </summary>
+        public static int Num8BitOutBytes(int inputBytes)
+        {
+            // Equals * 7 / 8
+            return (int)Math.Floor(((inputBytes) * 7) / 8.0);
+        }
+
+        /// <summary>
+        /// Calculates the number of bytes required for the 7-byte encoding
+        /// </summary>
+        public static int Num7BitOutBytes(int inputBytes)
+        {
+            return (int)Math.Ceiling(((inputBytes) * 8.0) / 7);
+        }
+
+        public static byte[] Encode(ReadOnlySpan<byte> data)
+        {
+            return Encode(data, 0, data.Length);
+        }
+
+        public static byte[] Encode(ReadOnlySpan<byte> data, int startIndex, int length)
+        {
+            int shift = 0;
+            byte[] retBytes = new byte[Num7BitOutBytes(length)];
+            int index = 0;
+            int previous = 0;
+            for (int i = startIndex; i < startIndex + length; i++)
+            {
+                if (shift == 0)
+                {
+                    retBytes[index] = (byte)(data[i] & 0x7f);
+                    index++;
+                    shift++;
+                    previous = data[i] >> 7;
+                }
+                else
+                {
+                    retBytes[index] = (byte)(((data[i] << shift) & 0x7f) | previous);
+                    index++;
+                    if (shift == 6)
+                    {
+                        retBytes[index] = (byte)(data[i] >> 1);
+                        index++;
+                        shift = 0;
+                    }
+                    else
+                    {
+                        shift++;
+                        previous = data[i] >> (8 - shift);
+                    }
+                }
+            }
+
+            if (shift > 0)
+            {
+                // Write remainder
+                retBytes[index] = (byte)previous;
+            }
+
+            return retBytes;
+        }
+
+        public static byte[] Decode(ReadOnlySpan<byte> inData)
+        {
+            byte[] outBytes = new byte[Num8BitOutBytes(inData.Length)];
+            for (int i = 0; i < outBytes.Length; i++)
+            {
+                int j = i << 3;
+                int pos = j / 7;
+                int shift = j % 7;
+                outBytes[i] = (byte)((inData[pos] >> shift) | ((inData[pos + 1] << (7 - shift)) & 0xFF));
+            }
+
+            return outBytes;
+        }
+}
+}

--- a/src/devices/Arduino/ExtendedCommandHandler.cs
+++ b/src/devices/Arduino/ExtendedCommandHandler.cs
@@ -62,13 +62,7 @@ namespace Iot.Device.Arduino
         /// This might need to be checked in Dispose, to make sure an uninitialized component doesn't attempt
         /// to send a command.
         /// </summary>
-        protected bool IsRegistered
-        {
-            get
-            {
-                return _board != null;
-            }
-        }
+        protected bool IsRegistered => _board != null;
 
         /// <summary>
         /// The reference to the arduino board
@@ -185,12 +179,13 @@ namespace Iot.Device.Arduino
         /// <summary>
         /// This is called when a sysex command is received from the board.
         /// This can include the reply to a command sent by a <see cref="SendCommandAndWait(FirmataCommandSequence)"/> before, in which case
-        /// the reply should be ignored, as it is returned as result of the call itself.
+        /// the reply should be ignored, as it is returned as result of the call itself. Therefore it is advised to use this function only
+        /// to listen for data sent by the device automatically (e.g event messages or recurring status reports)
         /// </summary>
         /// <param name="type">Type of data received from the hardware. This should normally be <see cref="ReplyType.SysexCommand"/>,
         /// unless the hardware sends unencoded Ascii messages</param>
         /// <param name="data">The binary representation of the received data</param>
-        /// <remarks>The implementation needs to check whether the data is for itself. The messages are not filtered by requester!</remarks>
+        /// <remarks>The implementation needs to check the type and source of the data. The messages are not filtered by requester!</remarks>
         protected virtual void OnSysexData(ReplyType type, byte[] data)
         {
         }
@@ -203,10 +198,7 @@ namespace Iot.Device.Arduino
         /// <param name="sequence">The sequence that was sent</param>
         /// <param name="reply">The reply</param>
         /// <returns>True if this reply matches the sequence. True is the default, for backwards compatibility</returns>
-        protected virtual bool IsMatchingAck(FirmataCommandSequence sequence, byte[] reply)
-        {
-            return true;
-        }
+        protected virtual bool IsMatchingAck(FirmataCommandSequence sequence, byte[] reply) => true;
 
         /// <summary>
         /// Callback function that returns whether the given reply indicates an error
@@ -214,10 +206,7 @@ namespace Iot.Device.Arduino
         /// <param name="sequence">The original sequence</param>
         /// <param name="reply">The reply. <see cref="IsMatchingAck"/> is already tested to be true for this reply</param>
         /// <returns>A command error code, in case this reply indicates a no-acknowledge</returns>
-        protected virtual CommandError HasCommandError(FirmataCommandSequence sequence, byte[] reply)
-        {
-            return CommandError.None;
-        }
+        protected virtual CommandError HasCommandError(FirmataCommandSequence sequence, byte[] reply) => CommandError.None;
 
         private void OnSysexDataInternal(ReplyType type, byte[] data)
         {

--- a/src/devices/Arduino/FirmataDevice.cs
+++ b/src/devices/Arduino/FirmataDevice.cs
@@ -46,7 +46,7 @@ namespace Iot.Device.Arduino
         private Thread? _inputThread;
         private bool _inputThreadShouldExit;
         private List<SupportedPinConfiguration> _supportedPinConfigurations;
-        private BlockingUnorderedCollection<byte[]> _pendingResponses;
+        private BlockingConcurrentBag<byte[]> _pendingResponses;
         private List<PinValue> _lastPinValues;
         private Dictionary<int, uint> _lastAnalogValues;
         private object _lastPinValueLock;
@@ -91,7 +91,7 @@ namespace Iot.Device.Arduino
             _lastAnalogValues = new Dictionary<int, uint>();
             _lastAnalogValueLock = new object();
             _dataQueue = new Queue<byte>(1024);
-            _pendingResponses = new BlockingUnorderedCollection<byte[]>();
+            _pendingResponses = new BlockingConcurrentBag<byte[]>();
             _lastRequestId = 1;
             _lastCommandError = CommandError.None;
             _firmwareName = string.Empty;

--- a/src/devices/Arduino/FirmataDevice.cs
+++ b/src/devices/Arduino/FirmataDevice.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Device.Gpio;
 using System.Device.Spi;
@@ -13,6 +14,8 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Iot.Device.Common;
+using Microsoft.Extensions.Logging;
 using UnitsNet;
 
 namespace Iot.Device.Arduino
@@ -27,12 +30,14 @@ namespace Iot.Device.Arduino
         private const byte FIRMATA_PROTOCOL_MAJOR_VERSION = 2;
         private const byte FIRMATA_PROTOCOL_MINOR_VERSION = 5; // 2.5 works, but 2.6 is recommended
         private const int FIRMATA_INIT_TIMEOUT_SECONDS = 2;
-        internal static readonly TimeSpan DefaultReplyTimeout = TimeSpan.FromMilliseconds(500);
+        internal static readonly TimeSpan DefaultReplyTimeout = TimeSpan.FromMilliseconds(1000);
 
         private byte _firmwareVersionMajor;
         private byte _firmwareVersionMinor;
         private byte _actualFirmataProtocolMajorVersion;
         private byte _actualFirmataProtocolMinorVersion;
+
+        private Version _firmwareVersion;
 
         private int _lastRequestId;
 
@@ -41,7 +46,7 @@ namespace Iot.Device.Arduino
         private Thread? _inputThread;
         private bool _inputThreadShouldExit;
         private List<SupportedPinConfiguration> _supportedPinConfigurations;
-        private IList<byte> _lastResponse;
+        private BlockingUnorderedCollection<byte[]> _pendingResponses;
         private List<PinValue> _lastPinValues;
         private Dictionary<int, uint> _lastAnalogValues;
         private object _lastPinValueLock;
@@ -52,10 +57,14 @@ namespace Iot.Device.Arduino
 
         private CommandError _lastCommandError;
 
+        private int _i2cSequence;
+
         /// <summary>
         /// Event used when waiting for answers (i.e. after requesting firmware version)
         /// </summary>
         private AutoResetEvent _dataReceived;
+
+        private ILogger _logger;
 
         public event PinChangeEventHandler? DigitalPortValueUpdated;
 
@@ -65,10 +74,13 @@ namespace Iot.Device.Arduino
 
         public event Action<ReplyType, byte[]>? OnSysexReply;
 
+        private long _bytesTransmitted = 0;
+
         public FirmataDevice(List<SupportedMode> supportedModes)
         {
             _firmwareVersionMajor = 0;
             _firmwareVersionMinor = 0;
+            _firmwareVersion = new Version(0, 0);
             _firmataStream = null;
             _inputThreadShouldExit = false;
             _dataReceived = new AutoResetEvent(false);
@@ -78,13 +90,15 @@ namespace Iot.Device.Arduino
             _lastPinValueLock = new object();
             _lastAnalogValues = new Dictionary<int, uint>();
             _lastAnalogValueLock = new object();
-            _dataQueue = new Queue<byte>();
-            _lastResponse = new List<byte>();
+            _dataQueue = new Queue<byte>(1024);
+            _pendingResponses = new BlockingUnorderedCollection<byte[]>();
             _lastRequestId = 1;
             _lastCommandError = CommandError.None;
             _firmwareName = string.Empty;
             _lastRawLine = new StringBuilder();
             SupportedModes = supportedModes;
+            _i2cSequence = 0;
+            _logger = this.GetCurrentClassLogger();
         }
 
         internal List<SupportedPinConfiguration> PinConfigurations
@@ -96,6 +110,8 @@ namespace Iot.Device.Arduino
         }
 
         internal List<SupportedMode> SupportedModes { get; set; }
+
+        internal long BytesTransmitted => _bytesTransmitted;
 
         public void Open(Stream stream)
         {
@@ -133,10 +149,8 @@ namespace Iot.Device.Arduino
             _inputThreadShouldExit = false;
 
             _inputThread = new Thread(InputThread);
+            _inputThread.Name = "Firmata input thread";
             _inputThread.Start();
-
-            // Reset device, in case it is still sending data from an aborted process
-            _firmataStream.WriteByte((byte)FirmataCommand.SYSTEM_RESET);
         }
 
         private void ProcessInput()
@@ -284,6 +298,7 @@ namespace Iot.Device.Arduino
 
                     _actualFirmataProtocolMajorVersion = message[0];
                     _actualFirmataProtocolMinorVersion = message[1];
+                    _logger.LogInformation($"Received protocol version: {_actualFirmataProtocolMajorVersion}.{_actualFirmataProtocolMinorVersion}.");
                     _dataReceived.Set();
 
                     return;
@@ -311,6 +326,12 @@ namespace Iot.Device.Arduino
                     {
                         int offset = lower_nibble * 8;
                         ushort pinValues = (ushort)(message[0] | (message[1] << 7));
+                        if (offset + 7 >= _lastPinValues.Count)
+                        {
+                            _logger.LogError($"Firmware reported an update for port {lower_nibble}, but there are only {_supportedPinConfigurations.Count} pins");
+                            break;
+                        }
+
                         lock (_lastPinValueLock)
                         {
                             for (int i = 0; i < 8; i++)
@@ -354,11 +375,13 @@ namespace Iot.Device.Arduino
                             {
                                 _firmwareVersionMajor = raw_data[1];
                                 _firmwareVersionMinor = raw_data[2];
+                                _firmwareVersion = new Version(_firmwareVersionMajor, _firmwareVersionMinor);
                                 int stringLength = (raw_data.Length - 3) / 2;
                                 Span<byte> bytesReceived = stackalloc byte[stringLength];
                                 ReassembleByteString(raw_data, 3, stringLength * 2, bytesReceived);
 
                                 _firmwareName = Encoding.ASCII.GetString(bytesReceived);
+                                _logger.LogDebug($"Received Firmware name {_firmwareName}");
                                 _dataReceived.Set();
                             }
 
@@ -461,22 +484,19 @@ namespace Iot.Device.Arduino
                             break;
                         case FirmataSysexCommand.I2C_REPLY:
                             _lastCommandError = CommandError.None;
-                            _lastResponse = raw_data;
-                            _dataReceived.Set();
+                            _pendingResponses.Add(raw_data);
                             break;
 
                         case FirmataSysexCommand.SPI_DATA:
                             _lastCommandError = CommandError.None;
-                            _lastResponse = raw_data;
-                            _dataReceived.Set();
+                            _pendingResponses.Add(raw_data);
                             break;
 
                         default:
                             // we pass the data forward as-is for any other type of sysex command
                             _lastCommandError = CommandError.None;
-                            _lastResponse = raw_data; // the instance is constant, so we can just remember the pointer
+                            _pendingResponses.Add(raw_data);
                             OnSysexReply?.Invoke(ReplyType.SysexCommand, raw_data);
-                            _dataReceived.Set();
                             break;
                     }
 
@@ -504,12 +524,8 @@ namespace Iot.Device.Arduino
                     throw new ObjectDisposedException(nameof(FirmataDevice));
                 }
 
-                // Use an explicit iteration, avoids a memory allocation here
-                for (int i = 0; i < sequence.Sequence.Count; i++)
-                {
-                    _firmataStream.WriteByte(sequence.Sequence[i]);
-                }
-
+                _firmataStream.Write(sequence.Sequence.ToArray());
+                _bytesTransmitted += sequence.Sequence.Count;
                 _firmataStream.Flush();
             }
         }
@@ -518,64 +534,112 @@ namespace Iot.Device.Arduino
         /// Send a command and wait for a reply
         /// </summary>
         /// <param name="sequence">The command sequence, typically starting with <see cref="FirmataCommand.START_SYSEX"/> and ending with <see cref="FirmataCommand.END_SYSEX"/></param>
-        /// <returns>The raw sequence of sysex reply bytes. The reply does not include the START_SYSEX byte, but it does include the terminating END_SYSEX byte. The first byte is the
-        /// <see cref="FirmataSysexCommand"/> command number of the corresponding request</returns>
-        public byte[] SendCommandAndWait(FirmataCommandSequence sequence)
-        {
-            return SendCommandAndWait(sequence, DefaultReplyTimeout);
-        }
-
-        /// <summary>
-        /// Send a command and wait for a reply
-        /// </summary>
-        /// <param name="sequence">The command sequence, typically starting with <see cref="FirmataCommand.START_SYSEX"/> and ending with <see cref="FirmataCommand.END_SYSEX"/></param>
         /// <param name="timeout">A non-default timeout</param>
-        /// <returns>The raw sequence of sysex reply bytes. The reply does not include the START_SYSEX byte, but it does include the terminating END_SYSEX byte. The first byte is the
-        /// <see cref="FirmataSysexCommand"/> command number of the corresponding request</returns>
-        public byte[] SendCommandAndWait(FirmataCommandSequence sequence, TimeSpan timeout)
-        {
-            return SendCommandAndWait(sequence, timeout, out _);
-        }
-
-        /// <summary>
-        /// Send a command and wait for a reply
-        /// </summary>
-        /// <param name="sequence">The command sequence, typically starting with <see cref="FirmataCommand.START_SYSEX"/> and ending with <see cref="FirmataCommand.END_SYSEX"/></param>
-        /// <param name="timeout">A non-default timeout</param>
+        /// <param name="isMatchingAck">A callback function that should return true if the given reply is the one this command should wait for. The default is true, because asynchronous replies
+        /// are rather the exception than the rule</param>
         /// <param name="error">An error code in case of failure</param>
         /// <returns>The raw sequence of sysex reply bytes. The reply does not include the START_SYSEX byte, but it does include the terminating END_SYSEX byte. The first byte is the
         /// <see cref="FirmataSysexCommand"/> command number of the corresponding request</returns>
-        public byte[] SendCommandAndWait(FirmataCommandSequence sequence, TimeSpan timeout, out CommandError error)
+        public byte[] SendCommandAndWait(FirmataCommandSequence sequence, TimeSpan timeout, Func<FirmataCommandSequence, byte[], bool> isMatchingAck, out CommandError error)
         {
             if (!sequence.Validate())
             {
                 throw new ArgumentException("The command sequence is invalid", nameof(sequence));
             }
 
-            lock (_synchronisationLock)
+            if (_firmataStream == null)
             {
-                if (_firmataStream == null)
-                {
-                    throw new ObjectDisposedException(nameof(FirmataDevice));
-                }
-
-                _dataReceived.Reset();
-                // Use an explicit iteration, avoids a memory allocation here
-                for (int i = 0; i < sequence.Sequence.Count; i++)
-                {
-                    _firmataStream.WriteByte(sequence.Sequence[i]);
-                }
-
-                _firmataStream.Flush();
-                bool result = _dataReceived.WaitOne(timeout);
-                if (result == false)
-                {
-                    throw new TimeoutException("Timeout waiting for command answer");
-                }
-
-                error = _lastCommandError;
-                return _lastResponse.ToArray();
+                throw new ObjectDisposedException(nameof(FirmataDevice));
             }
+
+            _firmataStream.Write(sequence.Sequence.ToArray(), 0, sequence.Sequence.Count);
+            _bytesTransmitted += sequence.Sequence.Count;
+            _firmataStream.Flush();
+
+            byte[]? response;
+            if (!_pendingResponses.TryRemoveElement(x => isMatchingAck(sequence, x!), timeout, out response))
+            {
+                throw new TimeoutException("Timeout waiting for command answer");
+            }
+
+            error = _lastCommandError;
+            return response ?? throw new InvalidOperationException("Got a null reply"); // should not happen in our case
+        }
+
+        /// <summary>
+        /// Send a command and wait for a reply
+        /// </summary>
+        /// <param name="sequences">The command sequences to send, typically starting with <see cref="FirmataCommand.START_SYSEX"/> and ending with <see cref="FirmataCommand.END_SYSEX"/></param>
+        /// <param name="timeout">A non-default timeout</param>
+        /// <param name="isMatchingAck">A callback function that should return true if the given reply is the one this command should wait for. The default is true, because asynchronous replies
+        /// are rather the exception than the rule</param>
+        /// <param name="errorFunc">A callback that determines a possible error in the reply message</param>
+        /// <param name="error">An error code in case of failure</param>
+        /// <returns>The raw sequence of sysex reply bytes. The reply does not include the START_SYSEX byte, but it does include the terminating END_SYSEX byte. The first byte is the
+        /// <see cref="FirmataSysexCommand"/> command number of the corresponding request</returns>
+        public bool SendCommandsAndWait(IList<FirmataCommandSequence> sequences, TimeSpan timeout, Func<FirmataCommandSequence, byte[], bool> isMatchingAck,
+            Func<FirmataCommandSequence, byte[], CommandError> errorFunc, out CommandError error)
+        {
+            if (sequences.Any(s => s.Validate() == false))
+            {
+                throw new ArgumentException("At least one command sequence is invalid", nameof(sequences));
+            }
+
+            if (sequences.Count > 127)
+            {
+                // Because we only have 7 bits for the sequence counter.
+                throw new ArgumentException("At most 127 sequences can be chained together", nameof(sequences));
+            }
+
+            if (isMatchingAck == null)
+            {
+                throw new ArgumentNullException(nameof(isMatchingAck));
+            }
+
+            error = CommandError.None;
+            if (_firmataStream == null)
+            {
+                throw new ObjectDisposedException(nameof(FirmataDevice));
+            }
+
+            Dictionary<FirmataCommandSequence, bool> sequencesWithAck = new();
+            foreach (var s in sequences)
+            {
+                sequencesWithAck.Add(s, false);
+                _firmataStream.Write(s.InternalSequence, 0, s.Length);
+            }
+
+            _firmataStream.Flush();
+
+            byte[]? response;
+            do
+            {
+                foreach (var s2 in sequencesWithAck)
+                {
+                    if (_pendingResponses.TryRemoveElement(x => isMatchingAck(s2.Key, x!), timeout, out response))
+                    {
+                        CommandError e = CommandError.None;
+                        if (response == null)
+                        {
+                            error = CommandError.Aborted;
+                        }
+                        else if (_lastCommandError != CommandError.None)
+                        {
+                            error = _lastCommandError;
+                        }
+                        else if ((e = errorFunc(s2.Key, response)) != CommandError.None)
+                        {
+                            error = e;
+                        }
+
+                        sequencesWithAck[s2.Key] = true;
+                        break;
+                    }
+                }
+            }
+            while (sequencesWithAck.Any(x => x.Value == false));
+
+            return sequencesWithAck.All(x => x.Value);
         }
 
         /// <summary>
@@ -656,7 +720,7 @@ namespace Iot.Device.Arduino
                 throw new ObjectDisposedException(nameof(FirmataDevice));
             }
 
-            Span<byte> rawData = stackalloc byte[100];
+            Span<byte> rawData = stackalloc byte[512];
 
             int bytesRead = _firmataStream.Read(rawData);
             for (int i = 0; i < bytesRead; i++)
@@ -677,7 +741,12 @@ namespace Iot.Device.Arduino
                 }
                 catch (Exception ex)
                 {
-                    OnError?.Invoke($"Firmata protocol error: Parser exception {ex.Message}", ex);
+                    // If the exception happens because the stream was closed, don't print an error
+                    if (!_inputThreadShouldExit)
+                    {
+                        _logger.LogError(ex, $"Error in parser: {ex.Message}");
+                        OnError?.Invoke($"Firmata protocol error: Parser exception {ex.Message}", ex);
+                    }
                 }
             }
         }
@@ -848,7 +917,10 @@ namespace Iot.Device.Arduino
 
             return PerformRetries(3, () =>
             {
-                var response = SendCommandAndWait(getPinModeSequence);
+                var response = SendCommandAndWait(getPinModeSequence, DefaultReplyTimeout, (sequence, bytes) =>
+                {
+                    return bytes.Length >= 4 && bytes[1] == pinNumber;
+                }, out _);
 
                 // The mode is byte 4
                 if (response.Length < 4)
@@ -929,10 +1001,13 @@ namespace Iot.Device.Arduino
             {
                 i2cSequence.WriteByte((byte)FirmataSysexCommand.I2C_REQUEST);
                 i2cSequence.WriteByte((byte)slaveAddress);
-                i2cSequence.WriteByte(0); // Write flag is 0, all other bits as well
+                // Write flag is 0, all other bits normally, too.
+                i2cSequence.WriteByte(0);
                 i2cSequence.WriteBytesAsTwo7bitBytes(writeData);
                 i2cSequence.WriteByte((byte)FirmataCommand.END_SYSEX);
             }
+
+            int sequenceNo = (_i2cSequence++) & 0b111;
 
             if (replyData != null && replyData.Length > 0)
             {
@@ -945,7 +1020,9 @@ namespace Iot.Device.Arduino
 
                 i2cSequence.WriteByte((byte)FirmataSysexCommand.I2C_REQUEST);
                 i2cSequence.WriteByte((byte)slaveAddress);
-                i2cSequence.WriteByte(0b1000); // Read flag is 1, all other bits are 0
+
+                // Read flag is 1, all other bits are 0. We use bits 0-2  (slave address MSB, unused in 7 bit mode) as sequence id.
+                i2cSequence.WriteByte((byte)(0b1000 | sequenceNo));
                 byte length = (byte)replyData.Length;
                 // Only write the length of the expected data.
                 // We could insert the register to read here, but we assume that has been written already (the client is responsible for that)
@@ -956,7 +1033,25 @@ namespace Iot.Device.Arduino
 
             if (doWait)
             {
-                var response = SendCommandAndWait(i2cSequence);
+                var response = SendCommandAndWait(i2cSequence, TimeSpan.FromSeconds(3), (sequence, bytes) =>
+                {
+                    if (bytes.Length < 5)
+                    {
+                        return false;
+                    }
+
+                    if (bytes[0] != (byte)FirmataSysexCommand.I2C_REPLY)
+                    {
+                        return false;
+                    }
+
+                    if ((bytes[2] & 0b111) != sequenceNo)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }, out _);
 
                 if (response[0] != (byte)FirmataSysexCommand.I2C_REPLY)
                 {
@@ -1053,17 +1148,71 @@ namespace Iot.Device.Arduino
             SendCommand(disableSpi);
         }
 
-        public void SpiWrite(int csPin, ReadOnlySpan<byte> writeBytes)
+        public void SpiWrite(int csPin, ReadOnlySpan<byte> writeBytes, bool waitForReply = false)
         {
             // When the command is SPI_WRITE, the device answer is already discarded in the firmware.
-            var command = SpiWrite(csPin, FirmataSpiCommand.SPI_WRITE, writeBytes, out _);
-            SendCommand(command);
+            if (waitForReply)
+            {
+                var command = SpiWrite(csPin, FirmataSpiCommand.SPI_WRITE_ACK, writeBytes, out byte requestId);
+                var response = SendCommandAndWait(command, DefaultReplyTimeout, (sequence, bytes) =>
+                {
+                    if (bytes.Length < 5)
+                    {
+                        return false;
+                    }
+
+                    if (bytes[0] != (byte)FirmataSysexCommand.SPI_DATA || bytes[1] != (byte)FirmataSpiCommand.SPI_REPLY)
+                    {
+                        return false;
+                    }
+
+                    if (bytes[3] != (byte)requestId)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }, out _lastCommandError);
+
+                if (response[0] != (byte)FirmataSysexCommand.SPI_DATA || response[1] != (byte)FirmataSpiCommand.SPI_REPLY)
+                {
+                    throw new IOException("Firmata protocol error: received incorrect query response");
+                }
+
+                if (response[3] != (byte)requestId)
+                {
+                    throw new IOException($"Firmata protocol sequence error.");
+                }
+            }
+            else
+            {
+                var command = SpiWrite(csPin, FirmataSpiCommand.SPI_WRITE, writeBytes, out _);
+                SendCommand(command);
+            }
         }
 
         public void SpiTransfer(int csPin, ReadOnlySpan<byte> writeBytes, Span<byte> readBytes)
         {
             var command = SpiWrite(csPin, FirmataSpiCommand.SPI_TRANSFER, writeBytes, out byte requestId);
-            var response = SendCommandAndWait(command);
+            var response = SendCommandAndWait(command, DefaultReplyTimeout, (sequence, bytes) =>
+            {
+                if (bytes.Length < 5)
+                {
+                    return false;
+                }
+
+                if (bytes[0] != (byte)FirmataSysexCommand.SPI_DATA || bytes[1] != (byte)FirmataSpiCommand.SPI_REPLY)
+                {
+                    return false;
+                }
+
+                if (bytes[3] != (byte)requestId)
+                {
+                    return false;
+                }
+
+                return true;
+            }, out _lastCommandError);
 
             if (response[0] != (byte)FirmataSysexCommand.SPI_DATA || response[1] != (byte)FirmataSpiCommand.SPI_REPLY)
             {
@@ -1089,7 +1238,7 @@ namespace Iot.Device.Arduino
             spiCommand.WriteByte(requestId);
             spiCommand.WriteByte(1); // Deselect CS after transfer (yes)
             spiCommand.WriteByte((byte)writeBytes.Length);
-            spiCommand.WriteBytesAsTwo7bitBytes(writeBytes);
+            spiCommand.Write(Encoder7Bit.Encode(writeBytes));
             spiCommand.WriteByte((byte)FirmataCommand.END_SYSEX);
             return spiCommand;
         }
@@ -1114,18 +1263,36 @@ namespace Iot.Device.Arduino
                 throw new NotSupportedException("Only pins <=15 are allowed as CS line");
             }
 
+            if (_firmwareVersion <= new Version(2, 11))
+            {
+                // we could leverage this, if needed, by using the older data encoding
+                throw new NotSupportedException("This library requires firmware version 2.12 or later for SPI transfers");
+            }
+
+            int deviceId = connectionSettings.ChipSelectLine;
             FirmataCommandSequence spiConfigSequence = new();
             spiConfigSequence.WriteByte((byte)FirmataSysexCommand.SPI_DATA);
             spiConfigSequence.WriteByte((byte)FirmataSpiCommand.SPI_DEVICE_CONFIG);
-            byte deviceIdChannel = (byte)(connectionSettings.ChipSelectLine << 3);
+            byte deviceIdChannel = (byte)(deviceId << 3 | (connectionSettings.BusId & 0x7));
             spiConfigSequence.WriteByte((byte)(deviceIdChannel));
-            spiConfigSequence.WriteByte((byte)1);
-            int clockSpeed = 1_000_000; // Hz
-            spiConfigSequence.WriteByte((byte)(clockSpeed & 0x7F));
-            spiConfigSequence.WriteByte((byte)((clockSpeed >> 7) & 0x7F));
-            spiConfigSequence.WriteByte((byte)((clockSpeed >> 15) & 0x7F));
-            spiConfigSequence.WriteByte((byte)((clockSpeed >> 22) & 0x7F));
-            spiConfigSequence.WriteByte((byte)((clockSpeed >> 29) & 0x7F));
+            int dataMode = 0;
+            if (connectionSettings.DataFlow == DataFlow.MsbFirst)
+            {
+                dataMode = 1;
+            }
+
+            int mode = ((int)connectionSettings.Mode) << 1;
+            dataMode |= mode;
+            dataMode |= 0x8; // Use fast transfer mode
+
+            spiConfigSequence.WriteByte((byte)dataMode);
+            int clockSpeed = connectionSettings.ClockFrequency;
+            if (clockSpeed <= 0)
+            {
+                clockSpeed = 1_000_000;
+            }
+
+            spiConfigSequence.SendInt32(clockSpeed);
             spiConfigSequence.WriteByte(0); // Word size (default = 8)
             spiConfigSequence.WriteByte(1); // Default CS pin control (enable)
             spiConfigSequence.WriteByte((byte)(connectionSettings.ChipSelectLine));
@@ -1194,6 +1361,14 @@ namespace Iot.Device.Arduino
         {
             Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        public void SendSoftwareReset()
+        {
+            lock (_synchronisationLock)
+            {
+                _firmataStream?.WriteByte(0xFF);
+            }
         }
     }
 }

--- a/src/devices/Arduino/FirmataSpiCommand.cs
+++ b/src/devices/Arduino/FirmataSpiCommand.cs
@@ -12,5 +12,6 @@ namespace Iot.Device.Arduino
         SPI_READ = 0x04,
         SPI_REPLY = 0x05,
         SPI_END = 0x06,
+        SPI_WRITE_ACK = 0x07,
     }
 }

--- a/src/devices/Arduino/ReconnectingNetworkStream.cs
+++ b/src/devices/Arduino/ReconnectingNetworkStream.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/devices/Arduino/ReconnectingNetworkStream.cs
+++ b/src/devices/Arduino/ReconnectingNetworkStream.cs
@@ -2,19 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Iot.Device.Arduino
 {
     internal class ReconnectingNetworkStream : Stream
     {
         private readonly Func<Stream> _reconnect;
+        private readonly object _lock = new object();
         private Stream? _streamImplementation;
-        private object _lock = new object();
 
         public ReconnectingNetworkStream(Stream? underlyingStream, Func<Stream> reconnect)
         {
@@ -28,37 +24,13 @@ namespace Iot.Device.Arduino
         {
         }
 
-        public override bool CanRead
-        {
-            get
-            {
-                return SafeExecute(x => x.CanRead, false);
-            }
-        }
+        public override bool CanRead => SafeExecute(x => x.CanRead, false);
 
-        public override bool CanSeek
-        {
-            get
-            {
-                return SafeExecute(x => x.CanSeek, false);
-            }
-        }
+        public override bool CanSeek => SafeExecute(x => x.CanSeek, false);
 
-        public override bool CanWrite
-        {
-            get
-            {
-                return SafeExecute(x => x.CanWrite, false);
-            }
-        }
+        public override bool CanWrite => SafeExecute(x => x.CanWrite, false);
 
-        public override long Length
-        {
-            get
-            {
-                return SafeExecute(x => x.Length, false);
-            }
-        }
+        public override long Length => SafeExecute(x => x.Length, false);
 
         public override long Position
         {
@@ -109,7 +81,7 @@ namespace Iot.Device.Arduino
                     }
                     catch (IOException)
                     {
-                        // Ignore
+                        // Ignore, cannot currently reconnect. So need to retry later.
                     }
                 }
             }
@@ -173,8 +145,6 @@ namespace Iot.Device.Arduino
                 {
                     throw new TimeoutException("Error executing operation. Retrying next time", x);
                 }
-
-                return;
             }
         }
 

--- a/src/devices/Arduino/ReconnectingNetworkStream.cs
+++ b/src/devices/Arduino/ReconnectingNetworkStream.cs
@@ -44,30 +44,15 @@ namespace Iot.Device.Arduino
             }
         }
 
-        public override void Flush()
-        {
-            SafeExecute(x => x.Flush(), true);
-        }
+        public override void Flush() => SafeExecute(x => x.Flush(), true);
 
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            return SafeExecute(x => x.Read(buffer, offset, count), true);
-        }
+        public override int Read(byte[] buffer, int offset, int count) => SafeExecute(x => x.Read(buffer, offset, count), true);
 
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            return SafeExecute(x => x.Seek(offset, origin), true);
-        }
+        public override long Seek(long offset, SeekOrigin origin) => SafeExecute(x => x.Seek(offset, origin), true);
 
-        public override void SetLength(long value)
-        {
-            SafeExecute(x => x.SetLength(value), false);
-        }
+        public override void SetLength(long value) => SafeExecute(x => x.SetLength(value), false);
 
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            SafeExecute(x => x.Write(buffer, offset, count), false);
-        }
+        public override void Write(byte[] buffer, int offset, int count) => SafeExecute(x => x.Write(buffer, offset, count), false);
 
         private void Connect()
         {

--- a/src/devices/Arduino/ReconnectingNetworkStream.cs
+++ b/src/devices/Arduino/ReconnectingNetworkStream.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Iot.Device.Arduino
+{
+    internal class ReconnectingNetworkStream : Stream
+    {
+        private readonly Func<Stream> _reconnect;
+        private Stream? _streamImplementation;
+        private object _lock = new object();
+
+        public ReconnectingNetworkStream(Stream? underlyingStream, Func<Stream> reconnect)
+        {
+            _streamImplementation = underlyingStream;
+            _reconnect = reconnect;
+            Connect();
+        }
+
+        public ReconnectingNetworkStream(Func<Stream> connect)
+        : this(null, connect)
+        {
+        }
+
+        public override bool CanRead
+        {
+            get
+            {
+                return SafeExecute(x => x.CanRead, false);
+            }
+        }
+
+        public override bool CanSeek
+        {
+            get
+            {
+                return SafeExecute(x => x.CanSeek, false);
+            }
+        }
+
+        public override bool CanWrite
+        {
+            get
+            {
+                return SafeExecute(x => x.CanWrite, false);
+            }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                return SafeExecute(x => x.Length, false);
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                return SafeExecute(x => x.Position, false);
+            }
+            set
+            {
+                SafeExecute(x => x.Position = value, false);
+            }
+        }
+
+        public override void Flush()
+        {
+            SafeExecute(x => x.Flush(), true);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return SafeExecute(x => x.Read(buffer, offset, count), true);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return SafeExecute(x => x.Seek(offset, origin), true);
+        }
+
+        public override void SetLength(long value)
+        {
+            SafeExecute(x => x.SetLength(value), false);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            SafeExecute(x => x.Write(buffer, offset, count), false);
+        }
+
+        private void Connect()
+        {
+            if (_streamImplementation == null)
+            {
+                lock (_lock)
+                {
+                    try
+                    {
+                        _streamImplementation = _reconnect();
+                    }
+                    catch (IOException)
+                    {
+                        // Ignore
+                    }
+                }
+            }
+        }
+
+        private T SafeExecute<T>(Func<Stream, T> operation, bool doThrow)
+            where T : struct
+        {
+            try
+            {
+                Connect();
+
+                if (_streamImplementation == null)
+                {
+                    if (doThrow)
+                    {
+                        throw new TimeoutException("Stream is disconnected. Retrying next time.");
+                    }
+
+                    return default(T);
+                }
+
+                return operation(_streamImplementation);
+            }
+            catch (IOException x)
+            {
+                _streamImplementation?.Dispose();
+                _streamImplementation = null;
+                if (doThrow)
+                {
+                    throw new TimeoutException("Error executing operation. Retrying next time", x);
+                }
+
+                return default(T);
+            }
+        }
+
+        private void SafeExecute(Action<Stream> operation, bool doThrow)
+        {
+            try
+            {
+                Connect();
+
+                if (_streamImplementation == null)
+                {
+                    if (doThrow)
+                    {
+                        throw new TimeoutException("Stream is disconnected. Retrying next time.");
+                    }
+
+                    return;
+                }
+
+                operation(_streamImplementation);
+            }
+            catch (IOException x)
+            {
+                _streamImplementation?.Dispose();
+                _streamImplementation = null;
+                if (doThrow)
+                {
+                    throw new TimeoutException("Error executing operation. Retrying next time", x);
+                }
+
+                return;
+            }
+        }
+
+        public override void Close()
+        {
+            if (_streamImplementation != null)
+            {
+                _streamImplementation.Close();
+                _streamImplementation = null;
+            }
+
+            base.Close();
+        }
+    }
+}

--- a/src/devices/Arduino/tests/BlockingConcurrentBagTest.cs
+++ b/src/devices/Arduino/tests/BlockingConcurrentBagTest.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Iot.Device.Arduino;
+using Xunit;
+
+namespace Iot.Device.Arduino.Tests
+{
+    public class BlockingConcurrentBagTest
+    {
+        private BlockingConcurrentBag<int> _blockingConcurrentBag;
+
+        public BlockingConcurrentBagTest()
+        {
+            _blockingConcurrentBag = new BlockingConcurrentBag<int>();
+        }
+
+        [Fact]
+        public void CanAddAndRemove()
+        {
+            _blockingConcurrentBag.Add(1);
+            Assert.True(_blockingConcurrentBag.TryRemoveElement(x => true, TimeSpan.Zero, out int a));
+            Assert.True(a == 1);
+        }
+
+        [Fact]
+        public void ReturnsFalseWhenElementDoesNotMatch()
+        {
+            _blockingConcurrentBag.Add(1);
+            Assert.False(_blockingConcurrentBag.TryRemoveElement(x => x == 3, TimeSpan.FromSeconds(1), out int a));
+        }
+    }
+}


### PR DESCRIPTION
- Support waiting for SPI write commands. When using fast data rates, a buffer overrun
will otherwise occur
- Write SPI data in 7-bit encoding format (requires firmata update)
- Make flow control parameter controllable from outside
- Various stability fixes

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1841)