### PR TITLE
Update Telemetry name for BNO055

### DIFF
--- a/src/devices/Bno055/Bno055Sensor.cs
+++ b/src/devices/Bno055/Bno055Sensor.cs
@@ -215,7 +215,7 @@ namespace Iot.Device.Bno055
         /// Get the latest error
         /// </summary>
         /// <returns>Returns the latest error</returns>
-        [Telemetry("Status")]
+        [Telemetry("Error")]
         public Error GetError() => (Error)ReadByte(Registers.SYS_ERR);
 
         /// <summary>


### PR DESCRIPTION
Error was accidentally called Status leading to duplicate telemetry name