### PR TITLE
Disable a flaky test for SysFs

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -230,9 +230,16 @@ public abstract class GpioControllerTestBase
     [Fact]
     public void AddCallbackFallingEdgeNotDetectedTest()
     {
+        var driver = GetTestDriver();
+        if (driver is SysFsDriver)
+        {
+            // This test is unreliable (flaky) with SysFs.
+            return;
+        }
+
         bool wasCalled = false;
         AutoResetEvent ev = new AutoResetEvent(false);
-        using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
+        using (GpioController controller = new GpioController(GetTestNumberingScheme(), driver))
         {
             controller.OpenPin(InputPin, PinMode.Input);
             controller.OpenPin(OutputPin, PinMode.Output);

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -234,7 +234,7 @@ public abstract class GpioControllerTestBase
         if (driver is SysFsDriver)
         {
             // This test is unreliable (flaky) with SysFs.
-            // See #629 and possibly #1581
+            // See https://github.com/dotnet/iot/issues/629 and possibly https://github.com/dotnet/iot/issues/1581
             return;
         }
 

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -234,6 +234,7 @@ public abstract class GpioControllerTestBase
         if (driver is SysFsDriver)
         {
             // This test is unreliable (flaky) with SysFs.
+            // See #629 and possibly #1581
             return;
         }
 


### PR DESCRIPTION
[This report](https://dev.azure.com/dotnet/IoT/_test/analytics?definitionId=179&contextType=build) indicates that this particular test is responsible for most of the helix test failures.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2023)