### PR TITLE
Add BiColorBargraph using Ht16k33

### DIFF
--- a/src/devices/Display/BarColor.cs
+++ b/src/devices/Display/BarColor.cs
@@ -11,21 +11,21 @@ namespace Iot.Device.Display
         /// <summary>
         /// Disable LED.
         /// </summary>
-        OFF = 0,
+        Off = 0,
 
         /// <summary>
         /// Enable red LED.
         /// </summary>
-        RED = 1,
+        Red = 1,
 
         /// <summary>
         /// Enable green LED.
         /// </summary>
-        GREEN = 2,
+        Green = 2,
 
         /// <summary>
         /// Enable both green and red LEDs, producing a yellow color.
         /// </summary>
-        YELLOW = 3
+        Yellow = 3
     }
 }

--- a/src/devices/Display/BarColor.cs
+++ b/src/devices/Display/BarColor.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Display
+{
+    /// <summary>
+    /// Describes LED colors in a Bargraph.
+    /// </summary>
+    public enum BarColor
+    {
+        /// <summary>
+        /// Disable LED.
+        /// </summary>
+        OFF = 0,
+
+        /// <summary>
+        /// Enable red LED.
+        /// </summary>
+        RED = 1,
+
+        /// <summary>
+        /// Enable green LED.
+        /// </summary>
+        GREEN = 2,
+
+        /// <summary>
+        /// Enable both green and red LEDs, producing a yellow color.
+        /// </summary>
+        YELLOW = 3
+    }
+}

--- a/src/devices/Display/BiColorBarGraph.cs
+++ b/src/devices/Display/BiColorBarGraph.cs
@@ -67,9 +67,16 @@ namespace Iot.Device.Display
             {
                 Flush();
             }
