### PR TITLE
Only check internal markdown links, plus a few stable sites

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,19 +1,8 @@
 {
     "ignorePatterns": [
-        { "pattern": "https://eu.industrial.panasonic.com/sites/default/pidseu/files/downloads/files/" },
-        { "pattern": "https://www.akm.com/akm/en/file/datasheet/AK8963C.pdf" },
-        { "pattern": "https://dotnet.myget.org/feed/dotnet-core/package/nuget/Iot.Device.Bindings" },
+        { "pattern": "^http[s]?://(?!(github.com|([a-zA-Z]*).microsoft.com|aka.ms|dotnetfoundation.org|www.nuget.org))" },
         { "pattern": "../.vscode/launch.json" },
         { "pattern": "../.vscode/tasks.json" },
-        { "pattern": "http://url/image" },
-        { "pattern": "https://dev.azure.com/dnceng/internal/_build\\?definitionId" },
-        { "pattern": "https://www.pine64.org/\\?page_id=46823" },
-        { "pattern": "http://ecee.colorado.edu/~mcclurel/Philips_I2C_IO_Expanders_AN469_2.pdf" },
-        { "pattern": "https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/MPU-6886-000193%2Bv1.1_GHIC_en.pdf" },
-        { "pattern": "https://www.digikey.com/" },
-        { "pattern": "https://www.aliexpress.com/" },
-        { "pattern": "https://www.emvlab.org/tlvutils/" },
-        { "pattern": "https://hackaday.io" },
-        { "pattern": "https://www.tindie.com" }
+        { "pattern": "http://url/image" }
     ] 
 }

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Once you have selected the right branch, you can browse the repository. The main
 ## Community
 
 This project has adopted the code of conduct defined by the [Contributor Covenant](https://contributor-covenant.org/)
-to clarify expected behavior in our community. For more information, see the [.NET Foundation Code of Conduct](https://www.dotnetfoundation.org/code-of-conduct).
+to clarify expected behavior in our community. For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
 
 ## License
 

--- a/src/devices/Board/README.md
+++ b/src/devices/Board/README.md
@@ -2,3 +2,14 @@
 
 A "board" is a piece of hardware that offers low-level interfaces to other devices. Typically, it has GPIO pins and one or multiple SPI or I2C busses.
 There should be exactly one instance of a board class per hardware component in an application, but it is possible to work with multiple boards at once (i.e. when having a GPIO expander connected to the Raspberry Pi).
+
+```csharp
+using Board b = Board.Create();
+
+using GpioController controller = b.CreateGpioController();
+controller.OpenPin(1);
+// ...
+
+using bus = b.CreateOrGetI2cBus(1);
+// ...
+```


### PR DESCRIPTION
Changed markdown check behavior to only check internal links (those not starting with https), except for servers known to be stable (e.g. github.com, microsoft.com)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2021)