### PR TITLE
Made I2cDevice/SpiDevice ReadByte/WriteByte methods virtual

### DIFF
--- a/src/System.Device.Gpio/System/Device/I2c/Devices/UnixI2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/Devices/UnixI2cDevice.cs
@@ -18,25 +18,9 @@ internal class UnixI2cDevice : I2cDevice
 
     public override I2cConnectionSettings ConnectionSettings => new I2cConnectionSettings(_bus.BusId, _deviceAddress);
 
-    public override unsafe byte ReadByte()
-    {
-        Span<byte> toRead = stackalloc byte[1];
-        Read(toRead);
-        return toRead[0];
-    }
-
     public override unsafe void Read(Span<byte> buffer)
     {
         _bus.Read(_deviceAddress, buffer);
-    }
-
-    public override unsafe void WriteByte(byte value)
-    {
-        Span<byte> toWrite = stackalloc byte[1]
-        {
-            value
-        };
-        Write(toWrite);
     }
 
     public override unsafe void Write(ReadOnlySpan<byte> buffer)

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
@@ -37,9 +37,10 @@ public abstract partial class I2cDevice : IDisposable
     /// <returns>A byte read from the I2C device.</returns>
     public virtual unsafe byte ReadByte()
     {
-        Span<byte> toRead = stackalloc byte[1];
+        byte value = 0;
+        Span<byte> toRead = new Span<byte>(&value, 1);
         Read(toRead);
-        return toRead[0];
+        return value;
     }
 
     /// <summary>
@@ -57,10 +58,7 @@ public abstract partial class I2cDevice : IDisposable
     /// <param name="value">The byte to be written to the I2C device.</param>
     public virtual unsafe void WriteByte(byte value)
     {
-        Span<byte> toWrite = stackalloc byte[1]
-        {
-            value
-        };
+        ReadOnlySpan<byte> toWrite = new ReadOnlySpan<byte>(&value, 1);
         Write(toWrite);
     }
 

--- a/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cDevice.cs
@@ -35,7 +35,12 @@ public abstract partial class I2cDevice : IDisposable
     /// Reads a byte from the I2C device.
     /// </summary>
     /// <returns>A byte read from the I2C device.</returns>
-    public abstract byte ReadByte();
+    public virtual unsafe byte ReadByte()
+    {
+        Span<byte> toRead = stackalloc byte[1];
+        Read(toRead);
+        return toRead[0];
+    }
 
     /// <summary>
     /// Reads data from the I2C device.
@@ -50,7 +55,14 @@ public abstract partial class I2cDevice : IDisposable
     /// Writes a byte to the I2C device.
     /// </summary>
     /// <param name="value">The byte to be written to the I2C device.</param>
-    public abstract void WriteByte(byte value);
+    public virtual unsafe void WriteByte(byte value)
+    {
+        Span<byte> toWrite = stackalloc byte[1]
+        {
+            value
+        };
+        Write(toWrite);
+    }
 
     /// <summary>
     /// Writes data to the I2C device.

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
@@ -37,9 +37,10 @@ public abstract partial class SpiDevice : IDisposable
     /// <returns>A byte read from the SPI device.</returns>
     public virtual unsafe byte ReadByte()
     {
-        Span<byte> toRead = stackalloc byte[1];
+        byte value = 0;
+        Span<byte> toRead = new Span<byte>(&value, 1);
         Read(toRead);
-        return toRead[0];
+        return value;
     }
 
     /// <summary>
@@ -57,10 +58,7 @@ public abstract partial class SpiDevice : IDisposable
     /// <param name="value">The byte to be written to the SPI device.</param>
     public virtual unsafe void WriteByte(byte value)
     {
-        Span<byte> toWrite = stackalloc byte[1]
-        {
-            value
-        };
+        ReadOnlySpan<byte> toWrite = new ReadOnlySpan<byte>(&value, 1);
         Write(toWrite);
     }
 

--- a/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
+++ b/src/System.Device.Gpio/System/Device/Spi/SpiDevice.cs
@@ -35,7 +35,12 @@ public abstract partial class SpiDevice : IDisposable
     /// Reads a byte from the SPI device.
     /// </summary>
     /// <returns>A byte read from the SPI device.</returns>
-    public abstract byte ReadByte();
+    public virtual unsafe byte ReadByte()
+    {
+        Span<byte> toRead = stackalloc byte[1];
+        Read(toRead);
+        return toRead[0];
+    }
 
     /// <summary>
     /// Reads data from the SPI device.
@@ -50,7 +55,14 @@ public abstract partial class SpiDevice : IDisposable
     /// Writes a byte to the SPI device.
     /// </summary>
     /// <param name="value">The byte to be written to the SPI device.</param>
-    public abstract void WriteByte(byte value);
+    public virtual unsafe void WriteByte(byte value)
+    {
+        Span<byte> toWrite = stackalloc byte[1]
+        {
+            value
+        };
+        Write(toWrite);
+    }
 
     /// <summary>
     /// Writes data to the SPI device.

