### PR TITLE
add protocol awareness to NFC card transceivers

### DIFF
--- a/src/devices/Card/CardTransceiver.cs
+++ b/src/devices/Card/CardTransceiver.cs
@@ -48,10 +48,5 @@ namespace Iot.Device.Card
         /// the size of a FIFO buffer in the transceiver).
         /// </summary>
         public abstract uint MaximumWriteSize { get; }
-
-        /// <summary>
-        /// The set of RF operating modes that are supported by this transceiver.
-        /// </summary>
-        public abstract NfcProtocol SupportedProtocols { get; }
     }
 }

--- a/src/devices/Card/CardTransceiver.cs
+++ b/src/devices/Card/CardTransceiver.cs
@@ -22,8 +22,9 @@ namespace Iot.Device.Card
         /// <param name="targetNumber">Some readers have a notion of target number for the cards as they can read multiple ones</param>
         /// <param name="dataToSend">A standardized raw buffer with the command at the position 0 in the array</param>
         /// <param name="dataFromCard">If any data are read from the card, they will be put into this array</param>
+        /// <param name="protocol">NFC protocol for this data exchange (e.g., Mifare)</param>
         /// <returns>-1 in case of error, otherwise the number of bytes read and copied into the <paramref name="dataFromCard"/> array</returns>
-        public abstract int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard);
+        public abstract int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard, NfcProtocol protocol);
 
         /// <summary>
         /// Once you have an authentication operation failing with Mifare cards or a read/write, the card stop.
@@ -33,5 +34,24 @@ namespace Iot.Device.Card
         /// <param name="targetNumber">The target number to reselect</param>
         /// <returns>True if success</returns>
         public abstract bool ReselectTarget(byte targetNumber);
+
+        /// <summary>
+        /// The maximum number of bytes that can be read from the card in a single transaction,
+        /// (excluding CRC). This is constrained by the operating mode as well as transceiver limitations (such as
+        /// the size of a FIFO buffer in the transceiver).
+        /// </summary>
+        public abstract uint MaximumReadSize { get; }
+
+        /// <summary>
+        /// The maximum number of bytes that can be written to the card in a single transaction,
+        /// (excluding CRC). This is constrained by the operating mode as well as transceiver limitations (such as
+        /// the size of a FIFO buffer in the transceiver).
+        /// </summary>
+        public abstract uint MaximumWriteSize { get; }
+
+        /// <summary>
+        /// The set of RF operating modes that are supported by this transceiver.
+        /// </summary>
+        public abstract NfcProtocol SupportedProtocols { get; }
     }
 }

--- a/src/devices/Card/CreditCard/CreditCard.cs
+++ b/src/devices/Card/CreditCard/CreditCard.cs
@@ -735,7 +735,7 @@ namespace Iot.Device.Card.CreditCardProcessing
 
         private int ReadFromCard(byte target, ReadOnlySpan<byte> toSend, Span<byte> received)
         {
-            var ret = _nfc.Transceive(_target, toSend, received);
+            var ret = _nfc.Transceive(_target, toSend, received, NfcProtocol.Iso14443_4);
             if (ret >= TailerSize)
             {
                 if (ret == TailerSize)
@@ -748,7 +748,7 @@ namespace Iot.Device.Card.CreditCardProcessing
                         Span<byte> toGet = stackalloc byte[5];
                         ApduCommands.GetBytesToRead.CopyTo(toGet);
                         toGet[4] = err.CorrectLegnthOrBytesAvailable;
-                        ret = _nfc.Transceive(_target, toGet, received);
+                        ret = _nfc.Transceive(_target, toGet, received, NfcProtocol.Iso14443_4);
                     }
                 }
             }

--- a/src/devices/Card/Mifare/MifareCard.cs
+++ b/src/devices/Card/Mifare/MifareCard.cs
@@ -153,7 +153,7 @@ namespace Iot.Device.Card.Mifare
                 dataOut = new byte[16];
             }
 
