### PR TITLE
change Mfrc522.ReselectTarget to use WUPA instead of REQA

### DIFF
--- a/src/devices/Mfrc522/MifareCardCommand.cs
+++ b/src/devices/Mfrc522/MifareCardCommand.cs
@@ -10,7 +10,7 @@ namespace Iot.Device.Mfrc522
     {
         ReqA = 0x26,
         HaltA = 0x50,
-        RequestAll = 0x52,
+        WupA = 0x52,
         SelectCascadeLevel1 = 0x93, // Used for anticollision as well
         SelectCascadeLevel2 = 0x95,
         SelectCascadeLevel3 = 0x97


### PR DESCRIPTION
```Mfrc522.ReselectTarget``` is used to reselect a card, notably after an error occurs. It does a ```HALT``` and then uses ```IsCardPresent``` to reconnect with the card, which eventually uses ```REQA```. However, according to ISO 14443-3, if the card successfully executes a ```HALT``` then it will not respond to a ```REQA```; instead, the PCD is required to use ```WUPA``` (wakeup). As a result, if ```ReselectTarget``` is called when the card is not in an error state, the card is non-responsive until it is taken out of range of the transceiver so that a completely new session can begin.

This PR adds an optional ```reselect``` parameter (default ```false```) to ```IsCardPresent``` and also adds an optional ```commandCode``` parameter to the private function ```PiccRequestA``` to specify which command to send to the card. ```ReselectTarget``` uses this to request reselection with ```WUPA```.

With this change, it is now possible to halt and wake up cards. Calling ```ReselectTarget``` (typically using something like ```MifareCard.ReselectCard```) on a card that is not in error state no longer puts the card in a non-responsive state.

```Pn532.ReselectTarget``` already uses ```WUPA```., and ```Pn5180.ReselectTarget``` is not implemented for Type A.
