### PR TITLE
Add support for new revision of RaspberryPi Compute Module 4

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
@@ -164,7 +164,7 @@ internal class RaspberryBoardInfo
         0x20E0 => Model.RaspberryPi3APlus,
         0x20A0 or 0x2100 => Model.RaspberryPiComputeModule3,
         0x3111 or 0x3112 or 0x3114 or 0x3115 => Model.RaspberryPi4,
-        0x3140 => Model.RaspberryPiComputeModule4,
+        0x3140 or 0x3141 => Model.RaspberryPiComputeModule4,
         0x3130 => Model.RaspberryPi400,
         _ => Model.Unknown,
     };


### PR DESCRIPTION
A new board revision of Raspberry Pi Compute Module 4 is available on the market. This is revision is not yet detected by this library.

This PR adds the new revision number 0x3141 to the library.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1978)