-            var ret = _rfid.Transceive(Target, Serialize(), dataOut.AsSpan());
+            var ret = _rfid.Transceive(Target, Serialize(), dataOut.AsSpan(), NfcProtocol.Mifare);
             _logger.LogDebug($"{nameof(RunMifareCardCommand)}: {Command}, Target: {Target}, Data: {BitConverter.ToString(Serialize())}, Success: {ret}, Dataout: {BitConverter.ToString(dataOut)}");
             if ((ret > 0) && (Command == MifareCardCommand.Read16Bytes))
             {

--- a/src/devices/Card/NfcProtocol.cs
+++ b/src/devices/Card/NfcProtocol.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Card
+{
+    /// <summary>
+    /// NFC protocol
+    /// These include standards as well as proprietary command sets, for which transceivers
+    /// may have special support. For example, Mifare is conveyed across ISO/IEC 14443-3 (Type A),
+    /// and transceivers have built-in support for Mifare authentication commands.
+    /// </summary>
+    [Flags]
+    public enum NfcProtocol
+    {
+        /// <summary>
+        /// Unknown or unspecified
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// ISO/IEC 14443-3 (Type A or B)
+        /// </summary>
+        Iso14443_3 = (1 << 0),
+
+        /// <summary>
+        /// ISO/IEC 14443-4 (Type A or B)
+        /// </summary>
+        Iso14443_4 = (1 << 1),
+
+        /// <summary>
+        /// Mifare Classic
+        /// (proprietary commands on top of ISO/IEC 14443-3 Type A)
+        /// </summary>
+        Mifare = (1 << 2),
+
+        /// <summary>
+        /// Innovision Jewel
+        /// </summary>
+        Jewel = (1 << 3),
+
+        /// <summary>
+        /// JIS X 6319-4 (compatible with FeliCa)
+        /// </summary>
+        JisX6319_4 = (1 << 4),
+
+        /// <summary>
+        /// JIS X 6319-4 (compatible with FeliCa)
+        /// </summary>
+        FeliCa = JisX6319_4,
+
+        /// <summary>
+        /// ISO/IEC 15693
+        /// </summary>
+        Iso15693 = (1 << 5)
+    }
+}

--- a/src/devices/Card/NfcProtocol.cs
+++ b/src/devices/Card/NfcProtocol.cs
@@ -31,7 +31,7 @@ namespace Iot.Device.Card
 
         /// <summary>
         /// Mifare Classic
-        /// (proprietary commands on top of ISO/IEC 14443-3 Type A)
+        /// Proprietary commands on top of ISO/IEC 14443-3 Type A
         /// </summary>
         Mifare = (1 << 2),
 
@@ -41,14 +41,9 @@ namespace Iot.Device.Card
         Jewel = (1 << 3),
 
         /// <summary>
-        /// JIS X 6319-4 (compatible with FeliCa)
+        /// JIS X 6319-4. Compatible with FeliCa.
         /// </summary>
         JisX6319_4 = (1 << 4),
-
-        /// <summary>
-        /// JIS X 6319-4 (compatible with FeliCa)
-        /// </summary>
-        FeliCa = JisX6319_4,
 
         /// <summary>
         /// ISO/IEC 15693

--- a/src/devices/Mfrc522/Mfrc522.cs
+++ b/src/devices/Mfrc522/Mfrc522.cs
@@ -34,6 +34,15 @@ namespace Iot.Device.Mfrc522
         /// </summary>
         public const SpiMode DefaultSpiMode = SpiMode.Mode0;
 
+        /// <inheritdoc/>
+        public override uint MaximumReadSize => 62;     // 64-byte FIFO, 2 byte CRC
+
+        /// <inheritdoc/>
+        public override uint MaximumWriteSize => 62;    // 64-byte FIFO, 2 byte CRC
+
+        /// <inheritdoc/>
+        public override NfcProtocol SupportedProtocols => NfcProtocol.Iso14443_3 | NfcProtocol.Mifare;
+
         private readonly int _pinReset;
         private readonly ILogger _logger;
         private readonly SerialPort? _serialPort;
@@ -858,45 +867,47 @@ namespace Iot.Device.Mfrc522
         }
 
         /// <inheritdoc/>
