### PR TITLE
Remove Windows Helix test execution

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,18 +54,6 @@ stages:
         /p:BuildPackages=true
       displayName: Build
 
-    - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 -warnaserror:0 -ci
-        eng/sendToHelix.proj
-        /t:Test
-        /p:TestOS=Windows_NT
-        /p:Configuration=$(BuildConfiguration)
-        /p:HelixBuild=$(Build.BuildNumber)
-        /bl:$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/SendToHelix.binlog
-      displayName: Run Helix Tests
-      condition: eq(variables['build.reason'], 'PullRequest')
-      env:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
     - task: PublishBuildArtifacts@1
       displayName: Publish Build logs
       condition: always()

--- a/eng/sendToHelix.proj
+++ b/eng/sendToHelix.proj
@@ -30,25 +30,6 @@
     <HelixTargetQueue Include="$(HelixTargetQueue)"/>
   </ItemGroup>
 
-  <!-- Windows-specific settings -->
-  <ItemGroup Condition="'$(TestOS)' == 'Windows_NT'">
-    <!-- Xunit project to test -->
-    <XUnitProject Include="..\src\System.Device.Gpio.Tests\System.Device.Gpio.Tests.csproj">
-      <TargetFramework>netcoreapp3.1</TargetFramework>
-      <RuntimeTargetFramework>netcoreapp2.0</RuntimeTargetFramework>
-    </XUnitProject>
-    <!-- Target queues -->
-    <HelixTargetQueue Condition="'$(HelixAccessToken)' != ''" Include="Windows.10.Arm32.IoT"/>
-    <HelixTargetQueue Condition="'$(HelixAccessToken)' == ''" Include="Windows.10.Arm32.IoT.Open"/>
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(TestOS)' == 'Windows_NT'">
-    <DotNetCliRuntime>win-arm</DotNetCliRuntime>
-    <XUnitArguments>$(XUnitArguments) -notrait "SkipOnTestRun=Windows_NT"</XUnitArguments>
-    <!-- Issue: https://github.com/dotnet/iot/issues/934 -->
-    <XUnitArguments>$(XUnitArguments) -notrait feature=pwm</XUnitArguments>
-  </PropertyGroup>
-
   <!-- Linux-specific settings -->
   <ItemGroup Condition="'$(TestOS)' == 'Unix'">
     <!-- Xunit project to test -->


### PR DESCRIPTION
Windows.10.Arm32.Iot devices are being removed from Helix, so removing their usage here (still get similar coverage from Raspbian Unix legs)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1976)