### PR TITLE
FT232H: SetDataBitsLowByte requires value before direction (#1996)

### DIFF
--- a/src/devices/Ft232H/Ft232HDevice.cs
+++ b/src/devices/Ft232H/Ft232HDevice.cs
@@ -489,8 +489,8 @@ namespace Iot.Device.Ft232H
             toSend[idx++] = (byte)FtOpcode.SetDataBitsLowByte;
             GpioLowDir = (byte)(I2cDirSDAoutSCLout | (GpioLowDir & 0xF8));
             GpioLowData = (byte)(I2cDataSDAhiSCLlo | (GpioLowData & 0xF8));
-            toSend[idx++] = GpioLowDir;
             toSend[idx++] = GpioLowData;
+            toSend[idx++] = GpioLowDir;
             // And ask it right away
             toSend[idx++] = (byte)FtOpcode.SendImmediate;
             Write(toSend);


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->
`Fixes #1996`

Reading more than 1 byte using FT232H I2C bus resulted in an unusable bus because the command used to set the GPIOs direction and values had the parameters appended in the wrong order. This PR fix the order. Tested in the same condition as described in #1996.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2001)