-        public override int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard)
+        public override int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard, NfcProtocol protocol)
         {
             // targetNumber is not used here as only 1 card can be selected at a time so will be ignored
             // The dataToSend buffer contains anyway the unique of the card
-            Status status;
-
-            // Use built in functions for authentication in case of classic Mifare cards
-            if ((dataToSend[0] == (byte)MifareCardCommand.AuthenticationA) || (dataToSend[0] == (byte)MifareCardCommand.AuthenticationB))
+            if (dataToSend.Length > MaximumWriteSize)
             {
-                // UltralightCommand.GetVersion has the same command code as MifareCardCommand.AuthenticationA
-                // GetVersion returns data; AuthenticationA does not
-                if ((dataFromCard == null) || (dataFromCard.Length == 0))
-                {
-                    status = SendAndReceiveData(MfrcCommand.MifareAuthenticate, dataToSend.ToArray(), null);
-                }
-                else
-                {
+                throw new ArgumentException($"dataToSend exceeds maximum transfer size ({dataToSend.Length} > {MaximumWriteSize})");
+            }
+            else if (dataFromCard.Length > MaximumReadSize)
+            {
+                throw new ArgumentException($"dataFromCard exceeds maximum transfer size ({dataFromCard.Length} > {MaximumReadSize})");
+            }
+
+            switch (protocol)
+            {
+                case NfcProtocol.Mifare:
+                    switch ((MifareCardCommand)dataToSend[0])
+                    {
+                        case MifareCardCommand.AuthenticationA:
+                        case MifareCardCommand.AuthenticationB:
+                            // Use built in functions for authentication
+                            var status = SendAndReceiveData(MfrcCommand.MifareAuthenticate, dataToSend.ToArray(), null);
+                            return status == Status.Ok ? 0 : -1;
+
+                        case MifareCardCommand.Incrementation:
+                        case MifareCardCommand.Decrementation:
+                        case MifareCardCommand.Restore:
+                        case MifareCardCommand.Write16Bytes:
+                            // Perform these functions in two steps
+                            return TwoStepsWrite16IncDecRestore(dataToSend);
+
+                        default:
+                            return SendWithCrc(dataToSend, dataFromCard);
+                    }
+
+                case NfcProtocol.Iso14443_3:
                     return SendWithCrc(dataToSend, dataFromCard);
-                }
 
-                return status == Status.Ok ? 0 : -1;
+                default:
+                    throw new NotSupportedException($"NfcProtocol {protocol} is not supported");
             }
-            else if ((dataToSend[0] == (byte)MifareCardCommand.Incrementation) || (dataToSend[0] == (byte)MifareCardCommand.Decrementation)
-                || (dataToSend[0] == (byte)MifareCardCommand.Restore || (dataToSend[0] == (byte)MifareCardCommand.Write16Bytes)))
-            {
-                return TwoStepsWrite16IncDecRestore(dataToSend);
-            }
-            else if (Enum.IsDefined(typeof(UltralightCommand), (UltralightCommand)dataToSend[0]))
-            {
-                if ((dataToSend[0] == (byte)UltralightCommand.ReadFast) && (dataFromCard.Length > 62))
-                {
-                    throw new ArgumentException($"Maximum number of pages to be able to read with MFRC522 is 7 as internal FIFO is limited to 64 including CRC.");
-                }
-
-                return SendWithCrc(dataToSend, dataFromCard);
-            }
-
-            status = SendAndReceiveData(MfrcCommand.Transceive, dataToSend.ToArray(), dataFromCard);
-            return status == Status.Ok ? dataFromCard.Length : -1;
         }
 
         private int SendWithCrc(ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard)
