### PR TITLE
Update UnitsNet to V5.0

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-runtime -->
     <!--  End: Package sources from dotnet-runtime -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-runtime -->
     <!--  End: Package sources from dotnet-runtime -->

--- a/eng/Versions.external.props
+++ b/eng/Versions.external.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- These references to third-party libraries are included in all projects except System.Device.Gpio and the build wrapper project -->
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'System.Device.Gpio' And '$(MSBuildProjectName)' != 'build'">
-    <PackageReference Include="UnitsNet" Version="5.0.0-rc010" />
+    <PackageReference Include="UnitsNet" Version="5.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
   </ItemGroup>
 

--- a/eng/Versions.external.props
+++ b/eng/Versions.external.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- These references to third-party libraries are included in all projects except System.Device.Gpio and the build wrapper project -->
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'System.Device.Gpio' And '$(MSBuildProjectName)' != 'build'">
-    <PackageReference Include="UnitsNet" Version="4.77.0" />
+    <PackageReference Include="UnitsNet" Version="5.0.0-rc010" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
   </ItemGroup>
 

--- a/eng/Versions.external.props
+++ b/eng/Versions.external.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- These references to third-party libraries are included in all projects except System.Device.Gpio and the build wrapper project -->
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'System.Device.Gpio' And '$(MSBuildProjectName)' != 'build'">
-    <PackageReference Include="UnitsNet" Version="5.0.0" />
+    <PackageReference Include="UnitsNet" Version="5.1.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
   </ItemGroup>
 

--- a/src/devices/Bmxx80/samples/Bmp280/Bmp280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bmp280/Bmp280.sample.cs
@@ -55,7 +55,7 @@ while (true)
     Console.WriteLine($"Pressure: {readResult.Pressure?.Hectopascals:0.##}hPa");
 
     // This time use altitude calculation
