### PR TITLE
Added support for built-in pull-down resistors

### DIFF
--- a/src/devices/KeyMatrix/KeyMatrix.cs
+++ b/src/devices/KeyMatrix/KeyMatrix.cs
@@ -207,9 +207,10 @@ namespace Iot.Device.KeyMatrix
                 _gpioController!.OpenPin(_outputPins[i], PinMode.Output);
             }
 
+            bool usePullDown = _inputPins.All(p => _gpioController!.IsPinModeSupported(p, PinMode.InputPullDown));
             for (int i = 0; i < _inputPins.Length; i++)
             {
-                _gpioController!.OpenPin(_inputPins[i], PinMode.Input);
+                _gpioController!.OpenPin(_inputPins[i], usePullDown ? PinMode.InputPullDown, PinMode.Input);
             }
 
             _pinsOpened = true;


### PR DESCRIPTION
fix #1845 
`OpenPins` now checks if all the input pins support `PinMode.inputPullDown`, and then uses that instead of `PinMode.input`