@@ -953,7 +964,7 @@ namespace Iot.Device.Mfrc522
             status = SendAndReceiveData(MfrcCommand.Transceive, toSendFirst.ToArray(), null);
             if (status != Status.Ok)
             {
-                _logger.LogWarning($"{nameof(TwoStepsWrite16IncDecRestore)} - Error {(MfrcCommand)dataToSend[0]}");
+                _logger.LogWarning($"{nameof(TwoStepsWrite16IncDecRestore)} - Error {(MifareCardCommand)dataToSend[0]}");
                 return -1;
             }
 

--- a/src/devices/Mfrc522/Mfrc522.cs
+++ b/src/devices/Mfrc522/Mfrc522.cs
@@ -40,8 +40,10 @@ namespace Iot.Device.Mfrc522
         /// <inheritdoc/>
         public override uint MaximumWriteSize => 62;    // 64-byte FIFO, 2 byte CRC
 
-        /// <inheritdoc/>
-        public override NfcProtocol SupportedProtocols => NfcProtocol.Iso14443_3 | NfcProtocol.Mifare;
+        /// <summary>
+        /// The set of NFC protocols that are supported by this transceiver.
+        /// </summary>
+        public const NfcProtocol SupportedProtocols = NfcProtocol.Iso14443_3 | NfcProtocol.Mifare;
 
         private readonly int _pinReset;
         private readonly ILogger _logger;

--- a/src/devices/Pn5180/Pn5180.cs
+++ b/src/devices/Pn5180/Pn5180.cs
@@ -54,6 +54,17 @@ namespace Iot.Device.Pn5180
         /// </summary>
         public const SpiMode DefaultSpiMode = System.Device.Spi.SpiMode.Mode0;
 
+        /// <inheritdoc/>
+        public override uint MaximumReadSize => 508;
+
+        /// <inheritdoc/>
+        public override uint MaximumWriteSize => 260;
+
+        /// <inheritdoc/>
+        public override NfcProtocol SupportedProtocols =>
+            NfcProtocol.Iso14443_3 | NfcProtocol.Iso14443_4 | NfcProtocol.Mifare |
+            NfcProtocol.JisX6319_4 | NfcProtocol.Jewel | NfcProtocol.Iso15693;
+
         /// <summary>
         /// Create a PN5180 RFID/NFC reader
         /// </summary>
@@ -109,7 +120,7 @@ namespace Iot.Device.Pn5180
         #region EEPROM
 
         /// <summary>
-        /// Get the Product, Firmware and EEPROM versions of the PN8150
+        /// Get the Product, Firmware and EEPROM versions of the PN5180
         /// </summary>
         /// <returns>A tuple with the Product, Firmware and EEPROM versions</returns>
         public (Version? Product, Version? Firmware, Version? Eeprom) GetVersions()
@@ -406,19 +417,30 @@ namespace Iot.Device.Pn5180
         }
 
         /// <inheritdoc/>
