### PR TITLE
Reverse byte order of ATQA calculated by ListenToIsoCard14443TypeA

### DIFF
--- a/src/devices/Mfrc522/Mfrc522.cs
+++ b/src/devices/Mfrc522/Mfrc522.cs
@@ -264,7 +264,7 @@ namespace Iot.Device.Mfrc522
             }
             while (true);
 
-            card.Atqa = BinaryPrimitives.ReadUInt16BigEndian(atqa);
+            card.Atqa = BinaryPrimitives.ReadUInt16LittleEndian(atqa);
             var status = Select(out byte[]? nfcId, out byte sak);
             if (status != Status.Ok)
             {


### PR DESCRIPTION
Fixes #2004 

The two bytes of the ATQA need to be treated as a little-endian integer.

<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2005)