### PR TITLE
Refactor status handling in SHTC3 binding

### DIFF
--- a/src/devices/Shtc3/Shtc3.cs
+++ b/src/devices/Shtc3/Shtc3.cs
@@ -41,7 +41,7 @@ namespace Iot.Device.Shtc3
         /// <summary>
         /// Current state of Shtc3 sensor
         /// </summary>
-        internal Status Status { get; private set; } = Status.Unknown;
+        private Status _status = Status.Unknown;
 
         private static Register GetMeasurementCmd(bool lowPower, bool clockStretching)
         {
@@ -167,11 +167,11 @@ namespace Iot.Device.Shtc3
         /// </summary>
         public void Sleep()
         {
-            if (Status != Status.Sleep)
+            if (_status != Status.Sleep)
             {
                 Write(Register.SHTC3_SLEEP);
 
-                Status = Status.Sleep;
+                _status = Status.Sleep;
             }
         }
 
@@ -180,11 +180,11 @@ namespace Iot.Device.Shtc3
         /// </summary>
         private void Wakeup()
         {
-            if (Status != Status.Idle)
+            if (_status != Status.Idle)
             {
                 Write(Register.SHTC3_WAKEUP);
 
-                Status = Status.Idle;
+                _status = Status.Idle;
             }
         }
 

--- a/src/devices/Shtc3/Status.cs
+++ b/src/devices/Shtc3/Status.cs
@@ -9,6 +9,11 @@ namespace Iot.Device.Shtc3
     internal enum Status
     {
         /// <summary>
+        /// Sensor in an unknown state
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
         /// Sensor ready to use
         /// </summary>
         Idle,


### PR DESCRIPTION
As discussed on Discord with @krwq 
* Reduce to a single `_status` field (use field instead of property, per feedback)
* Only check current status in `Wakeup`/`Sleep` methods, where it's needed
* Add an `Unknown` status enum value to describe the moments before we have explicitly set the status.

Of course, fully tested on physical hardware.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2038)