-        public override int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard)
+        public override int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard, NfcProtocol protocol)
         {
-            // Check if we have a Mifare Card authentication request
-            // Only valid for Type A card so with a target number equal to 0
-            if (((targetNumber == 0) && ((dataToSend[0] == (byte)MifareCardCommand.AuthenticationA) || (dataToSend[0] == (byte)MifareCardCommand.AuthenticationB))) && (dataFromCard.Length == 0))
+            if (protocol == NfcProtocol.Mifare)
             {
-                var ret = MifareAuthenticate(dataToSend.Slice(2, 6).ToArray(), (MifareCardCommand)dataToSend[0], dataToSend[1], dataToSend.Slice(8).ToArray());
-                return ret ? 0 : -1;
+                // Check if we have a Mifare Card authentication request or 2-step write (special handling)
+                switch ((MifareCardCommand)dataToSend[0])
+                {
+                    case MifareCardCommand.AuthenticationA:
+                    case MifareCardCommand.AuthenticationB:
+                        var ret = MifareAuthenticate(dataToSend.Slice(2, 6).ToArray(), (MifareCardCommand)dataToSend[0], dataToSend[1], dataToSend.Slice(8).ToArray());
+                        return ret ? 0 : -1;
+
+                    case MifareCardCommand.Incrementation:
+                    case MifareCardCommand.Decrementation:
+                    case MifareCardCommand.Restore:
+                    case MifareCardCommand.Write16Bytes:
+                        return TwoStepsWrite16IncDecRestore(dataToSend);
+
+                    default:
+                        return TransceiveBuffer(dataToSend, dataFromCard);
+                }
             }
-            else
-            {
-                return TransceiveClassic(targetNumber, dataToSend, dataFromCard);
-            }
+
+            return TransceiveClassic(targetNumber, dataToSend, dataFromCard);
         }
 
         /// <inheritdoc/>
@@ -444,6 +466,17 @@ namespace Iot.Device.Pn5180
                 var ret = SelectCardTypeB(card.Card);
                 return ret;
             }
+        }
+
+        private int TwoStepsWrite16IncDecRestore(ReadOnlySpan<byte> dataToSend)
+        {
+            if (TransceiveBuffer(dataToSend.Slice(0, 2), Span<byte>.Empty) < 0)
+            {
+                _logger.LogWarning($"{nameof(TwoStepsWrite16IncDecRestore)} - Error {(MifareCardCommand)dataToSend[0]}");
+                return -1;
+            }
+
+            return TransceiveBuffer(dataToSend.Slice(2), Span<byte>.Empty);
         }
 
         private int TransceiveClassic(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard)
@@ -634,8 +667,9 @@ namespace Iot.Device.Pn5180
                 return -1;
             }
 
-            // 10 etu needed for 1 byte, 1 etu = 9.4 µs, so about 100 µs are needed to transfer 1 character
-            return ReadWithTimeout(dataFromCard, dataFromCard.Length / 100);
+            // 10 etu needed for 1 byte, 1 etu = 9.4 µs, so about 100 µs (0.1ms) are needed per byte
+            // add a couple of milliseconds for general overhead to avoid timing out too soon
+            return ReadWithTimeout(dataFromCard, 2 + (dataFromCard.Length + 9) / 10);
         }
 
         private bool SendRBlock(byte targetNumber, RBlock ack, int blockNumber)
@@ -1476,13 +1510,13 @@ namespace Iot.Device.Pn5180
             // 3.Wait until BUSY is high
             // 4.Deassert NSS
             // 5.Wait until BUSY is low
-            // Wait for the PN8150 to be ready
+            // Wait for the PN5180 to be ready
             Stopwatch stopwatch = Stopwatch.StartNew();
             while (_gpioController.Read(_pinBusy) == PinValue.High)
             {
                 if (stopwatch.Elapsed.TotalMilliseconds >= TimeoutWaitingMilliseconds)
                 {
-                    throw new TimeoutException($"PN8150 not ready to write");
+                    throw new TimeoutException($"PN5180 not ready to write");
                 }
             }
 
@@ -1495,7 +1529,7 @@ namespace Iot.Device.Pn5180
             {
                 if (stopwatch.Elapsed.TotalMilliseconds >= TimeoutWaitingMilliseconds)
                 {
-                    throw new TimeoutException($"PN8150 is still busy after writting");
+                    throw new TimeoutException($"PN5180 is still busy after writting");
                 }
             }
 
@@ -1515,13 +1549,13 @@ namespace Iot.Device.Pn5180
             // 4.Deassert NSS
             // 5.Wait until BUSY is low
 
