### PR TITLE
Fixing broken links in markdown documents

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -13,5 +13,6 @@
         { "pattern": "https://www.digikey.com/" },
         { "pattern": "https://www.aliexpress.com/" },
         { "pattern": "https://www.emvlab.org/tlvutils/" }
+        { "pattern": "https://hackaday.io" }
     ] 
 }

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -12,7 +12,7 @@
         { "pattern": "https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/MPU-6886-000193%2Bv1.1_GHIC_en.pdf" },
         { "pattern": "https://www.digikey.com/" },
         { "pattern": "https://www.aliexpress.com/" },
-        { "pattern": "https://www.emvlab.org/tlvutils/" }
+        { "pattern": "https://www.emvlab.org/tlvutils/" },
         { "pattern": "https://hackaday.io" }
     ] 
 }

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -134,7 +134,7 @@ This repository mainly contains two different components:
 
 ### Social
 
-* Hackaday.io
+* [Hackaday.io](https://hackaday.io)
 * [hackster.io](https://www.hackster.io/)
 * [instructables](https://www.instructables.com/)
 

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -134,7 +134,7 @@ This repository mainly contains two different components:
 
 ### Social
 
-* [Hackaday.io](https://hackaday.io/)
+* Hackaday.io
 * [hackster.io](https://www.hackster.io/)
 * [instructables](https://www.instructables.com/)
 

--- a/src/devices/Bh1750fvi/README.md
+++ b/src/devices/Bh1750fvi/README.md
@@ -4,7 +4,7 @@ BH1750FVI is an digital Ambient Light Sensor IC for I2C bus interface. This IC i
 
 ## Documentation
 
-Product datasheet can be found [here](https://cdn.datasheetspdf.com/pdf-down/B/H/1/BH1750FVI_Rohm.pdf)
+Product datasheet can be found [here](https://www.mouser.com/datasheet/2/348/bh1750fvi-e-186247.pdf)
 
 ## Sensor Image
 

--- a/src/devices/Dhtxx/README.md
+++ b/src/devices/Dhtxx/README.md
@@ -14,10 +14,10 @@ The DHT temperature and humidity sensors are very popular. This projects support
 | Protocol | I2C | 1-Wire | I2C, 1-Wire | 1-Wire | 1-Wire |
 
 * **DHT10** [datasheet (Currently only Chinese)](http://www.aosong.com/userfiles/files/media/DHT10%E8%A7%84%E6%A0%BC%E4%B9%A6.pdf)
-* **DHT11** [datasheet](https://cdn.datasheetspdf.com/pdf-down/D/H/T/DHT11-Aosong.pdf)
-* **DHT12** [datasheet](https://cdn.datasheetspdf.com/pdf-down/D/H/T/DHT12-Aosong.pdf)
-* **DHT21** [datasheet](https://cdn.datasheetspdf.com/pdf-down/A/M/2/AM2301-Aosong.pdf)
-* **DHT22** [datasheet](https://cdn-shop.adafruit.com/datasheets/DHT22.pdf)
+* **DHT11** [datasheet](https://www.mouser.com/datasheet/2/758/DHT11-Technical-Data-Sheet-Translated-Version-1143054.pdf)
+* **DHT12** [datasheet](https://www.sunrom.com/download/592.pdf)
+* **DHT21** [datasheet](https://mikroshop.ch/pdf/DHT21.pdf)
+* **DHT22** [datasheet](https://www.sparkfun.com/datasheets/Sensors/Temperature/DHT22.pdf)
 
 ## Usage
 

--- a/src/devices/Display/README.md
+++ b/src/devices/Display/README.md
@@ -10,7 +10,7 @@ These [bright crisp displays](https://www.adafruit.com/product/1270) are good fo
 
 <img src="https://cdn-shop.adafruit.com/970x728/1268-00.jpg" width ="250px" title="Adafruit 1.2 inch 4-Digit 7-Segment Display w/I2C Backpack - Green" />
 
-You can write the following code to control them or checkout a [larger sample](samples/Program.cs).
+You can write the following code to control them or checkout a [larger sample](samples/Large4Digit7SegmentDisplay/Program.cs).
 
 ```csharp
 // Initialize display (busId = 1 for Raspberry Pi 2 & 3)
@@ -44,7 +44,7 @@ Make a [scrolling sign or a small video display](https://www.adafruit.com/produc
 
 ![8x8 Bicolor LED matrix](https://camo.githubusercontent.com/f85caa66967ebd6752469f1baff0a660104dbe02081f42f1ee78c920f4b60cdd/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f3974316d38477466613841346162477443682f323030772e77656270)
 
-You can write the following code to control them or checkout a [larger sample](samples/Program.Matrix.cs) ([Bicolor sample](samples/Program.Matrix8x8Bicolor.cs)).
+You can write the following code to control them or checkout a [larger sample](samples\Matrix\Program.Matrix.cs) ([Bicolor sample](samples\Matrix8x8Bicolor\Program.Matrix8x8Bicolor.cs)).
 
 ```csharp
 using Matrix8x8 matrix = new(I2cDevice.Create(new I2cConnectionSettings(busId: 1, Ht16k33.DefaultI2cAddress)))
@@ -70,7 +70,7 @@ Make a [small linear display](https://www.adafruit.com/product/1721) with multip
 
 ![Bi-Color (Red/Green) 24-Bar Bargraph w/I2C Backpack Kit](https://camo.githubusercontent.com/7667a4f1a7f3956b94c8d4373668290fa6af5cf76862553f54247dffe91b4745/68747470733a2f2f692e67697068792e636f6d2f6d656469612f326c4d71686e6b494273504d47704f4a49782f67697068792d646f776e73697a65642e676966)
 
-You can write the following code to control them or checkout a [larger sample](samples/Program.BiColorBargraph.cs).
+You can write the following code to control them or checkout a [larger sample](samples\BiColorBargraph\Program.BiColorBargraph.cs).
 
 ```csharp
 using BiColorBarGraph bargraph = new(I2cDevice.Create(new I2cConnectionSettings(busId: 1, Ht16k33.DefaultI2cAddress)))

--- a/src/devices/Display/README.md
+++ b/src/devices/Display/README.md
@@ -44,7 +44,7 @@ Make a [scrolling sign or a small video display](https://www.adafruit.com/produc
 
 ![8x8 Bicolor LED matrix](https://camo.githubusercontent.com/f85caa66967ebd6752469f1baff0a660104dbe02081f42f1ee78c920f4b60cdd/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f3974316d38477466613841346162477443682f323030772e77656270)
 
-You can write the following code to control them or checkout a [larger sample](samples\Matrix\Program.Matrix.cs) ([Bicolor sample](samples\Matrix8x8Bicolor\Program.Matrix8x8Bicolor.cs)).
+You can write the following code to control them or checkout a [larger sample](samples/Matrix/Program.Matrix.cs) ([Bicolor sample](samples/Matrix8x8Bicolor/Program.Matrix8x8Bicolor.cs)).
 
 ```csharp
 using Matrix8x8 matrix = new(I2cDevice.Create(new I2cConnectionSettings(busId: 1, Ht16k33.DefaultI2cAddress)))
@@ -70,7 +70,7 @@ Make a [small linear display](https://www.adafruit.com/product/1721) with multip
 
 ![Bi-Color (Red/Green) 24-Bar Bargraph w/I2C Backpack Kit](https://camo.githubusercontent.com/7667a4f1a7f3956b94c8d4373668290fa6af5cf76862553f54247dffe91b4745/68747470733a2f2f692e67697068792e636f6d2f6d656469612f326c4d71686e6b494273504d47704f4a49782f67697068792d646f776e73697a65642e676966)
 
-You can write the following code to control them or checkout a [larger sample](samples\BiColorBargraph\Program.BiColorBargraph.cs).
+You can write the following code to control them or checkout a [larger sample](samples/BiColorBargraph/Program.BiColorBargraph.cs).
 
 ```csharp
 using BiColorBarGraph bargraph = new(I2cDevice.Create(new I2cConnectionSettings(busId: 1, Ht16k33.DefaultI2cAddress)))

--- a/src/devices/Hcsr501/README.md
+++ b/src/devices/Hcsr501/README.md
@@ -5,7 +5,7 @@ HC-SR501 is used to detect motion based on the infrared heat in the surrounding 
 ## Documentation
 
 - In [Chinese](http://wenku.baidu.com/view/26ef5a9c49649b6648d747b2.html)
-- In [English](https://cdn.datasheetspdf.com/pdf-down/H/C/-/HC-SR501-1-ETC.pdf)
+- In [English](https://www.mpja.com/download/31227sc.pdf)
 
 ![sensor](sensor.jpg)
 

--- a/src/devices/Hmc5883l/README.md
+++ b/src/devices/Hmc5883l/README.md
@@ -4,7 +4,7 @@ HMC5883L is a surface-mount, multi-chip module designed for low-field magnetic s
 
 ## Documentation
 
-- HMC5883L [datasheet](https://cdn.datasheetspdf.com/pdf-down/H/M/C/HMC5883L-Honeywell.pdf)
+- HMC5883L [datasheet](https://cdn-shop.adafruit.com/datasheets/HMC5883L_3-Axis_Digital_Compass_IC.pdf)
 
 ![sensor](sensor.jpg)
 

--- a/src/devices/Lm75/README.md
+++ b/src/devices/Lm75/README.md
@@ -4,7 +4,7 @@ The LM75 is a temperature sensor, Delta-Sigma analog-to-digital converter, and d
 
 ## Documentation
 
-- LM75 [datasheet](https://cdn.datasheetspdf.com/pdf-down/L/M/7/LM75_NationalSemiconductor.pdf)
+- LM75 [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/LM75.pdf)
 
 ![sensor](sensor.jpg)
 

--- a/src/devices/Lsm9Ds1/README.md
+++ b/src/devices/Lsm9Ds1/README.md
@@ -9,7 +9,7 @@ and therefore functionality has been split into 2 classes which allows using the
 
 ## Documentation
 
-- You can find the datasheet [here](https://www.st.com/resource/en/datasheet/lsm9ds1.pdf)
+- You can find the datasheet [here](https://cdn.sparkfun.com/assets/learn_tutorials/3/7/3/LSM9DS1_Datasheet.pdf)
 
 ## Usage
 

--- a/src/devices/Max44009/README.md
+++ b/src/devices/Max44009/README.md
@@ -6,7 +6,7 @@ The MAX44009 ambient light sensor features an I2C digital output that is ideal f
 
 ## Documentation
 
-- You can find the datasheet [here](https://cdn.datasheetspdf.com/pdf-down/M/A/X/MAX44009_MaximIntegratedProducts.pdf)
+- You can find the datasheet [here](https://www.analog.com/media/en/technical-documentation/data-sheets/max44009.pdf)
 
 ## Usage
 

--- a/src/devices/Mlx90614/README.md
+++ b/src/devices/Mlx90614/README.md
@@ -4,7 +4,7 @@ The MLX90614 is an Infra Red thermometer for noncontact temperature measurements
 
 ## Documentation
 
-- You can find the datasheet [here](https://cdn.datasheetspdf.com/pdf-down/M/L/X/MLX90614-Melexis.pdf)
+- You can find the datasheet [here](https://www.melexis.com/-/media/files/documents/datasheets/mlx90614-datasheet-melexis.pdf)
 
 ## Board
 

--- a/src/devices/Nrf24l01/README.md
+++ b/src/devices/Nrf24l01/README.md
@@ -4,7 +4,7 @@ The nRF24L01 is a single chip radio transceiver for the world wide 2.4 - 2.5 GHz
 
 ## Documentation
 
-- The bindging datasheet can be found [here](https://cdn.datasheetspdf.com/pdf-down/N/R/F/NRF24L01-Nordic.pdf)
+- The bindging datasheet can be found [here](https://infocenter.nordicsemi.com/pdf/nRF24L01P_PS_v1.0.pdf)
 
 ## Board
 

--- a/src/devices/RadioReceiver/README.md
+++ b/src/devices/RadioReceiver/README.md
@@ -4,7 +4,7 @@ The radio receiver devices supported by the project include TEA5767.
 
 ## Documentation
 
-- TEA5767 radio receiver [datasheet](https://cdn.datasheetspdf.com/pdf-down/T/E/A/TEA5767HN-NXP.pdf)
+- TEA5767 radio receiver [datasheet](https://www.sparkfun.com/datasheets/Wireless/General/TEA5767.pdf)
 
 ## Usage
 

--- a/src/devices/RadioTransmitter/README.md
+++ b/src/devices/RadioTransmitter/README.md
@@ -4,7 +4,7 @@ The radio transmitter devices supported by the project include KT0803.
 
 ## Documentation
 
-- KT0803 radio transmitter [datasheet](https://cdn.datasheetspdf.com/pdf-down/K/T/0/KT0803L-KTMicro.pdf)
+- KT0803 radio transmitter [datasheet](http://radio-z.ucoz.lv/kt_0803/KT0803L_V1.3.pdf)
 
 ## Usage
 

--- a/src/devices/Rtc/README.md
+++ b/src/devices/Rtc/README.md
@@ -7,9 +7,9 @@ to a hardware RTC clock.
 
 ## Documentation
 
-- DS1307 [datasheet](https://cdn.datasheetspdf.com/pdf-down/D/S/1/DS1307-Maxim.pdf)
+- DS1307 [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/DS1307.pdf)
 - DS3231 [datasheet](https://datasheets.maximintegrated.com/en/ds/DS3231.pdf)
-- PCF8563 [datasheet](https://cdn.datasheetspdf.com/pdf-down/P/C/F/PCF-856.pdf)
+- PCF8563 [datasheet](https://www.nxp.com/docs/en/data-sheet/PCF8563.pdf)
 
 ## Board
 

--- a/src/devices/Sht3x/README.md
+++ b/src/devices/Sht3x/README.md
@@ -4,7 +4,7 @@ SHT3x is the next generation of Sensirion’s temperature and humidity sensors. 
 
 ## Documentation
 
-- SHT30 [datasheet](https://cdn.datasheetspdf.com/pdf-down/S/H/T/SHT30-DIS-Sensirion.pdf)
+- SHT30 [datasheet](https://sensirion.com/media/documents/213E6A3B/63A5A569/Datasheet_SHT3x_DIS.pdf)
 
 ## Board
 


### PR DESCRIPTION
This PR replaced a broken link (missing datasheet) with:
https://www.mouser.com/datasheet/2/348/bh1750fvi-e-186247.pdf


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2014)