-    if (readResult.Temperature != null && readResult.Pressure != null)
+    if (readResult.Temperature.HasValue && readResult.Pressure.HasValue)
     {
         altValue = WeatherHelper.CalculateAltitude((Pressure)readResult.Pressure, defaultSeaLevelPressure, (Temperature)readResult.Temperature);
         Console.WriteLine($"Calculated Altitude: {altValue.Meters:0.##}m");
@@ -65,7 +65,7 @@ while (true)
     // Change the stationHeight value above to get a correct reading, but do not be tempted to insert
     // the value obtained from the formula above. Since that estimates the altitude based on pressure,
     // using that altitude to correct the pressure won't work.
-    if (readResult.Temperature != null && readResult.Pressure != null)
+    if (readResult.Temperature.HasValue && readResult.Pressure.HasValue)
     {
         var correctedPressure = WeatherHelper.CalculateBarometricPressure((Pressure)readResult.Pressure, (Temperature)readResult.Temperature, stationHeight);
         Console.WriteLine($"Pressure corrected for altitude {stationHeight:F0}m (with average humidity): {correctedPressure.Hectopascals:0.##} hPa");

--- a/src/devices/Ft232H/samples/Program.cs
+++ b/src/devices/Ft232H/samples/Program.cs
@@ -127,7 +127,7 @@ void TestI2c(Ft232HDevice ft232h)
         Console.WriteLine($"Pressure: {readResult.Pressure?.Hectopascals:0.##}hPa");
 
         // This time use altitude calculation
-        if (readResult.Temperature != null && readResult.Pressure != null)
+        if (readResult.Temperature.HasValue && readResult.Pressure.HasValue)
         {
             altValue = WeatherHelper.CalculateAltitude((Pressure)readResult.Pressure, defaultSeaLevelPressure, (Temperature)readResult.Temperature);
             Console.WriteLine($"Calculated Altitude: {altValue.Meters:0.##}m");
@@ -137,7 +137,7 @@ void TestI2c(Ft232HDevice ft232h)
         // Change the stationHeight value above to get a correct reading, but do not be tempted to insert
         // the value obtained from the formula above. Since that estimates the altitude based on pressure,
         // using that altitude to correct the pressure won't work.
-        if (readResult.Temperature != null && readResult.Pressure != null)
+        if (readResult.Temperature.HasValue && readResult.Pressure.HasValue)
         {
             var correctedPressure = WeatherHelper.CalculateBarometricPressure((Pressure)readResult.Pressure, (Temperature)readResult.Temperature, stationHeight);
             Console.WriteLine($"Pressure corrected for altitude {stationHeight:F0}m (with average humidity): {correctedPressure.Hectopascals:0.##} hPa");

--- a/src/devices/HardwareMonitor/OpenHardwareMonitor.cs
+++ b/src/devices/HardwareMonitor/OpenHardwareMonitor.cs
@@ -422,22 +422,14 @@ namespace Iot.Device.HardwareMonitor
                 {
                     if (unitThatWasUsed == null)
                     {
-#if !NET5_0_OR_GREATER
                         unitThatWasUsed = singleValue!.Unit;
-#else
-                        unitThatWasUsed = singleValue.Unit;
-#endif
                     }
-#if !NET5_0_OR_GREATER
                     else if (!unitThatWasUsed.Equals(singleValue!.Unit))
-#else
-                    else if (!unitThatWasUsed.Equals(singleValue.Unit))
-#endif
                     {
                         throw new NotSupportedException($"The different sensors for {hardware.Name} deliver values in different units");
                     }
 
-                    value += singleValue.Value;
+                    value += (double)singleValue!.Value;
                     count++;
                 }
             }
@@ -601,7 +593,7 @@ namespace Iot.Device.HardwareMonitor
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="monitoringInterval"/> is less than 0.</exception>
         public void EnableDerivedSensors(Area cpuDieSize = default, TimeSpan monitoringInterval = default)
         {
-            if (cpuDieSize == default)
+            if (cpuDieSize.Equals(Area.Zero, 0, ComparisonType.Absolute))
             {
                 // Values for some recent intel chips (coffee lake)
                 if (LogicalProcessors <= 4)
@@ -643,7 +635,7 @@ namespace Iot.Device.HardwareMonitor
                     {
                         double previousEnergy = newSensor.Value;
                         // Value is in watts, so increment is in watts-hours, which is an unit we can later convert from
-                        double increment = value.Value * timeSinceUpdate.TotalHours;
+                        double increment = (double)value.Value * timeSinceUpdate.TotalHours;
                         double newEnergy = previousEnergy + increment;
                         newSensor.Value = newEnergy;
                     });

--- a/src/devices/HardwareMonitor/samples/Program.cs
+++ b/src/devices/HardwareMonitor/samples/Program.cs
@@ -38,7 +38,7 @@ while (!Console.KeyAvailable)
             Console.Write($"{sensor.Name}: Path {sensor.Identifier}, Parent {sensor.Parent} ");
             if (sensor.TryGetValue(out IQuantity? quantity))
             {
-                Console.WriteLine(string.Format(CultureInfo.CurrentCulture, "{0}: {1:g}", quantity!.Type, quantity));
+                Console.WriteLine(string.Format(CultureInfo.CurrentCulture, "{0}: {1:g}", quantity.QuantityInfo.Name, quantity));
             }
             else
             {

--- a/src/devices/Nmea0183/tests/SentenceTests.cs
+++ b/src/devices/Nmea0183/tests/SentenceTests.cs
@@ -231,7 +231,7 @@ namespace Iot.Device.Nmea0183.Tests
             CrossTrackError xte = (CrossTrackError)decoded!.TryGetTypedValue(ref _lastPacketTime)!;
 
             Assert.True(xte.Valid);
-            Assert.Equal(Length.Zero, xte.Distance);
+            Assert.True(xte.Distance.Equals(Length.Zero, 0, ComparisonType.Absolute));
         }
 
         [Fact]

--- a/src/devices/SensorHub/SensorHub.cs
+++ b/src/devices/SensorHub/SensorHub.cs
@@ -49,7 +49,7 @@ namespace Iot.Device.SensorHub
         /// <exception cref="IOException">Thrown when ext. temperature sensor not found.</exception>
         public bool TryReadOffBoardTemperature(out Temperature temperature)
         {
-            temperature = Temperature.MaxValue;
+            temperature = default;
 
             var status = ReadRegister(Register.STATUS_REG);
             if (IsStatusRegError(status, StatusFunctionError.TEMP_NOT_FOUND))
@@ -73,7 +73,7 @@ namespace Iot.Device.SensorHub
         /// <returns><c>True</c> on success, <c>False</c> otherwise</returns>
         public bool TryReadBarometerTemperature(out Temperature temperature)
         {
-            temperature = Temperature.MaxValue;
+            temperature = default;
             if (ReadRegister(Register.BMP280_STATUS).Equals(NO_ERROR))
             {
                 temperature = Temperature.FromDegreesCelsius(ReadRegister(Register.BMP280_TEMP_REG));
@@ -91,7 +91,7 @@ namespace Iot.Device.SensorHub
         /// <returns><c>True</c> on success, <c>False</c> otherwise</returns>
         public bool TryReadBarometerPressure(out Pressure pressure)
         {
-            pressure = Pressure.MaxValue;
+            pressure = default;
             if (ReadRegister(Register.BMP280_STATUS).Equals(NO_ERROR))
             {
                 Span<byte> bytes = stackalloc byte[4]
@@ -117,7 +117,7 @@ namespace Iot.Device.SensorHub
         /// <returns><c>True</c> on success, <c>False</c> otherwise</returns>
         public bool TryReadIlluminance(out Illuminance illuminance)
         {
-            illuminance = Illuminance.MaxValue;
+            illuminance = default;
 
             var status = ReadRegister(Register.STATUS_REG);
             if (IsStatusRegError(status, StatusFunctionError.LIGHT_BRIGHTNESS_NOT_FOUND)
@@ -144,7 +144,7 @@ namespace Iot.Device.SensorHub
         /// <returns><c>True</c> on success, <c>False</c> otherwise</returns>
         public bool TryReadRelativeHumidity(out RelativeHumidity humidity)
         {
-            humidity = RelativeHumidity.MaxValue;
+            humidity = default;
             if (ReadRegister(Register.ON_BOARD_SENSOR_ERROR).Equals(NO_ERROR))
             {
                 humidity = RelativeHumidity.FromPercent(ReadRegister(Register.ON_BOARD_HUMIDITY_REG));
@@ -162,7 +162,7 @@ namespace Iot.Device.SensorHub
         /// <returns><c>True</c> on success, <c>False</c> otherwise</returns>
         public bool TryReadOnBoardTemperature(out Temperature temperature)
         {
-            temperature = Temperature.MaxValue;
+            temperature = default;
             if (ReadRegister(Register.ON_BOARD_SENSOR_ERROR).Equals(NO_ERROR))
             {
                 temperature = Temperature.FromDegreesCelsius(ReadRegister(Register.ON_BOARD_TEMP_REG));

--- a/src/devices/StUsb4500/Helper/UsbPdObjectHelper.cs
+++ b/src/devices/StUsb4500/Helper/UsbPdObjectHelper.cs
@@ -72,5 +72,18 @@ namespace Iot.Device.Usb
                 throw new ArgumentOutOfRangeException(propertyName);
             }
         }
+
+        /// <summary>Checks it an argument is in range.</summary>
+        /// <param name="value">The value.</param>
+        /// <param name="maxValue">The maximum value.</param>
+        /// <param name="minValue">The minimum value.</param>
+        /// <param name="propertyName">Name of the property.</param>
+        public static void CheckArgumentInRange(this decimal value, decimal maxValue, decimal minValue = 0, [CallerMemberName] string? propertyName = null)
+        {
+            if (value < minValue || value > maxValue)
+            {
+                throw new ArgumentOutOfRangeException(propertyName);
+            }
+        }
     }
 }

--- a/src/devices/StUsb4500/Objects/BatteryObject.cs
+++ b/src/devices/StUsb4500/Objects/BatteryObject.cs
@@ -22,7 +22,7 @@ namespace Iot.Device.Usb
             get => Power.FromWatts((ushort)(Value & OperatingPowerMask) / 4.0);
             set
             {
-                value.Watts.CheckArgumentInRange(255.75);
+                value.Watts.CheckArgumentInRange(255.75M);
                 Value = (Value & ~OperatingPowerMask) | (Convert.ToUInt32(value.Watts * 4) & OperatingPowerMask);
             }
         }

--- a/tools/ArduinoCsCompiler/Frontend/CompilerRun.cs
+++ b/tools/ArduinoCsCompiler/Frontend/CompilerRun.cs
@@ -67,7 +67,7 @@ namespace ArduinoCsCompiler
                 Logger.LogInformation($"Recommended minimum values are 512 kB of flash and 100 kB of RAM. Some microcontrollers (e.g. ESP32) may allow configuration of the amount of flash " +
                                       $"available for code.");
 
-                if (caps.IntSize != Information.FromBytes(4) || caps.PointerSize != Information.FromBytes(4))
+                if (!caps.IntSize.Equals(Information.FromBytes(4), 0, ComparisonType.Absolute) || !caps.PointerSize.Equals(Information.FromBytes(4), 0, ComparisonType.Absolute))
                 {
                     Logger.LogWarning("Board pointer and/or integer size is not 32 bits. This is untested and may lead to unpredictable behavior.");
                 }

--- a/tools/ArduinoCsCompiler/Frontend/PrepareRun.cs
+++ b/tools/ArduinoCsCompiler/Frontend/PrepareRun.cs
@@ -150,7 +150,7 @@ namespace ArduinoCsCompiler
             Logger.LogInformation("Valid units for sizes: ");
             foreach (var u in Information.Info.UnitInfos)
             {
-                double factor = Information.From(1, u.Value) / Information.FromBytes(1);
+                decimal factor = Information.From(1, u.Value) / Information.FromBytes(1);
                 Logger.LogInformation($"Use {Information.GetAbbreviation(u.Value)} for a multiplication by {factor:N0} bytes");
             }
         }


### PR DESCRIPTION
Updates UnitsNet to V5.0.0-rc010, fixing all the compile breakages due to breaking changes. 

@joperezr Can we upload this package to the internal server? It seems the build is failing with an unpatched nuget.config.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2010)