### PR TITLE
add ReselectAfterError property to MifareCard and UltralightCard

### DIFF
--- a/src/devices/Card/Mifare/MifareCard.cs
+++ b/src/devices/Card/Mifare/MifareCard.cs
@@ -100,6 +100,15 @@ namespace Iot.Device.Card.Mifare
         public byte[] Data { get; set; } = new byte[0];
 
         /// <summary>
+        /// Reselect the card after a card command fails
+        /// After an error, the card will not respond to any further commands
+        /// until it is reselected. If this property is false, the caller
+        /// is responsible for calling ReselectCard when RunMifareCardCommand
+        /// returns an error (-1).
+        /// </summary>
+        public bool ReselectAfterError { get; set; } = false;
+
+        /// <summary>
         /// Determine the block group corresponding to a block number
         /// </summary>
         /// <param name="blockNumber">block number</param>
@@ -158,6 +167,11 @@ namespace Iot.Device.Card.Mifare
             if ((ret > 0) && (Command == MifareCardCommand.Read16Bytes))
             {
                 Data = dataOut;
+            }
+
+            if (ret < 0 && ReselectAfterError)
+            {
+                ReselectCard();
             }
 
             return ret;

--- a/src/devices/Card/Mifare/README.md
+++ b/src/devices/Card/Mifare/README.md
@@ -35,7 +35,8 @@ var decrypted = pn532.TryDecode106kbpsTypeA(retData.AsSpan().Slice(1));
 if (decrypted is object)
 {
     Console.Write($"Tg: {decrypted.TargetNumber}, ATQA: {decrypted.Atqa} SAK: {decrypted.Sak}, NFCID: {BitConverter.ToString(decrypted.NfcId)}");
-    if (decrypted.Ats is object) {
+    if (decrypted.Ats is object)
+    {
         Console.WriteLine($", ATS: {BitConverter.ToString(decrypted.Ats)}");
     }
     else

--- a/src/devices/Card/Mifare/README.md
+++ b/src/devices/Card/Mifare/README.md
@@ -7,7 +7,18 @@ This class supports Mifare cards. They are RFID cards responding to ISO 14443 ty
 You'll need first to get the card from an RFID reader. The example below shows how to do it with a PN532 and read all the sectors and print all the sector data information.
 
 ```csharp
-byte[] retData = null;
+using System.Device.I2c;
+using Iot.Device.Pn532;
+using Iot.Device.Pn532.ListPassive;
+using Iot.Device.Card.Mifare;
+
+const int I2cBus = 1;
+
+I2cConnectionSettings i2cSettings = new(I2cBus, Pn532.I2cDefaultAddress);
+using I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);
+using Pn532 pn532 = new(i2cDevice, true);
+
+byte[]? retData = null;
 while (!Console.KeyAvailable)
 {
     retData = pn532.ListPassiveTarget(MaxTarget.One, TargetBaudRate.B106kbpsTypeA);
@@ -16,15 +27,23 @@ while (!Console.KeyAvailable)
     // Give time to PN532 to process
     Thread.Sleep(200);
 }
-if (retData is null)
+if (retData is null) {
     return;
-var decrypted = pn532.Decode106kbpsTypeA(retData.AsSpan().Slice(1));
+}
+
+var decrypted = pn532.TryDecode106kbpsTypeA(retData.AsSpan().Slice(1));
 if (decrypted is object)
 {
-    Console.WriteLine($"Tg: {decrypted.TargetNumber}, ATQA: {decrypted.Atqa} SAK: {decrypted.Sak}, NFCID: {BitConverter.ToString(decrypted.NfcId)}");
-    if (decrypted.Ats is object)
+    Console.Write($"Tg: {decrypted.TargetNumber}, ATQA: {decrypted.Atqa} SAK: {decrypted.Sak}, NFCID: {BitConverter.ToString(decrypted.NfcId)}");
+    if (decrypted.Ats is object) {
         Console.WriteLine($", ATS: {BitConverter.ToString(decrypted.Ats)}");
-    MifareCard mifareCard = new MifareCard(pn532, decrypted.TargetNumber) { BlockNumber = 0, Command = MifareCardCommand.AuthenticationA };
+    }
+    else
+    {
+        Console.WriteLine();
+    }
+
+    MifareCard mifareCard = new MifareCard(pn532, decrypted.TargetNumber) { ReselectAfterError = true };
     mifareCard.SetCapacity(decrypted.Atqa, decrypted.Sak);
     mifareCard.SerialNumber = decrypted.NfcId;
     mifareCard.KeyA = new byte[6] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
@@ -33,25 +52,28 @@ if (decrypted is object)
     {
         mifareCard.BlockNumber = block;
         mifareCard.Command = MifareCardCommand.AuthenticationB;
-        var ret = mifareCard.RunMifiCardCommand();
+        var ret = mifareCard.RunMifareCardCommand();
         if (ret < 0)
         {
             // Try another one
             mifareCard.Command = MifareCardCommand.AuthenticationA;
-            ret = mifareCard.RunMifiCardCommand();
+            ret = mifareCard.RunMifareCardCommand();
         }
 
         if (ret >= 0)
         {
             mifareCard.BlockNumber = block;
             mifareCard.Command = MifareCardCommand.Read16Bytes;
-            ret = mifareCard.RunMifiCardCommand();
+            ret = mifareCard.RunMifareCardCommand();
             if (ret >= 0)
+            {
                 Console.WriteLine($"Bloc: {block}, Data: {BitConverter.ToString(mifareCard.Data)}");
+            }
             else
             {
                 Console.WriteLine($"Error reading bloc: {block}, Data: {BitConverter.ToString(mifareCard.Data)}");
             }
+
             if (block % 4 == 3)
             {
                 // Check what are the permissions

--- a/src/devices/Card/Mifare/README.md
+++ b/src/devices/Card/Mifare/README.md
@@ -27,7 +27,9 @@ while (!Console.KeyAvailable)
     // Give time to PN532 to process
     Thread.Sleep(200);
 }
-if (retData is null) {
+
+if (retData is null)
+{
     return;
 }
 

--- a/src/devices/Card/Ultralight/UltralightCard.cs
+++ b/src/devices/Card/Ultralight/UltralightCard.cs
@@ -72,6 +72,15 @@ namespace Iot.Device.Card.Ultralight
         public byte[]? SerialNumber { get; set; }
 
         /// <summary>
+        /// Reselect the card after a card command fails
+        /// After an error, the card will not respond to any further commands
+        /// until it is reselected. If this property is false, the caller
+        /// is responsible for calling ReselectCard when RunUltralightCommand
+        /// returns an error (-1).
+        /// </summary>
+        public bool ReselectAfterError { get; set; } = false;
+
+        /// <summary>
         /// Check if this is a Ultralight card type
         /// </summary>
         /// <param name="ATQA">The ATQA</param>
@@ -310,6 +319,11 @@ namespace Iot.Device.Card.Ultralight
             if ((ret > 0) && awaitingData)
             {
                 Data = dataOut;
+            }
+
+            if (ret < 0 && ReselectAfterError)
+            {
+                ReselectCard();
             }
 
             return ret;


### PR DESCRIPTION
Add a new property ```ReselectAfterError``` to ```MifareCard``` and ```UltralightCard```. When ```true```, if an error occurs when performing an NFC transceive operation (```RunMifareCardCommand``` or ```RunUltralightCommand```, respectively), call ```ReselectCard``` to re-select the card. If it is ```false```, the caller is responsible for reselecting the card.

Update the examples in the README files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2062)