### PR TITLE
Fix creation of driver for Raspberry Pi 4 CM

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3Driver.cs
@@ -141,8 +141,8 @@ public class RaspberryPi3Driver : GpioDriver
             RaspberryBoardInfo.Model.RaspberryPiZeroW or
             RaspberryBoardInfo.Model.RaspberryPiZero2W or
             RaspberryBoardInfo.Model.RaspberryPi4 or
-            RaspberryBoardInfo.Model.RaspberryPi400 or
-            RaspberryBoardInfo.Model.RaspberryPiComputeModule4 => new RaspberryPi3LinuxDriver(),
+            RaspberryBoardInfo.Model.RaspberryPi400 => new RaspberryPi3LinuxDriver(),
+            RaspberryBoardInfo.Model.RaspberryPiComputeModule4 or
             RaspberryBoardInfo.Model.RaspberryPiComputeModule3 => new RaspberryPiCm3Driver(),
             _ => null,
         };


### PR DESCRIPTION
Fixes #1888

The RaspberryPi3CMDriver needs to be used in this case

This does not address the issue that we should improve the detection system for now, it just fixes the obvious bug.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1907)