-            // Wait for the PN8150 to be ready
+            // Wait for the PN5180 to be ready
             Stopwatch stopwatch = Stopwatch.StartNew();
             while (_gpioController.Read(_pinBusy) == PinValue.High)
             {
                 if (stopwatch.Elapsed.TotalMilliseconds >= TimeoutWaitingMilliseconds)
                 {
-                    throw new TimeoutException($"PN8150 not ready to write");
+                    throw new TimeoutException($"PN5180 not ready to write");
                 }
             }
 
@@ -1543,7 +1577,7 @@ namespace Iot.Device.Pn5180
             {
                 if (stopwatch.Elapsed.TotalMilliseconds >= TimeoutWaitingMilliseconds)
                 {
-                    throw new TimeoutException($"PN8150 is still busy after reading");
+                    throw new TimeoutException($"PN5180 is still busy after reading");
                 }
             }
 

--- a/src/devices/Pn5180/Pn5180.cs
+++ b/src/devices/Pn5180/Pn5180.cs
@@ -60,8 +60,10 @@ namespace Iot.Device.Pn5180
         /// <inheritdoc/>
         public override uint MaximumWriteSize => 260;
 
-        /// <inheritdoc/>
-        public override NfcProtocol SupportedProtocols =>
+        /// <summary>
+        /// The set of NFC protocols that are supported by this transceiver.
+        /// </summary>
+        public const NfcProtocol SupportedProtocols =
             NfcProtocol.Iso14443_3 | NfcProtocol.Iso14443_4 | NfcProtocol.Mifare |
             NfcProtocol.JisX6319_4 | NfcProtocol.Jewel | NfcProtocol.Iso15693;
 

--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -81,8 +81,10 @@ namespace Iot.Device.Pn532
         /// <inheritdoc/>
         public override uint MaximumWriteSize => 261;   // C-APDU with header, data, and Le
 
-        /// <inheritdoc/>
-        public override NfcProtocol SupportedProtocols =>
+        /// <summary>
+        /// The set of NFC protocols that are supported by this transceiver.
+        /// </summary>
+        public const NfcProtocol SupportedProtocols =
             NfcProtocol.Iso14443_3 | NfcProtocol.Iso14443_4 | NfcProtocol.Mifare |
             NfcProtocol.JisX6319_4 | NfcProtocol.Jewel;
 

--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -84,7 +84,7 @@ namespace Iot.Device.Pn532
         /// <inheritdoc/>
         public override NfcProtocol SupportedProtocols =>
             NfcProtocol.Iso14443_3 | NfcProtocol.Iso14443_4 | NfcProtocol.Mifare |
-            NfcProtocol.FeliCa | NfcProtocol.Jewel;
+            NfcProtocol.JisX6319_4 | NfcProtocol.Jewel;
 
         #region Spi and I2c Settings
 
@@ -788,7 +788,7 @@ namespace Iot.Device.Pn532
             {
                 // The PN532 supports these modes with InDataExchange
                 case NfcProtocol.Mifare:
-                case NfcProtocol.FeliCa:
+                case NfcProtocol.JisX6319_4:
                 case NfcProtocol.Jewel:
                 case NfcProtocol.Iso14443_4:
                     return TransceiveAdvance(targetNumber, dataToSend, dataFromCard);

--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -75,6 +75,17 @@ namespace Iot.Device.Pn532
         /// </summary>
         public FirmwareVersion? FirmwareVersion { get; internal set; }
 
+        /// <inheritdoc/>
+        public override uint MaximumReadSize => 258;    // R-APDU with 256 bytes of data plus SW1,SW2
+
+        /// <inheritdoc/>
+        public override uint MaximumWriteSize => 261;   // C-APDU with header, data, and Le
+
+        /// <inheritdoc/>
+        public override NfcProtocol SupportedProtocols =>
+            NfcProtocol.Iso14443_3 | NfcProtocol.Iso14443_4 | NfcProtocol.Mifare |
+            NfcProtocol.FeliCa | NfcProtocol.Jewel;
+
         #region Spi and I2c Settings
 
         /// <summary>
@@ -745,48 +756,51 @@ namespace Iot.Device.Pn532
                 return -1;
             }
 
