### PR TITLE
UltralightCard fixes - byte order of ATQA, number of blocks in EV1

### DIFF
--- a/src/devices/Card/Ultralight/UltralightCard.cs
+++ b/src/devices/Card/Ultralight/UltralightCard.cs
@@ -76,7 +76,7 @@ namespace Iot.Device.Card.Ultralight
         /// <param name="ATQA">The ATQA</param>
         /// <param name="SAK">The SAK</param>
         /// <returns>True if this is an Ultralight</returns>
-        public static bool IsUltralightCard(ushort ATQA, byte SAK) => (ATQA == 0x4400) && (SAK == 0);
+        public static bool IsUltralightCard(ushort ATQA, byte SAK) => (ATQA == 0x0044) && (SAK == 0);
 
         /// <summary>
         /// Constructor for Ultralight
@@ -435,7 +435,6 @@ namespace Iot.Device.Card.Ultralight
         /// </summary>
         public int NumberBlocks => UltralightCardType switch
         {
-            // Whenever NdefCapacity + 9 is used, then it's a guess
             UltralightCardType.UltralightNtag210 => 16,
             UltralightCardType.UltralightNtag212 => 45,
             UltralightCardType.UltralightNtag213 => 45,
@@ -443,10 +442,10 @@ namespace Iot.Device.Card.Ultralight
             UltralightCardType.UltralightNtag215 => 135,
             UltralightCardType.UltralightNtag216 => 231,
             UltralightCardType.UltralightNtag216F => 231,
-            UltralightCardType.UltralightEV1MF0UL1101 => 41,
-            UltralightCardType.UltralightEV1MF0ULH1101 => 41,
-            UltralightCardType.UltralightEV1MF0UL2101 => NdefCapacity + 9,
-            UltralightCardType.UltralightEV1MF0ULH2101 => NdefCapacity + 9,
+            UltralightCardType.UltralightEV1MF0UL1101 => 20,
+            UltralightCardType.UltralightEV1MF0ULH1101 => 20,
+            UltralightCardType.UltralightEV1MF0UL2101 => 41,
+            UltralightCardType.UltralightEV1MF0ULH2101 => 41,
             UltralightCardType.UltralightNtagI2cNT3H1101 => 231,
             UltralightCardType.UltralightNtagI2cNT3H1101W0 => 231,
             UltralightCardType.UltralightNtagI2cNT3H2111W0 => 476 + 9,


### PR DESCRIPTION
The ATQA returned by NFC anticollision is converted by a ushort by the Mfrc522, Pn532, and Pn5180 transceivers. In the case of the Mfrc522, the byte order was reversed - which was corrected by #2005. However, perhaps because the ATQA ushorts were inconsistently calculated by the different transceivers, it is also inconsistently used.  Iot.Device.Card.Mifare.SetCapacity expects the ATQA of a Mifare classic 1K card to be 0x0004 and the ATQA of a Mifare classic 4K card to be 0x0002 (which are the values defined by NXP for those parts). However, Iot.Device.Card.Ultralight.UltralightCard.IsUltralightCard expects the ATQA of an Ultralight card to be 0x4400, when it should be 0x0044 according to the NXP spec.

In addition, the property UltralightCard.NumberBlocks returns the number of blocks based upon the type of the card. The values returned for UltralightEV1 cards are incorrect. This causes the sample code to attempt to read past the end of the card prevents the card configuration from being decoded.

This change aligns the expected ATQA and the actual number of blocks with the spec.

Tested with an Mfrc522 and a Pn532 using Mifare Classic and Ultralight cards. The cards are now correctly identified.

<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2022)