### PR TITLE
Fix OragePiPC typo

### DIFF
--- a/src/devices/Gpio/Drivers/OrangePiPCDriver.cs
+++ b/src/devices/Gpio/Drivers/OrangePiPCDriver.cs
@@ -6,12 +6,12 @@ using Iot.Device.Gpio.Drivers;
 namespace System.Device.Gpio.Drivers
 {
     /// <summary>
-    /// A GPIO driver for the Orange Pi PC.
+    /// A GPIO driver for the Orange Pi PC and PC+.
     /// </summary>
     /// <remarks>
     /// SoC: Allwinner H3
     /// </remarks>
-    public class OragePiPCDriver : SunxiDriver
+    public class OrangePiPCDriver : SunxiDriver
     {
         /// <inheritdoc/>
         protected override int CpuxPortBaseAddress => 0x01C20800;


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->
Fixed a typo in the OrangePiPC driver and added that it also supports the PC+ model.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2035)