-            if (dataFromCard.Length > 0)
+            Span<byte> toReceive = stackalloc byte[1 + dataFromCard.Length];
+            ret = ReadResponse(CommandSet.InCommunicateThru, toReceive);
+            if (ret > 0)
             {
-                Span<byte> toReceive = stackalloc byte[1 + dataFromCard.Length];
-                ret = ReadResponse(CommandSet.InCommunicateThru, toReceive);
-                toReceive.Slice(1).CopyTo(dataFromCard);
-                if ((toReceive[0] == (byte)ErrorCode.None) && (ret > 0))
+                if (dataFromCard.Length > 0)
                 {
-                    return ret - 1;
+                    toReceive.Slice(1).CopyTo(dataFromCard);
+                    if (toReceive[0] == (byte)ErrorCode.None)
+                    {
+                        return ret - 1;
+                    }
                 }
+                else
+                {
+                    // if the response is only an ACK, there is no CRC - but the PN532 reports a CRC error
+                    if ((toReceive[0] == (byte)ErrorCode.None) || (toReceive[0] == (byte)ErrorCode.CRCError))
+                    {
+                        return 0;
+                    }
+                }
+            }
 
-                return -1;
-            }
-            else
-            {
-                return 0;
-            }
+            return -1;
         }
 
-        /// <summary>
-        /// Write data to a card and read what the card responses
-        /// </summary>
-        /// <param name="targetNumber">The card target number</param>
-        /// <param name="dataToSend">The data to write to the card</param>
-        /// <param name="dataFromCard">The potential data to receive</param>
-        /// <returns>The number of bytes read</returns>
-        public override int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard)
+        /// <inheritdoc/>
+        public override int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard, NfcProtocol protocol)
         {
-            // We need to add some logic here to understand what the command is and the size of the needed buffer.
-            // For Mifare card, the authentications needs to use the native part.
-            // For non Mifare card, it should not.
-            if (((dataToSend[0] == 0x60) || (dataToSend[0] == 0x61)) && (dataFromCard.Length == 0))
+            switch (protocol)
             {
-                return TransceiveAdvance(targetNumber, dataToSend, dataFromCard);
-            }
-            else
-            {
-                return WriteReadDirect(dataToSend, dataFromCard);
+                // The PN532 supports these modes with InDataExchange
+                case NfcProtocol.Mifare:
+                case NfcProtocol.FeliCa:
+                case NfcProtocol.Jewel:
+                case NfcProtocol.Iso14443_4:
+                    return TransceiveAdvance(targetNumber, dataToSend, dataFromCard);
+
+                // Otherwise, use InCommunicateThru
+                default:
+                    return WriteReadDirect(dataToSend, dataFromCard);
             }
         }
 
         /// <summary>
-        /// Use the build in feature to transceive the data to the card. This add specific logic for some cards.
+        /// Use the built in feature to transceive the data to the card. This add specific logic for some cards.
         /// </summary>
         /// <param name="targetNumber">The card target number</param>
         /// <param name="dataToSend">The data to write to the card</param>
@@ -2103,6 +2117,7 @@ namespace Iot.Device.Pn532
             else if (_i2cDevice is object)
             {
                 Span<byte> i2cackReceived = stackalloc byte[7];
+                i2cackReceived.Clear();
                 _i2cDevice.Read(i2cackReceived);
                 i2cackReceived.Slice(1).CopyTo(ackReceived);
             }


