### PR TITLE
Added support for internal pull-down resistors

### DIFF
--- a/src/devices/KeyMatrix/KeyMatrix.cs
+++ b/src/devices/KeyMatrix/KeyMatrix.cs
@@ -99,7 +99,7 @@ namespace Iot.Device.KeyMatrix
 
             if (inputPinMode != PinMode.Input && inputPinMode != PinMode.InputPullDown)
             {
-                throw new ArgumentException("Input pins can only be set to Input or inputPullDown.");
+                throw new ArgumentException("Input pins can only be set to Input or InputPullDown.");
             }
 
             if (!outputPins.Any())
@@ -120,7 +120,7 @@ namespace Iot.Device.KeyMatrix
             if (inputPinMode == PinMode.InputPullDown &&
                 !inputPins.All(p => _gpioController.IsPinModeSupported(p, _inputPinMode)))
             {
-                throw new ArgumentException("Input pins do not soppurt InputPullDown");
+                throw new ArgumentException("Not all input pins support InputPullDown");
             }
 
             _outputPins = outputPins.ToArray();

--- a/src/devices/KeyMatrix/KeyMatrix.cs
+++ b/src/devices/KeyMatrix/KeyMatrix.cs
@@ -207,9 +207,10 @@ namespace Iot.Device.KeyMatrix
                 _gpioController!.OpenPin(_outputPins[i], PinMode.Output);
             }
 
+            bool usePullDown = _inputPins.All(p => _gpioController!.IsPinModeSupported(p, PinMode.InputPullDown));
             for (int i = 0; i < _inputPins.Length; i++)
             {
-                _gpioController!.OpenPin(_inputPins[i], PinMode.Input);
+                _gpioController!.OpenPin(_inputPins[i], usePullDown ? PinMode.InputPullDown : PinMode.Input);
             }
 
             _pinsOpened = true;

--- a/src/devices/KeyMatrix/KeyMatrix.cs
+++ b/src/devices/KeyMatrix/KeyMatrix.cs
@@ -73,7 +73,7 @@ namespace Iot.Device.KeyMatrix
         /// <param name="gpioController">GPIO controller</param>
         /// <param name="shouldDispose">True to dispose the GpioController</param>
         public KeyMatrix(IEnumerable<int> outputPins, IEnumerable<int> inputPins, TimeSpan scanInterval, GpioController? gpioController = null, bool shouldDispose = true)
-            : this(outputPins, inputPins, scanInterval, gpioController, PinMode.Input, shouldDispose)
+            : this(outputPins, inputPins, scanInterval, PinMode.Input, gpioController, shouldDispose)
         {
         }
 
@@ -86,7 +86,7 @@ namespace Iot.Device.KeyMatrix
         /// <param name="gpioController">GPIO controller</param>
         /// <param name="inputPinMode">Mode for input pins - Input / InputPullDown</param>
         /// <param name="shouldDispose">True to dispose the GpioController</param>
-        public KeyMatrix(IEnumerable<int> outputPins, IEnumerable<int> inputPins, TimeSpan scanInterval, GpioController? gpioController = null, PinMode inputPinMode = PinMode.Input, bool shouldDispose = true)
+        public KeyMatrix(IEnumerable<int> outputPins, IEnumerable<int> inputPins, TimeSpan scanInterval, PinMode inputPinMode, GpioController? gpioController = null, bool shouldDispose = true)
         {
             _shouldDispose = shouldDispose || gpioController == null;
             _gpioController = gpioController ?? new();

--- a/src/devices/KeyMatrix/KeyMatrix.cs
+++ b/src/devices/KeyMatrix/KeyMatrix.cs
@@ -71,6 +71,19 @@ namespace Iot.Device.KeyMatrix
         /// <param name="inputPins">Input pins</param>
         /// <param name="scanInterval">Scanning interval in milliseconds</param>
         /// <param name="gpioController">GPIO controller</param>
+        /// <param name="shouldDispose">True to dispose the GpioController</param>
+        public KeyMatrix(IEnumerable<int> outputPins, IEnumerable<int> inputPins, TimeSpan scanInterval, GpioController? gpioController = null, bool shouldDispose = true)
+            : this(outputPins, inputPins, scanInterval, gpioController, PinMode.Input, shouldDispose)
+        {
+        }
+
+        /// <summary>
+        /// Initialize key matrix
+        /// </summary>
+        /// <param name="outputPins">Output pins</param>
+        /// <param name="inputPins">Input pins</param>
+        /// <param name="scanInterval">Scanning interval in milliseconds</param>
+        /// <param name="gpioController">GPIO controller</param>
         /// <param name="inputPinMode">Mode for input pins - Input / InputPullDown</param>
         /// <param name="shouldDispose">True to dispose the GpioController</param>
         public KeyMatrix(IEnumerable<int> outputPins, IEnumerable<int> inputPins, TimeSpan scanInterval, GpioController? gpioController = null, PinMode inputPinMode = PinMode.Input, bool shouldDispose = true)
@@ -106,7 +119,7 @@ namespace Iot.Device.KeyMatrix
 
             if (inputPinMode == PinMode.InputPullDown &&
                 !inputPins.All(p => _gpioController.IsPinModeSupported(p, _inputPinMode)))
-                {
+            {
                 throw new ArgumentException("Input pins do not soppurt InputPullDown");
             }
 


### PR DESCRIPTION
Fix #1845 
`OpenPins` now checks if all the input pins support `PinMode.InputPullDown`, and then uses `PinMode.InputPullDown` instead of `PinMode.Input`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1847)