### PR TITLE
Bump sample versions to 2.2.0 in one pass

### DIFF
--- a/samples/led-blink/led-blink.csproj
+++ b/samples/led-blink/led-blink.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="2.1.0" />
+    <PackageReference Include="System.Device.Gpio" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/led-matrix-weather/led-matrix-weather.csproj
+++ b/samples/led-matrix-weather/led-matrix-weather.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="2.1.0" />
-    <PackageReference Include="Iot.Device.Bindings" Version="2.1.0" />
+    <PackageReference Include="System.Device.Gpio" Version="2.2.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/led-more-blinking-lights/led-more-blinking-lights.csproj
+++ b/samples/led-more-blinking-lights/led-more-blinking-lights.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Device.Gpio" Version="2.2.0" />
-    <PackageReference Include="Iot.Device.Bindings" Version="2.1.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/serialport-arduino/serialport-arduino.csproj
+++ b/samples/serialport-arduino/serialport-arduino.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="2.1.0" />
-    <PackageReference Include="Iot.Device.Bindings" Version="2.1.0" />
+    <PackageReference Include="System.Device.Gpio" Version="2.2.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This replaces #1943 #1945 #1946 #1947 #1948 #1949 #1950 to do those in one pass.

cc: @pgrawehr 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1963)