### PR DESCRIPTION
NFC is a complex ecosystem with multiple protocols at different layers of the stack. NFC chipsets support varying combinations of these, including special handling for some protocol-specific commands. As an example, ISO/IEC 14443 is one set of RF standards, for which 14443-3 defines initialization and anticollision (of two types, A and B), and 14443-4 defines a transmission protocol atop 14443-3. However, some protocols, notably Mifare Classic and Mifare Ultralight, use a proprietary command set atop 14443-3. Mifare Classic uses a proprietary authentication scheme, so NFC chipsets implement this authentication protocol. (Alas, security by obscurity was not successful at preventing Mifare Classic authentication from being broken, particularly because it uses a relatively short 64-bit key.)

Some Mifare Classic commands require multiple RF exchanges - these include Write16Bytes, and counter operations. The PN532 provides direct support for these commands, but this must be handled in software for other transceivers.

The PN532 also provides direct support for other protocols, such as chaining and retransmission for 14443-4.

In .NET IoT, all card transceivers derive from the ```CardTransceiver``` abstract base class and override a specific implementation of the abstract ```Transceive``` method. This creates a common interface between the different NFC card types (```MifareCard```, ```Ultralight```, ```CreditCard```) and the NFC transceiver
```C#
public abstract int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard);
```

However, the diversity of protocols and transceiver support creates challenges to implement this interface. The various implementations must deduce the type of data exchange that is being performed and handle the special cases (such as Mifare authentication and Mifare writes) appropriately. However, this is difficult to do in general, because there are multiple commands, and the commands used by different protocols overlap. For example, Mifare Classic's ```AuthenticationA``` command uses the same command byte as Ultralight's ```GetVersion``` command. For transceivers that support other protocols as well (such as Innovision Jewel or FeliCa) there is an even greater risk that commands will overlap.

Therefore, this CR redefines the transceiver interface with a *breaking change*. A new enum, ```Iot.Device.Card.NfcProtocol``` defines protocols that may be understood specially by NFC transceivers. A new abstract property ```SupportedProtocols``` is added to ```CardTransceiver``` and overridden by each transceiver to indicate the protocols it supports, including:
- ISO/IEC 14443-3
- ISO/IEC 14443-4
- Mifare (Classic)
- Innovision Jewel
- JIS X 6319-4 (FeliCa)
- ISO/IEC 15693 (ICODE SLIX)

The ```Transceive``` method has an additional parameter that specifies the protocol that the caller intends to use for this transaction:
```C#
public abstract int Transceive(byte targetNumber, ReadOnlySpan<byte> dataToSend, Span<byte> dataFromCard, NfcProtocol protocol);
```

Each transceiver handles the protocols according to its specific implementation:
- ```Mfrc522``` uses this as an indication that it should handle a request as Mifare Classic (including authentiation and two-stage write operations) or 14443-3 (such as for Ultralight). [In theory the Mfrc522 could also be used for 14443-4, but its small FIFO is a significant obstacle.]
- ```Pn532``` uses this to determine whether it should invoke its special handlers for various protocols (Mifare, Jewel, FeliCa, 14443-4) or simply pass through the request (14443-3, notably for Ultralight)
- ```Pn5180``` uses this to recognize when it should perform special handling for Mifare Classic

```MifareCard``` always requests Mifare protocol. ```Ultralight``` requests 14443-3 except for the "compatibility write" command, which has the same command code as Mifare Classic's write command, and requires a two-step operation. ```CreditCard``` requests 14443-4.

In addition, two additional abstract properties are defined in ```CardTransceiver```:
```C#
public abstract uint MaximumWriteSize { get; }
public abstract uint MaximumWriteSize { get; }
```

so that callers can determine whether their requests are appropriately sized.

This also includes some miscellaneous fixes:
- added support for Mifare 2-step writes to PN5180
- changed the timeout for Type A transceive in the PN5180
- fixed a PN532 issue with commands that returned no data (e.g., Ultralight write was actually successful, but it was reported as a failure)

Tested on a Raspberry Pi 4B with MFRC522, PN532, and PN5180 using Mifare Classic and Ultralight cards. This change didn't impact the code path in PN5180 for CreditCard, but I was not able to verify that there are no regressions here.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2045)