### PR TITLE
Update .markdown-link-check.json

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,7 +1,6 @@
 {
     "ignorePatterns": [
         { "pattern": "^http[s]?://(?!(github.com|([a-zA-Z]*).microsoft.com|aka.ms|dotnetfoundation.org|www.nuget.org))" },
-        { "pattern": "^http[s]?://dev.azure.com/dnceng/internal/.*" },
         { "pattern": "../.vscode/launch.json" },
         { "pattern": "../.vscode/tasks.json" },
         { "pattern": "http://url/image" }

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,7 +1,7 @@
 {
     "ignorePatterns": [
         { "pattern": "^http[s]?://(?!(github.com|([a-zA-Z]*).microsoft.com|aka.ms|dotnetfoundation.org|www.nuget.org))" },
-        { "pattern": "^http[s]?://dev.azure.com/dnceng/internal/"},
+        { "pattern": "^http[s]?://dev.azure.com/dnceng/internal/" },
         { "pattern": "../.vscode/launch.json" },
         { "pattern": "../.vscode/tasks.json" },
         { "pattern": "http://url/image" }

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,6 +1,7 @@
 {
     "ignorePatterns": [
         { "pattern": "^http[s]?://(?!(github.com|([a-zA-Z]*).microsoft.com|aka.ms|dotnetfoundation.org|www.nuget.org))" },
+        { "pattern": "^http[s]?://dev.azure.com/dnceng/internal/"},
         { "pattern": "../.vscode/launch.json" },
         { "pattern": "../.vscode/tasks.json" },
         { "pattern": "http://url/image" }

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,7 +1,7 @@
 {
     "ignorePatterns": [
         { "pattern": "^http[s]?://(?!(github.com|([a-zA-Z]*).microsoft.com|aka.ms|dotnetfoundation.org|www.nuget.org))" },
-        { "pattern": "^http[s]?://dev.azure.com/dnceng/internal/" },
+        { "pattern": "^http[s]?://dev.azure.com/dnceng/internal/.*" },
         { "pattern": "../.vscode/launch.json" },
         { "pattern": "../.vscode/tasks.json" },
         { "pattern": "http://url/image" }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,9 +83,10 @@ stages:
     pool:
       vmImage: windows-latest
 
+    # Use Version 3.10.3 of markdown-link-check, as 3.11.0 is broken (completely ignores the json file)
     steps:
     - powershell: |
-        npm install -g markdown-link-check
+        npm install -g markdown-link-check@3.10.3
         ls -r *.md | % { markdown-link-check -v -c $(System.DefaultWorkingDirectory)\.markdown-link-check.json $_.FullName; if (-Not $?) { throw "One of the links is wrong" } }
       displayName: 'Execute markdown-link-check'
       condition: eq(variables['build.reason'], 'PullRequest')


### PR DESCRIPTION
Ignore links to internal builds from link checker. They are used as documentation for how to release.

Fixes issue seen in: https://github.com/dotnet/iot/pull/2055


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2056)