### PR TITLE
Fix bug where SHTC3 was not woken from sleep before operations

### DIFF
--- a/src/devices/Shtc3/Shtc3.cs
+++ b/src/devices/Shtc3/Shtc3.cs
@@ -192,7 +192,6 @@ namespace Iot.Device.Shtc3
             Write(Register.SHTC3_WAKEUP);
 
             _status = Status.Idle;
-
         }
 
         /// <summary>

--- a/src/devices/Shtc3/Shtc3.cs
+++ b/src/devices/Shtc3/Shtc3.cs
@@ -36,7 +36,6 @@ namespace Iot.Device.Shtc3
             _i2cDevice = i2cDevice ?? throw new ArgumentNullException(nameof(i2cDevice));
 
             Wakeup();
-            _status = Status.Idle;
 
             Reset();
         }
@@ -181,12 +180,20 @@ namespace Iot.Device.Shtc3
             }
 
             Write(Register.SHTC3_SLEEP);
+
+            _status = Status.Sleep;
         }
 
         /// <summary>
         /// SHTC3 Wakeup
         /// </summary>
-        private void Wakeup() => Write(Register.SHTC3_WAKEUP);
+        private void Wakeup()
+        {
+            Write(Register.SHTC3_WAKEUP);
+
+            _status = Status.Idle;
+
+        }
 
         /// <summary>
         /// SHTC3 Soft Reset


### PR DESCRIPTION
As discussed in Discord.

SHTC3 binding would only ever read one set of values, before triggering this exception:

```
Unhandled exception. System.IO.IOException: Error 121 performing I2C data transfer.
   at System.Device.I2c.UnixI2cBus.WriteReadCore(UInt16 deviceAddress, Byte* writeBuffer, Byte* readBuffer, UInt16 writeBufferLength, UInt16 readBufferLength) in C:\Source\jcoliz\dotnet\iot\src\System.Device.Gpio\System\Device\I2c\UnixI2cBus.cs:line 197
   at System.Device.I2c.UnixI2cBus.Write(Int32 deviceAddress, ReadOnlySpan`1 buffer) in C:\Source\jcoliz\dotnet\iot\src\System.Device.Gpio\System\Device\I2c\UnixI2cBus.cs:line 125
   at System.Device.I2c.UnixI2cDevice.Write(ReadOnlySpan`1 buffer) in C:\Source\jcoliz\dotnet\iot\src\System.Device.Gpio\System\Device\I2c\Devices\UnixI2cDevice.cs:line 28
   at Iot.Device.Shtc3.Shtc3.Write(Register register) in C:\Source\jcoliz\dotnet\iot\src\devices\Shtc3\Shtc3.cs:line 247
   at Iot.Device.Shtc3.Shtc3.TryReadSensorData(Register cmd, Double& temperature, Double& humidity) in C:\Source\jcoliz\dotnet\iot\src\devices\Shtc3\Shtc3.cs:line 148
   at Iot.Device.Shtc3.Shtc3.TryGetTemperatureAndHumidity(Temperature& temperature, RelativeHumidity& relativeHumidity, Boolean lowPower, Boolean clockStretching) in C:\Source\jcoliz\dotnet\iot\src\devices\Shtc3\Shtc3.cs:line 133
```

That's because the device was put to sleep (in the sample), but never actually woken up before getting the next reading. THAT was because the status was never set when device put to sleep.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2034)