### PR TITLE
Support Raspberry Pi 400

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -141,6 +141,7 @@ public class RaspberryPi3Driver : GpioDriver
             RaspberryBoardInfo.Model.RaspberryPiZeroW or
             RaspberryBoardInfo.Model.RaspberryPiZero2W or
             RaspberryBoardInfo.Model.RaspberryPi4 or
+            RaspberryBoardInfo.Model.RaspberryPi400 or
             RaspberryBoardInfo.Model.RaspberryPiComputeModule4 => new RaspberryPi3LinuxDriver(),
             RaspberryBoardInfo.Model.RaspberryPiComputeModule3 => new RaspberryPiCm3Driver(),
             _ => null,


### PR DESCRIPTION
Fixes #1830 by modifying `RaspberryPi3Driver.CreateInternalRaspberryPi3LinuxDriver()` to support the Raspberry Pi 400.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1885)