### PR TITLE
fix encoding of NfcProtocol.cs

### DIFF
--- a/src/devices/Card/NfcProtocol.cs
+++ b/src/devices/Card/NfcProtocol.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;


### PR DESCRIPTION
Mea culpa.

Card/NfcProtocol.cs was created with the wrong encoding (was utf8, should be utf8bom)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2055)