--- a/src/devices/Arduino/ArduinoSpiDevice.cs
+++ b/src/devices/Arduino/ArduinoSpiDevice.cs
@@ -25,27 +25,11 @@ namespace Iot.Device.Arduino
         }
 
         public override SpiConnectionSettings ConnectionSettings { get; }
-        public override byte ReadByte()
-        {
-            Span<byte> dummy = stackalloc byte[1];
-            Read(dummy);
-            return dummy[0];
-        }
 
         public override void Read(Span<byte> buffer)
         {
             ReadOnlySpan<byte> dummy = stackalloc byte[buffer.Length];
             Board.Firmata.SpiTransfer(ConnectionSettings.ChipSelectLine, dummy, buffer);
-        }
-
-        public override void WriteByte(byte value)
-        {
-            ReadOnlySpan<byte> span = stackalloc byte[1]
-            {
-                value
-            };
-
-            Write(span);
         }
 
         public override void Write(ReadOnlySpan<byte> buffer)

--- a/src/devices/Ft232H/Ft232HI2c.cs
+++ b/src/devices/Ft232H/Ft232HI2c.cs
@@ -32,27 +32,9 @@ namespace Iot.Device.Ft232H
         }
 
         /// <inheritdoc/>
-        public override byte ReadByte()
-        {
-            Span<byte> toRead = stackalloc byte[1];
-            Read(toRead);
-            return toRead[0];
-        }
-
-        /// <inheritdoc/>
         public override void Write(ReadOnlySpan<byte> buffer)
         {
             _i2cBus.Write(_deviceAddress, buffer);
-        }
-
-        /// <inheritdoc/>
-        public override void WriteByte(byte value)
-        {
-            Span<byte> toWrite = stackalloc byte[1]
-            {
-                value
-            };
-            Write(toWrite);
         }
 
         /// <inheritdoc/>

--- a/src/devices/Ft4222/Ft4222I2c.cs
+++ b/src/devices/Ft4222/Ft4222I2c.cs
@@ -35,27 +35,9 @@ namespace Iot.Device.Ft4222
         }
 
         /// <inheritdoc/>
-        public override byte ReadByte()
-        {
-            Span<byte> toRead = stackalloc byte[1];
-            Read(toRead);
-            return toRead[0];
-        }
-
-        /// <inheritdoc/>
         public override void Write(ReadOnlySpan<byte> buffer)
         {
             _i2cBus.Write(_deviceAddress, buffer);
-        }
-
-        /// <inheritdoc/>
-        public override void WriteByte(byte value)
-        {
-            Span<byte> toWrite = stackalloc byte[1]
-            {
-                value
-            };
-            Write(toWrite);
         }
 
         /// <inheritdoc/>

--- a/src/devices/Ft4222/Ft4222Spi.cs
+++ b/src/devices/Ft4222/Ft4222Spi.cs
@@ -136,14 +136,6 @@ namespace Iot.Device.Ft4222
         }
 
         /// <inheritdoc/>
-        public override byte ReadByte()
-        {
-            Span<byte> toRead = stackalloc byte[1];
-            Read(toRead);
-            return toRead[0];
-        }
-
-        /// <inheritdoc/>
         public override void TransferFullDuplex(ReadOnlySpan<byte> writeBuffer, Span<byte> readBuffer)
         {
             ushort readBytes;
@@ -166,16 +158,6 @@ namespace Iot.Device.Ft4222
             {
                 throw new IOException($"{nameof(Write)} failed to write, error: {ftStatus}");
             }
-        }
-
-        /// <inheritdoc/>
-        public override void WriteByte(byte value)
-        {
-            Span<byte> toWrite = stackalloc byte[1]
-            {
-                value
-            };
-            Write(toWrite);
         }
 
         /// <inheritdoc/>

--- a/src/devices/SoftwareSpi/SoftwareSpi.cs
+++ b/src/devices/SoftwareSpi/SoftwareSpi.cs
@@ -221,22 +221,6 @@ namespace Iot.Device.Spi
         public override void Write(ReadOnlySpan<byte> data) => TransferWriteOnly(data);
 
         /// <inheritdoc />
-        public override void WriteByte(byte data)
-        {
-            Span<byte> outData = stackalloc byte[1];
-            outData[0] = data;
-            Write(outData);
-        }
-
-        /// <inheritdoc />
-        public override byte ReadByte()
-        {
-            Span<byte> data = stackalloc byte[1];
-            Read(data);
-            return data[0];
-        }
-
-        /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
             if (_shouldDispose)


### PR DESCRIPTION
Fixes https://github.com/dotnet/iot/issues/1629

Made `WriteByte`/`ReadByte` methods virtual for `I2cDevice` and `SpiDevice` and removed the override methods from deriving classes that had same implementation as base methods.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1937)