-    }
+        }
 
         /*
+            Task: Update data for the bargraph
+
+            The following diagram shows the intended orientation of the bargraph.
+
+            x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x
+            23 22 21 20 19 18 17 16 15 14 13 12 11 10 9  8  7  6  5  4  3  2  1  0
+
             Each bargraph has three segments, four LEDs each.
             For the 24-segment bargraph, that's six segments of four LEDs.
             Each segment is addressed separately, with 4 bits (of a byte).
@@ -125,23 +132,24 @@ namespace Iot.Device.Display
             byte red = _displayBuffer[bufferIndex];
             byte green = _displayBuffer[bufferIndex + 1];
 
-            if (value is BarColor.OFF)
+            switch (value)
             {
-                _displayBuffer[bufferIndex] = (byte)(red & ~mask);
-                _displayBuffer[bufferIndex + 1] = (byte)(green & ~mask);
-            }
-            else if (value is BarColor.RED)
-            {
-                _displayBuffer[bufferIndex] = (byte)(red ^ mask);
-            }
-            else if (value is BarColor.GREEN)
-            {
-                _displayBuffer[bufferIndex + 1] = (byte)(green ^ mask);
-            }
-            else if (value is BarColor.YELLOW)
-            {
-                _displayBuffer[bufferIndex] = (byte)(red ^ mask);
-                _displayBuffer[bufferIndex + 1] = (byte)(green ^ mask);
+                case BarColor.Off:
+                    _displayBuffer[bufferIndex] = (byte)(red & ~mask);
+                    _displayBuffer[bufferIndex + 1] = (byte)(green & ~mask);
+                    break;
+                case BarColor.Red:
+                    _displayBuffer[bufferIndex] = (byte)(red ^ mask);
+                    break;
+                case BarColor.Green:
+                    _displayBuffer[bufferIndex + 1] = (byte)(green ^ mask);
+                    break;
+                case BarColor.Yellow:
+                    _displayBuffer[bufferIndex] = (byte)(red ^ mask);
+                    _displayBuffer[bufferIndex + 1] = (byte)(green ^ mask);
+                    break;
+                default:
+                    break;
             }
         }
     }

--- a/src/devices/Display/BiColorBarGraph.cs
+++ b/src/devices/Display/BiColorBarGraph.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Device.I2c;
+
+namespace Iot.Device.Display
+{
+    /// <summary>
+    /// Represents a 24-Segment bargraph that can display multiple colors.
+    /// </summary>
+    // Product: https://www.adafruit.com/product/1721
+    public class BiColorBarGraph : Ht16k33
+    {
+        private byte[] _displayBuffer = new byte[7];
+        private BarColor[] _biColorSegment = new BarColor[24];
+
+        /// <summary>
+        /// Initialize BarGraph display
+        /// </summary>
+        /// <param name="i2cDevice">The <see cref="I2cDevice"/> to create with.</param>
+        public BiColorBarGraph(I2cDevice i2cDevice)
+            : base(i2cDevice)
+        {
+        }
+
+        /// <summary>
+        /// Indexer for <see cref="BiColorBarGraph"/>.
+        /// </summary>
+        public BarColor this[int index]
+        {
+            get => _biColorSegment[index];
+            set
+            {
+                _biColorSegment[index] = value;
+                UpdateBuffer(index);
+                if (BufferingEnabled)
+                {
+                    Flush();
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Clear()
+        {
+            _displayBuffer = new byte[7];
+            if (BufferingEnabled)
+            {
+                _i2cDevice.Write(_displayBuffer);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Flush() => _i2cDevice.Write(_displayBuffer);
+
+        /// <inheritdoc/>
+        public override void Write(ReadOnlySpan<byte> data, int startAddress = 0)
+        {
+            // Note: first byte is command data; does not affect display
+            foreach (byte b in data)
+            {
+                _displayBuffer[startAddress++] = b;
+            }
+
+            if (BufferingEnabled)
+            {
+                Flush();
+            }
+    }
+
+        /*
+            Each bargraph has three segments, four LEDs each.
+            For the 24-segment bargraph, that's six segments of four LEDs.
+            Each segment is addressed separately, with 4 bits (of a byte).
+            The first and last 4 bits of each byte represent different segments.
+            Each bit represents an LED. If the bits are on, the LEDs are on.
+
+            Each bar contains two LEDs. These are separately controlled.
+            That means that there are eight bits to consider for each segement,
+            four for each color. All of which can be separately on or off.
+
+            There are seven (7) bytes in the buffer.
+
+            The first byte of the buffer is for control/command information.
+            It should always be `0` unless specifically sending commands (like for blinking).
+
+            Each of the following bytes are paired, the first for red and the second for green.
+            Each of the bytes in the pair are split, the first half for one segment,
+            and the second half for the matching segement on the other bargraph.
+
+            The bytes are laid out this way:
+            - first segment: first four bits of bytes[2] for red; first four bits of bytes[3] for green
+            - second segment: first four bits of bytes[4] for red; first four bits of bytes[5] for green
+            - third segment: first four bits of bytes[6] for red; first four bits of bytes[7] for green
+            ------------- // boundary of the bargraph units
+            - fourth segment: second four bits of bytes[2] for red; second four bits of bytes[3] for green
+            - fifth segment: second four bits of bytes[4] for red; second four bits of bytes[5] for green
+            - sixth segment: second four bits of bytes[6] for red; second four bits of bytes[7] for green
+
+            This is more obvious if you write some variation of value to the i2cdevice:
+
+            byte[] buffer =
+            {
+                0, 255, 0, 0, 255, 255, 255
+            };
+        */
+        private void UpdateBuffer(int index)
+        {
+            // Tasks:
+            // Determine the location of the bar (for `index`).
+            // Produce a mask for the correct bit (within four bits).
+            // bitmask the correct bits dependending on the desired result
+            // Some basic math to use:
+            // x = index % 4 // which third (for example, for the 24 bar graph, there are six thirds)
+            // y = x % 3 // which third of the bar segment to use
+            // z = index / 12 // which of the bar segments to use
+            BarColor value = _biColorSegment[index];
+            int unit = index / 12;
+            int segment = index / 4;
+            int third = segment % 3;
+            int bit = index % 4 + (index / 12) * 4;
+            int mask = 1 << bit;
+            int bufferIndex = (third * 2) + 1;
+            byte red = _displayBuffer[bufferIndex];
+            byte green = _displayBuffer[bufferIndex + 1];
+
+            if (value is BarColor.OFF)
+            {
+                _displayBuffer[bufferIndex] = (byte)(red & ~mask);
+                _displayBuffer[bufferIndex + 1] = (byte)(green & ~mask);
+            }
+            else if (value is BarColor.RED)
+            {
+                _displayBuffer[bufferIndex] = (byte)(red ^ mask);
+            }
+            else if (value is BarColor.GREEN)
+            {
+                _displayBuffer[bufferIndex + 1] = (byte)(green ^ mask);
+            }
+            else if (value is BarColor.YELLOW)
+            {
+                _displayBuffer[bufferIndex] = (byte)(red ^ mask);
+                _displayBuffer[bufferIndex + 1] = (byte)(green ^ mask);
+            }
+        }
+    }
+}

