### PR TITLE
fix call to GetIOException (issue 1928)

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/LibgpiodDriverEventHandler.cs
@@ -38,7 +38,7 @@ internal sealed class LibGpiodDriverEventHandler : IDisposable
 
         if (eventSuccess < 0)
         {
-            throw ExceptionHelper.GetIOException(ExceptionResource.RequestEventError, _pinNumber, Marshal.GetLastWin32Error());
+            throw ExceptionHelper.GetIOException(ExceptionResource.RequestEventError, Marshal.GetLastWin32Error(), _pinNumber);
         }
     }
 


### PR DESCRIPTION
Fixes #1928
As described in the issue, in ```LibGpiodDriverEventHandler.SubscribeForEvent``` the last two arguments to ```GetIOException``` were reversed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1932)