### PR TITLE
Adding AM2320 (migration from .NET nanoFramework)

### DIFF
--- a/src/devices/Am2320/Am2320.cs
+++ b/src/devices/Am2320/Am2320.cs
@@ -43,9 +43,6 @@ namespace Iot.Device.Am2320
         /// <returns>True on success, false if reading failed.</returns>
         [Telemetry("Temperature")]
         public bool TryReadTemperature(
-#if NET5_0_OR_GREATER
-        [NotNullWhen(true)]
-#endif
                 out Temperature temperature)
         {
             temperature = default;
@@ -70,9 +67,6 @@ namespace Iot.Device.Am2320
         /// <returns>True on success, false if reading failed.</returns>
         [Telemetry("Humidity")]
         public bool TryReadHumidity(
-#if NET5_0_OR_GREATER
-            [NotNullWhen(true)]
-#endif
                     out RelativeHumidity humidity)
         {
             humidity = default;

--- a/src/devices/Am2320/Am2320.cs
+++ b/src/devices/Am2320/Am2320.cs
@@ -1,0 +1,214 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Device.I2c;
+using System.Device.Model;
+using System.Threading;
+using UnitsNet;
+
+namespace Iot.Device.Am2320
+{
+    /// <summary>
+    /// AM2320 - Temperature and Humidity sensor.
+    /// </summary>
+    [Interface("AM2320 - Temperature and Humidity sensor")]
+    public class Am2320 : IDisposable
+    {
+        private readonly I2cDevice _i2c;
+        private readonly byte[] _readBuff = new byte[8];
+
+        /// <summary>
+        /// AM3220 default I2C address.
+        /// </summary>
+        public const int DefaultI2cAddress = 0x5C;
+
+        /// <summary>
+        /// The minimum read period is 1.5 seconds. Do not read the sensor more often.
+        /// </summary>
+        public static readonly TimeSpan MinimumReadPeriod = new TimeSpan(0, 0, 0, 1, 500);
+
+        private DateTime _lastMeasurement = DateTime.UtcNow.Subtract(MinimumReadPeriod);
+
+        /// <summary>
+        /// Gets a value indicating whether last read went, <c>true</c> for success, <c>false</c> for failure.
+        /// </summary>
+        public bool IsLastReadSuccessful { get; internal set; }
+
+        /// <summary>
+        /// Gets the last read temperature.
+        /// </summary>
+        /// <remarks>
+        /// If last read was not successful, it returns <code>default(Temperature).</code>
+        /// </remarks>
+        [Telemetry]
+        public Temperature Temperature
+        {
+            get
+            {
+                if (IsOutDated())
+                {
+                    ReadData();
+                }
+
+                return IsLastReadSuccessful ? GetTemperature() : default(Temperature);
+            }
+        }
+
+        /// <summary>
+        /// Gets the last read of relative humidity in percentage.
+        /// </summary>
+        /// <remarks>
+        /// If last read was not successful, it returns <code>default(RelativeHumidity).</code>
+        /// </remarks>
+        [Telemetry]
+        public RelativeHumidity Humidity
+        {
+            get
+            {
+                if (IsOutDated())
+                {
+                    ReadData();
+                }
+
+                return IsLastReadSuccessful ? GetHumidity() : default(RelativeHumidity);
+            }
+        }
+
+        /// <summary>
+        /// Gets the device information.
+        /// </summary>
+        [Property]
+        public DeviceInformation DeviceInformation
+        {
+            get
+            {
+                Span<byte> buff = stackalloc byte[11];
+
+                // 32 bit device ID
+                // Forces the sensor to wake up and wait 10 ms according to documentation
+                _i2c.WriteByte(0x00);
+                Thread.Sleep(10);
+
+                // Sending functin code 0x03, start regster 0x00 and 4 registers
+                _i2c.Write(stackalloc byte[] { 0x03, 0x08, 0x07 });
+
+                // Wait at least 30 micro seconds
+                Thread.Sleep(1);
+                _i2c.Read(buff);
+
+                // Check if it is valid
+                if (!IsValidReadBuffer(buff, 0x07))
+                {
+                    return null!;
+                }
+
+                if (!IsCrcValid(buff))
+                {
+                    return null!;
+                }
+
+                return new DeviceInformation()
+                {
+                    Model = BinaryPrimitives.ReadUInt16BigEndian(buff.Slice(2)),
+                    Version = buff[4],
+                    DeviceId = BinaryPrimitives.ReadUInt32BigEndian(buff.Slice(5)),
+                };
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Am2320" /> class.
+        /// </summary>
+        /// <param name="i2c">The <see cref="I2cDevice"/>.</param>
+        /// <remarks>This sensor only works on Standard Mode speed.</remarks>
+        public Am2320(I2cDevice i2c)
+        {
+            _i2c = i2c ?? throw new ArgumentNullException(nameof(i2c));
+        }
+
+        private bool IsOutDated() => !(_lastMeasurement.Add(MinimumReadPeriod) > DateTime.UtcNow);
+
+        private void ReadData()
+        {
+            // Forces the sensor to wake up and wait 10 ms according to documentation
+            _i2c.WriteByte(0x00);
+            Thread.Sleep(10);
+
+            // Sending functin code 0x03, start regster 0x00 and 4 registers
+            _i2c.Write(stackalloc byte[] { 0x03, 0x00, 0x04 });
+
+            // Wait at least 30 micro seconds
+            Thread.Sleep(1);
+            _i2c.Read(_readBuff);
+            _lastMeasurement = DateTime.UtcNow;
+
+            // Check if sucessfull read
+            if (!IsValidReadBuffer(_readBuff, 0x04))
+            {
+                IsLastReadSuccessful = false;
+                return;
+            }
+
+            if (!IsCrcValid(_readBuff))
+            {
+                IsLastReadSuccessful = false;
+                return;
+            }
+
+            IsLastReadSuccessful = true;
+        }
+
+        private bool IsValidReadBuffer(Span<byte> buff, byte expected) => (buff[0] == 0x03) && (buff[1] == expected);
+
+        private bool IsCrcValid(Span<byte> buff)
+        {
+            var crc = Crc16(buff.Slice(0, buff.Length - 2));
+            return (crc >> 8 == buff[buff.Length - 1]) && ((crc & 0xFF) == buff[buff.Length - 2]);
+        }
+
+        private Temperature GetTemperature()
+        {
+            short temp = BinaryPrimitives.ReadInt16BigEndian((new Span<byte>(_readBuff)).Slice(4));
+            return Temperature.FromDegreesCelsius(temp / 10.0);
+        }
+
+        private RelativeHumidity GetHumidity()
+        {
+            short hum = BinaryPrimitives.ReadInt16BigEndian((new Span<byte>(_readBuff)).Slice(2));
+            return RelativeHumidity.FromPercent(hum / 10.0);
+        }
+
+        private ushort Crc16(Span<byte> ptr)
+        {
+            ushort crc = 0xFFFF;
+            byte i;
+            byte inc = 0;
+            while (inc < ptr.Length)
+            {
+                crc ^= ptr[inc++];
+                for (i = 0; i < 8; i++)
+                {
+                    if ((crc & 0x01) == 0x01)
+                    {
+                        crc >>= 1;
+                        crc ^= 0xA001;
+                    }
+                    else
+                    {
+                        crc >>= 1;
+                    }
+                }
+            }
+
+            return crc;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _i2c?.Dispose();
+        }
+    }
+}

--- a/src/devices/Am2320/Am2320.csproj
+++ b/src/devices/Am2320/Am2320.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="*.cs" />
+    <None Include="README.md" />
+  </ItemGroup>
+</Project>

--- a/src/devices/Am2320/Am2320.sln
+++ b/src/devices/Am2320/Am2320.sln
@@ -1,0 +1,53 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{77DA90A9-38BE-454A-B91B-48B7C720D34C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Am2320.sample", "samples\Am2320.sample.csproj", "{7B971FB2-39B5-43D0-8779-3867AE9D02E6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Am2320", "Am2320.csproj", "{92F7D43D-F70C-4606-9A14-5F28F97EC703}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Debug|x64.Build.0 = Debug|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Debug|x86.Build.0 = Debug|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Release|x64.ActiveCfg = Release|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Release|x64.Build.0 = Release|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Release|x86.ActiveCfg = Release|Any CPU
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6}.Release|x86.Build.0 = Release|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Debug|x64.Build.0 = Debug|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Debug|x86.Build.0 = Debug|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Release|x64.ActiveCfg = Release|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Release|x64.Build.0 = Release|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Release|x86.ActiveCfg = Release|Any CPU
+		{92F7D43D-F70C-4606-9A14-5F28F97EC703}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{7B971FB2-39B5-43D0-8779-3867AE9D02E6} = {77DA90A9-38BE-454A-B91B-48B7C720D34C}
+	EndGlobalSection
+EndGlobal

--- a/src/devices/Am2320/DeviceInformation.cs
+++ b/src/devices/Am2320/DeviceInformation.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Am2320
+{
+    /// <summary>
+    /// Device information.
+    /// </summary>
+    public class DeviceInformation
+    {
+        /// <summary>
+        /// Gets or sets the model.
+        /// </summary>
+        public ushort Model { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version.
+        /// </summary>
+        public byte Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the device ID.
+        /// </summary>
+        public uint DeviceId { get; set; }
+    }
+}

--- a/src/devices/Am2320/README.md
+++ b/src/devices/Am2320/README.md
@@ -1,0 +1,62 @@
+﻿# AM2320 - Temperature and Humidity sensor
+
+AM2320 is a temperature and humidity sensor, sensible to 0.1 degree and 0.1 relative humidity.
+
+## Documentation
+
+- [AM2320](https://cdn-shop.adafruit.com/product-files/3721/AM2320.pdf)
+
+## Usage
+
+Here is an example how to use the AM2320:
+
+```csharp
+using System.Device.I2c;
+using System.Diagnostics;
+using System.Threading;
+using Iot.Device.Am2320;
+
+Debug.WriteLine("Hello from AM2320!");
+
+// Important: make sure the bus speed is in standar mode and not in fast more.
+using Am2320 am2330 = new(I2cDevice.Create(new I2cConnectionSettings(1, Am2320.DefaultI2cAddress)));
+
+while (true)
+{
+    var temp = am2330.Temperature;
+    var hum = am2330.Humidity;
+    if (am2330.IsLastReadSuccessful)
+    {
+        Debug.WriteLine($"Temp = {temp.DegreesCelsius} C, Hum = {hum.Percent} %");
+    }
+    else
+    {
+        Debug.WriteLine("Not sucessful reading.");
+    }
+
+    Thread.Sleep(Am2320.MinimumReadPeriod);
+}
+```
+
+### Device Information
+
+You can read the Device Information.
+
+> Note: on some copies, the device information only returns 0.
+
+```csharp
+// On some copies, the device information contains only 0
+var deviceInfo = am2330.DeviceInformation;
+if (deviceInfo != null)
+{
+    Debug.WriteLine($"Model: {deviceInfo.Model}");
+    Debug.WriteLine($"Version: {deviceInfo.Version}");
+    Debug.WriteLine($"Device ID: {deviceInfo.DeviceId}");
+}
+```
+
+## Limitations
+
+Only the I2C implementation is available, not the 1 wire one.
+
+The user registers and the status register are not implemented. The status register is just a register the user can store data. It is not currently used for any usage according to the documentation.

--- a/src/devices/Am2320/README.md
+++ b/src/devices/Am2320/README.md
@@ -23,15 +23,22 @@ using Am2320 am2330 = new(I2cDevice.Create(new I2cConnectionSettings(1, Am2320.D
 
 while (true)
 {
-    var temp = am2330.Temperature;
-    var hum = am2330.Humidity;
-    if (am2330.IsLastReadSuccessful)
+    if (am2330.TryReadTemperature(out Temperature temp))
     {
-        Debug.WriteLine($"Temp = {temp.DegreesCelsius} C, Hum = {hum.Percent} %");
+        Debug.Write($"Temp = {temp.DegreesCelsius} C. ");
     }
     else
     {
-        Debug.WriteLine("Not sucessful reading.");
+        Debug.WriteLine("Can't read temperature. ");
+    }
+
+    if (am2330.TryReadHumidity(out RelativeHumidity hum))
+    {
+        Debug.WriteLine($"Hum = {hum.Percent} %.");
+    }
+    else
+    {
+        Debug.WriteLine("Can't read humidity.");
     }
 
     Thread.Sleep(Am2320.MinimumReadPeriod);

--- a/src/devices/Am2320/category.txt
+++ b/src/devices/Am2320/category.txt
@@ -1,0 +1,2 @@
+﻿thermometer
+hygrometer

--- a/src/devices/Am2320/samples/Am2320.sample.csproj
+++ b/src/devices/Am2320/samples/Am2320.sample.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultSampleTfms)</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Am2320.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/devices/Am2320/samples/Program.cs
+++ b/src/devices/Am2320/samples/Program.cs
@@ -23,15 +23,22 @@ if (deviceInfo != null)
 
 while (true)
 {
-    am2330.TryReadTemperature(out Temperature temp);
-    am2330.TryReadHumidity(out RelativeHumidity hum);
-    if (am2330.IsLastReadSuccessful)
+    if (am2330.TryReadTemperature(out Temperature temp))
     {
-        Debug.WriteLine($"Temp = {temp.DegreesCelsius} C, Hum = {hum.Percent} %");
+        Debug.Write($"Temp = {temp.DegreesCelsius} C. ");
     }
     else
     {
-        Debug.WriteLine("Not sucessful reading.");
+        Debug.WriteLine("Can't read temperature. ");
+    }
+
+    if (am2330.TryReadHumidity(out RelativeHumidity hum))
+    {
+        Debug.WriteLine($"Hum = {hum.Percent} %.");
+    }
+    else
+    {
+        Debug.WriteLine("Can't read humidity.");
     }
 
     Thread.Sleep(Am2320.MinimumReadPeriod);

--- a/src/devices/Am2320/samples/Program.cs
+++ b/src/devices/Am2320/samples/Program.cs
@@ -5,6 +5,7 @@ using System.Device.I2c;
 using System.Diagnostics;
 using System.Threading;
 using Iot.Device.Am2320;
+using UnitsNet;
 
 Debug.WriteLine("Hello from AM2320!");
 
@@ -12,7 +13,7 @@ Debug.WriteLine("Hello from AM2320!");
 using Am2320 am2330 = new(I2cDevice.Create(new I2cConnectionSettings(1, Am2320.DefaultI2cAddress)));
 
 // On some copies, the device information contains only 0
-var deviceInfo = am2330.DeviceInformation;
+am2330.TryGetDeviceInformation(out DeviceInformation? deviceInfo);
 if (deviceInfo != null)
 {
     Debug.WriteLine($"Model: {deviceInfo.Model}");
@@ -22,8 +23,8 @@ if (deviceInfo != null)
 
 while (true)
 {
-    var temp = am2330.Temperature;
-    var hum = am2330.Humidity;
+    am2330.TryReadTemperature(out Temperature temp);
+    am2330.TryReadHumidity(out RelativeHumidity hum);
     if (am2330.IsLastReadSuccessful)
     {
         Debug.WriteLine($"Temp = {temp.DegreesCelsius} C, Hum = {hum.Percent} %");

--- a/src/devices/Am2320/samples/Program.cs
+++ b/src/devices/Am2320/samples/Program.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Device.I2c;
+using System.Diagnostics;
+using System.Threading;
+using Iot.Device.Am2320;
+
+Debug.WriteLine("Hello from AM2320!");
+
+// Important: make sure the bus speed is in standar mode and not in fast more.
+using Am2320 am2330 = new(I2cDevice.Create(new I2cConnectionSettings(1, Am2320.DefaultI2cAddress)));
+
+// On some copies, the device information contains only 0
+var deviceInfo = am2330.DeviceInformation;
+if (deviceInfo != null)
+{
+    Debug.WriteLine($"Model: {deviceInfo.Model}");
+    Debug.WriteLine($"Version: {deviceInfo.Version}");
+    Debug.WriteLine($"Device ID: {deviceInfo.DeviceId}");
+}
+
+while (true)
+{
+    var temp = am2330.Temperature;
+    var hum = am2330.Humidity;
+    if (am2330.IsLastReadSuccessful)
+    {
+        Debug.WriteLine($"Temp = {temp.DegreesCelsius} C, Hum = {hum.Percent} %");
+    }
+    else
+    {
+        Debug.WriteLine("Not sucessful reading.");
+    }
+
+    Thread.Sleep(Am2320.MinimumReadPeriod);
+}


### PR DESCRIPTION
This PR is about adding AM2320

- migration from .NET nanoFramework (replacing SpanByte by Span<byte), new by stackalloc)
- adjusting the sample

Origin: https://github.com/nanoframework/nanoFramework.IoT.Device/tree/develop/devices/Am2320


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/1998)