--- a/src/devices/Display/BiColorBarGraph.cs
+++ b/src/devices/Display/BiColorBarGraph.cs
@@ -12,8 +12,8 @@ namespace Iot.Device.Display
     // Product: https://www.adafruit.com/product/1721
     public class BiColorBarGraph : Ht16k33
     {
-        private byte[] _displayBuffer = new byte[7];
-        private BarColor[] _biColorSegment = new BarColor[24];
+        private readonly byte[] _displayBuffer = new byte[7];
+        private readonly BarColor[] _biColorSegment = new BarColor[24];
 
         /// <summary>
         /// Initialize BarGraph display
@@ -41,10 +41,43 @@ namespace Iot.Device.Display
             }
         }
 
+        /// <summary>
+        /// Enable all LEDs.
+        /// </summary>
+        public void Fill(BarColor color)
+        {
+            byte fill = 0xFF;
+            switch (color)
+            {
+                case BarColor.Red:
+                    _displayBuffer[1] = fill;
+                    _displayBuffer[3] = fill;
+                    _displayBuffer[5] = fill;
+                    break;
+                case BarColor.Green:
+                    _displayBuffer[2] = fill;
+                    _displayBuffer[4] = fill;
+                    _displayBuffer[6] = fill;
+                    break;
+                case BarColor.Yellow:
+                    Span<byte> displayBuffer = _displayBuffer;
+                    displayBuffer.Fill(0xFF);
+                    displayBuffer[0] = 0x00;
+                    break;
+                default:
+                    break;
+            }
+
+            if (BufferingEnabled)
+            {
+                _i2cDevice.Write(_displayBuffer);
+            }
+        }
+
         /// <inheritdoc/>
         public override void Clear()
         {
-            _displayBuffer = new byte[7];
+            _displayBuffer.AsSpan().Clear();
             if (BufferingEnabled)
             {
                 _i2cDevice.Write(_displayBuffer);

--- a/src/devices/Display/BiColorBarGraph.cs
+++ b/src/devices/Display/BiColorBarGraph.cs
@@ -74,7 +74,7 @@ namespace Iot.Device.Display
 
             The following diagram shows the intended orientation of the bargraph.
 
-            x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x
+      pins  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x
             23 22 21 20 19 18 17 16 15 14 13 12 11 10 9  8  7  6  5  4  3  2  1  0
 
             Each bargraph has three segments, four LEDs each.

--- a/src/devices/Display/BiColorBarGraph.cs
+++ b/src/devices/Display/BiColorBarGraph.cs
@@ -61,7 +61,7 @@ namespace Iot.Device.Display
                     break;
                 case BarColor.Yellow:
                     Span<byte> displayBuffer = _displayBuffer;
-                    displayBuffer.Fill(0xFF);
+                    displayBuffer.Fill(fill);
                     displayBuffer[0] = 0x00;
                     break;
                 default:

--- a/src/devices/Display/Display.csproj
+++ b/src/devices/Display/Display.csproj
@@ -13,6 +13,8 @@
     <Compile Include="FontHelper.cs" />
     <Compile Include="ISevenSegmentDisplay.cs" />
     <Compile Include="Large4Digit7SegmentDisplay.cs" />
+    <Compile Include="BiColorBarGraph.cs" />
+    <Compile Include="BarColor.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />

--- a/src/devices/Display/Display.sln
+++ b/src/devices/Display/Display.sln
@@ -7,6 +7,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{20F2
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Large4Digit7SegmentDisplay.sample", "samples\Large4Digit7SegmentDisplay.sample.csproj", "{C4D7AED7-B340-4DCD-974C-5150C6D5F074}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BiColorBargraph.sample", "samples\BiColorBargraph.sample.csproj", "{C4D7AED7-B340-4DCD-974C-5150C6D5F074}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Display", "Display.csproj", "{4AAE8B9E-8540-4582-8083-D1F14104BAAC}"
 EndProject
 Global

--- a/src/devices/Display/README.md
+++ b/src/devices/Display/README.md
@@ -9,9 +9,12 @@ Adafruit sells multiple display backpacks built upon this driver:
 - [1.2" 4-Digit 7-Segment Display w/I2C Backpack - Red](https://www.adafruit.com/product/1270)
 - [Bi-Color (Red/Green) 24-Bar Bargraph w/I2C Backpack Kit](https://www.adafruit.com/product/1721)
 
-More information on wiring can be found on the respective product pages.
+More information on wiring can be found on the respective product pages and at [adafruit/Adafruit_CircuitPython_HT16K33
+](https://github.com/adafruit/Adafruit_CircuitPython_HT16K33) (Adafruit-maintained Python bindings).
 
 ## 7-Segment Display Usage
+
+![Adafruit 1.2" 4-Digit 7-Segment Display w/I2C Backpack - Green](https://cdn-shop.adafruit.com/970x728/1268-00.jpg)
 
 ```csharp
 // Initialize display (busId = 1 for Raspberry Pi 2 & 3)
@@ -38,6 +41,8 @@ display.Flush();
 ```
 
 ## Bi-Color Bargraph Usage
+
+![Bi-Color (Red/Green) 24-Bar Bargraph w/I2C Backpack Kit](https://cdn-shop.adafruit.com/970x728/1721-00.jpg)
 
 ```csharp
 using BiColorBarGraph bargraph = new(I2cDevice.Create(new I2cConnectionSettings(busId: 1, Ht16k33.DefaultI2cAddress)))

--- a/src/devices/Display/README.md
+++ b/src/devices/Display/README.md
@@ -1,27 +1,21 @@
-# Segment display driver (HT16K33)
+# HT16K33 -- LED Matrix Display Driver
 
-This project contains multipurpose LED display drivers and binding implementations for concrete display configurations.
-
-## Documentation
-
-The **HT16K33** is LED display driver that supports multiple LED configurations and I2C communication.
+The [Ht16k33](https://cdn-shop.adafruit.com/datasheets/ht16K33v110.pdf)  is a memory mapping and multi-function LED controller driver. It is used as a [backpack driver for several Adafruit products](https://www.adafruit.com/?q=Ht16k33). It supports multiple LED configurations and I2C communication.
 
 Adafruit sells multiple display backpacks built upon this driver:
 
-- [Adafruit LED / SEGMENTED category](https://www.adafruit.com/category/103)
-- **Large4Digit7SegmentDisplay** is a binding that supports the **Adafruit 1.2" 4-Digit 7-Segment Display w/I2C Backpack** that comes in 3 colors:
-- [Adafruit 1.2" 4-Digit 7-Segment Display w/I2C Backpack - Yellow](https://www.adafruit.com/product/1268)
-- [Adafruit 1.2" 4-Digit 7-Segment Display w/I2C Backpack - Green](https://www.adafruit.com/product/1269)
-- [Adafruit 1.2" 4-Digit 7-Segment Display w/I2C Backpack - Red](https://www.adafruit.com/product/1270)
-- [HT16K33 datasheet](https://cdn-shop.adafruit.com/datasheets/ht16K33v110.pdf)
+- [1.2" 4-Digit 7-Segment Display w/I2C Backpack - Yellow](https://www.adafruit.com/product/1268)
+- [1.2" 4-Digit 7-Segment Display w/I2C Backpack - Green](https://www.adafruit.com/product/1269)
+- [1.2" 4-Digit 7-Segment Display w/I2C Backpack - Red](https://www.adafruit.com/product/1270)
+- [Bi-Color (Red/Green) 24-Bar Bargraph w/I2C Backpack Kit](https://www.adafruit.com/product/1721)
 
 More information on wiring can be found on the respective product pages.
 
-## Usage
+## 7-Segment Display Usage
 
 ```csharp
 // Initialize display (busId = 1 for Raspberry Pi 2 & 3)
-var display = new Large4Digit7SegmentDisplay(I2cDevice.Create(new I2cConnectionSettings(busId: 1, address: Ht16k33.DefaultI2cAddress));
+using var display = new Large4Digit7SegmentDisplay(I2cDevice.Create(new I2cConnectionSettings(busId: 1, address: Ht16k33.DefaultI2cAddress));
 
 // Set max brightness (automatically turns on display)
 display.Brightness = display.MaxBrightness;
@@ -41,7 +35,23 @@ display.Dots = Dot.DecimalPoint;
 
 // Send buffer to the device
 display.Flush();
+```
 
-// Dispose display object (the device itself will not be turned off until powered down)
-display.Dispose();
+## Bi-Color Bargraph Usage
+
+```csharp
+using BiColorBarGraph bargraph = new(I2cDevice.Create(new I2cConnectionSettings(busId: 1, Ht16k33.DefaultI2cAddress)))
+    {
+        // Set max brightness
+        Brightness = Ht16k33.MaxBrightness,
+        BufferingEnabled = true
+    };
+
+bargraph.Clear();
+
+bargraph[0] = BarColor.RED;
+bargraph[1] = BarColor.GREEN;
+bargraph[2] = BarColor.YELLOW;
+bargraph[3] = BarColor.OFF;
+bargraph[4] = BarColor.RED;
 ```

--- a/src/devices/Display/samples/BiColorBargraph.sample.csproj
+++ b/src/devices/Display/samples/BiColorBargraph.sample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DefaultSampleTfms)</TargetFramework>
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Display.csproj" />
-    <Compile Include="Program.cs" />
+    <Compile Include="Program.BiColorBargraph.cs" />
   </ItemGroup>
 </Project>

--- a/src/devices/Display/samples/Program.BiColorBargraph.cs
+++ b/src/devices/Display/samples/Program.BiColorBargraph.cs
@@ -16,11 +16,11 @@ using BiColorBarGraph bargraph = new(I2cDevice.Create(new I2cConnectionSettings(
 
 bargraph.Clear();
 
-bargraph[0] = BarColor.RED;
-bargraph[1] = BarColor.GREEN;
-bargraph[2] = BarColor.YELLOW;
-bargraph[3] = BarColor.OFF;
-bargraph[4] = BarColor.RED;
+bargraph[0] = BarColor.Red;
+bargraph[1] = BarColor.Green;
+bargraph[2] = BarColor.Yellow;
+bargraph[3] = BarColor.Off;
+bargraph[4] = BarColor.Red;
 
 Thread.Sleep(2000);
 bargraph.Clear();
@@ -54,12 +54,12 @@ for (int i = 23; i >= 0; i--)
 Thread.Sleep(2000);
 bargraph.Clear();
 
-bargraph[0] = BarColor.RED;
-bargraph[6] = BarColor.GREEN;
-bargraph[11] = BarColor.YELLOW;
-bargraph[12] = BarColor.YELLOW;
-bargraph[18] = BarColor.GREEN;
-bargraph[23] = BarColor.RED;
+bargraph[0] = BarColor.Red;
+bargraph[6] = BarColor.Green;
+bargraph[11] = BarColor.Yellow;
+bargraph[12] = BarColor.Yellow;
+bargraph[18] = BarColor.Green;
+bargraph[23] = BarColor.Red;
 
 Thread.Sleep(2000);
 bargraph.Clear();

--- a/src/devices/Display/samples/Program.BiColorBargraph.cs
+++ b/src/devices/Display/samples/Program.BiColorBargraph.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Device.I2c;
+using System.Threading;
+using Iot.Device.Display;
+
+// Initialize display (busId = 1 for Raspberry Pi 2+)
+using BiColorBarGraph bargraph = new(I2cDevice.Create(new I2cConnectionSettings(busId: 1, Ht16k33.DefaultI2cAddress)))
+    {
+        // Set max brightness
+        Brightness = Ht16k33.MaxBrightness,
+        BufferingEnabled = true
+    };
+
+bargraph.Clear();
+
+bargraph[0] = BarColor.RED;
+bargraph[1] = BarColor.GREEN;
+bargraph[2] = BarColor.YELLOW;
+bargraph[3] = BarColor.OFF;
+bargraph[4] = BarColor.RED;
+
+Thread.Sleep(2000);
+bargraph.Clear();
+
+for (int i = 0; i < 24; i++)
+{
+    if (i % 2 is 1)
+    {
+        continue;
+    }
+
+    int num = i % 4;
+    BarColor color = (BarColor)(i % 3 + 1);
+    bargraph[i] = color;
+    Thread.Sleep(250);
+}
+
+for (int i = 23; i >= 0; i--)
+{
+    if (i % 2 is 0)
+    {
+        continue;
+    }
+
+    int num = i % 4;
+    BarColor color = (BarColor)(i % 3 + 1);
+    bargraph[i] = color;
+    Thread.Sleep(250);
+}
+
+Thread.Sleep(2000);
+bargraph.Clear();
+
+bargraph[0] = BarColor.RED;
+bargraph[6] = BarColor.GREEN;
+bargraph[11] = BarColor.YELLOW;
+bargraph[12] = BarColor.YELLOW;
+bargraph[18] = BarColor.GREEN;
+bargraph[23] = BarColor.RED;
+
+Thread.Sleep(2000);
+bargraph.Clear();
+
+byte[] customBuffer =
+{
+    0, 255, 0, 0, 255, 255, 255
+};
+
+bargraph.Write(customBuffer);
+
+Thread.Sleep(10000);
+bargraph.Clear();

--- a/src/devices/Display/samples/Program.BiColorBargraph.cs
+++ b/src/devices/Display/samples/Program.BiColorBargraph.cs
@@ -22,7 +22,7 @@ bargraph[2] = BarColor.Yellow;
 bargraph[3] = BarColor.Off;
 bargraph[4] = BarColor.Red;
 
-Thread.Sleep(2000);
+Thread.Sleep(1000);
 bargraph.Clear();
 
 for (int i = 0; i < 24; i++)
@@ -35,7 +35,7 @@ for (int i = 0; i < 24; i++)
     int num = i % 4;
     BarColor color = (BarColor)(i % 3 + 1);
     bargraph[i] = color;
-    Thread.Sleep(250);
+    Thread.Sleep(100);
 }
 
 for (int i = 23; i >= 0; i--)
@@ -48,10 +48,10 @@ for (int i = 23; i >= 0; i--)
     int num = i % 4;
     BarColor color = (BarColor)(i % 3 + 1);
     bargraph[i] = color;
-    Thread.Sleep(250);
+    Thread.Sleep(100);
 }
 
-Thread.Sleep(2000);
+Thread.Sleep(1000);
 bargraph.Clear();
 
 bargraph[0] = BarColor.Red;
@@ -61,7 +61,7 @@ bargraph[12] = BarColor.Yellow;
 bargraph[18] = BarColor.Green;
 bargraph[23] = BarColor.Red;
 
-Thread.Sleep(2000);
+Thread.Sleep(1000);
 bargraph.Clear();
 
 byte[] customBuffer =
@@ -71,5 +71,15 @@ byte[] customBuffer =
 
 bargraph.Write(customBuffer);
 
-Thread.Sleep(10000);
+Thread.Sleep(1000);
+bargraph.Clear();
+
+bargraph.Fill(BarColor.Red);
+Thread.Sleep(1000);
+bargraph.Clear();
+bargraph.Fill(BarColor.Green);
+Thread.Sleep(1000);
+bargraph.Clear();
+bargraph.Fill(BarColor.Yellow);
+Thread.Sleep(1000);
 bargraph.Clear();

--- a/src/devices/Ht16k33/README.md
+++ b/src/devices/Ht16k33/README.md
@@ -1,0 +1,5 @@
+# Ht16k33
+
+The [Ht16k33](https://cdn-shop.adafruit.com/datasheets/ht16K33v110.pdf)  is a memory mapping and multi-function LED controller driver. It is used as a [backpack driver for several Adafruit products](https://www.adafruit.com/?q=Ht16k33).
+
+See the [Display](../Display/) folder for implementations of various products that use the Ht16k33.


### PR DESCRIPTION
This PR adds a binding for the [Adafruit 24-bar bicolor bargraph](https://www.adafruit.com/product/1721). It uses the same HT16K33 chip as is used in the [`Display`](https://github.com/dotnet/iot/tree/main/src/devices/Display) folder.

![giphy](https://i.giphy.com/media/2lMqhnkIBsPMGpOJIx/giphy-downsized.gif)

I've also written a binding for [8x8 Matrices](https://www.adafruit.com/product/2042), which I'll add in another PR. This and bicolor bargraph are two additional bindings implemented at https://github.com/adafruit/Adafruit_CircuitPython_HT16K33 for this same chip.

I created a separate folder for HT16K33 in this PR. I had previously looked for it and not found it due to the `Display` folder naming, which I consider poorly chosen. We could rename the `Display` if that's decided to be a good thing.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1915)