### PR TITLE
add support for Mifare application directory (resolves #2030)

### DIFF
--- a/src/devices/Card/Mifare/MifareApplicationIdentifier.cs
+++ b/src/devices/Card/Mifare/MifareApplicationIdentifier.cs
@@ -1,0 +1,157 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+
+namespace Iot.Device.Card.Mifare
+{
+    /// <summary>
+    /// Mifare application identifier as defined in https://www.nxp.com/docs/en/application-note/AN10787.pdf
+    /// This identifies an application within a Mifare application directory.
+    /// It is an unsigned 16-bit quantity (2 bytes, little-endian order)
+    /// The high-order 8 bits identify the function cluster, and
+    /// the low-order 8 bits define an application code within that cluster
+    /// </summary>
+    public struct MifareApplicationIdentifier : IEquatable<MifareApplicationIdentifier>
+    {
+        /// <summary>
+        /// Construct a MifareApplicationIdentifier from an ushort
+        /// </summary>
+        /// <param name="appId">application identifier as a ushort</param>
+        public MifareApplicationIdentifier(ushort appId) => _appId = appId;
+
+        /// <summary>
+        /// Construct a MifareApplicationIdentifier from a sequence of bytes
+        /// </summary>
+        /// <param name="bytes">two bytes representing the application identifier</param>
+        /// <exception cref="ArgumentException">the input is not 2 bytes long</exception>
+        public MifareApplicationIdentifier(ReadOnlySpan<byte> bytes) =>
+            _appId = BinaryPrimitives.ReadUInt16LittleEndian(bytes);
+
+        /// <summary>
+        /// Copy the MifareApplicationIdentifier to a sequence of bytes
+        /// </summary>
+        /// <param name="bytes">bytes that will receive the value</param>
+        /// <exception cref="ArgumentException">the output span is not 2 bytes long</exception>
+        public void CopyTo(Span<byte> bytes) => BinaryPrimitives.WriteUInt16LittleEndian(bytes, _appId);
+
+        /// <summary>
+        /// The function cluster for this application identifier (high-order 8 bits)
+        /// </summary>
+        public byte FunctionCluster => (byte)(_appId >> 8);
+
+        /// <summary>
+        /// The application code for this application identifier (low-order 8 bits)
+        /// </summary>
+        public byte ApplicationCode => (byte)(_appId & 0xff);
+
+        /// <summary>
+        /// Indicates if this is an administrative application ID
+        /// </summary>
+        public bool IsAdmin => FunctionCluster == 0;
+
+        /// <summary>
+        /// Convert to a string that represents the value in hexadecimal
+        /// </summary>
+        /// <returns>the string representation of this application identifier</returns>
+        public override string ToString() => "0x" + _appId.ToString("X4");
+
+        /// <summary>
+        /// Convert a ushort to a MifareApplicationIdentifier
+        /// </summary>
+        /// <param name="appId">application identifier as a ushort</param>
+        public static explicit operator MifareApplicationIdentifier(ushort appId) =>
+            new MifareApplicationIdentifier(appId);
+
+        /// <summary>
+        /// Convert a MifareApplicationIdentifier to a ushort
+        /// </summary>
+        /// <param name="appId">application identifier</param>
+        public static explicit operator ushort(MifareApplicationIdentifier appId) => appId._appId;
+
+        #region IEquatable
+
+        /// <summary>
+        /// Equality comparison (object)
+        /// </summary>
+        /// <param name="obj">the object to compare</param>
+        /// <returns></returns>
+        public override bool Equals(object? obj) =>
+            obj is MifareApplicationIdentifier other && Equals(other);
+
+        /// <summary>
+        /// Equality comparison (MifareApplicationIdentifier)
+        /// </summary>
+        /// <param name="other">the other MifareApplicationIdentifier to compare</param>
+        /// <returns></returns>
+        public bool Equals(MifareApplicationIdentifier other) => _appId == other._appId;
+
+        /// <summary>
+        /// Get a hash code for this object
+        /// </summary>
+        /// <returns>the hash code</returns>
+        public override int GetHashCode() => _appId.GetHashCode();
+
+        /// <summary>
+        /// Equality operator
+        /// </summary>
+        /// <param name="lhs">left hand operand to be compared</param>
+        /// <param name="rhs">right hand operand to be compared</param>
+        /// <returns>true if equal</returns>
+        public static bool operator ==(MifareApplicationIdentifier lhs, MifareApplicationIdentifier rhs) => lhs.Equals(rhs);
+
+        /// <summary>
+        /// Inequality operator
+        /// </summary>
+        /// <param name="lhs">left hand operand to be compared</param>
+        /// <param name="rhs">right hand operand to be compared</param>
+        /// <returns>true if not equal</returns>
+        public static bool operator !=(MifareApplicationIdentifier lhs, MifareApplicationIdentifier rhs) => !(lhs == rhs);
+
+        #endregion
+
+        #region statics
+
+        /// Administrative application identifiers
+
+        /// <summary>
+        /// Identifies an unallocated sector
+        /// </summary>
+        public static MifareApplicationIdentifier AdminSectorFree = new(0x0000);
+
+        /// <summary>
+        ///  Identifies a bad sector
+        ///  This sector cannot be used, e.g., because the sector trailer is not writeable or
+        ///  the authentication keys are unknown
+        /// </summary>
+        public static MifareApplicationIdentifier AdminSectorDefect = new(0x0001);
+
+        /// <summary>
+        /// Identifies a reserved sector
+        /// </summary>
+        public static MifareApplicationIdentifier AdminSectorReserved = new(0x0002);
+
+        /// <summary>
+        /// Identifies an additional directory sector
+        /// This is currently unused, reserved for future cards
+        /// </summary>
+        public static MifareApplicationIdentifier AdminSectorAdditionalDirectory = new(0x0003);
+
+        /// <summary>
+        /// Identifies a sector containing cardholder information
+        /// </summary>
+        public static MifareApplicationIdentifier AdminSectorCardHolderInformation = new(0x0004);
+
+        /// <summary>
+        /// Identifies that a sector does not exist
+        /// This is used for entries in the directory that are beyond the end of the card,
+        /// for example, sectors 32 through 39 of a 2K card
+        /// </summary>
+        public static MifareApplicationIdentifier AdminSectorNotApplicable = new(0x0005);
+
+        #endregion
+
+        private readonly ushort _appId;
+    }
+}

--- a/src/devices/Card/Mifare/MifareApplicationIdentifier.cs
+++ b/src/devices/Card/Mifare/MifareApplicationIdentifier.cs
@@ -15,6 +15,8 @@ namespace Iot.Device.Card.Mifare
     /// </summary>
     public struct MifareApplicationIdentifier : IEquatable<MifareApplicationIdentifier>
     {
+        private readonly ushort _appId;
+
         /// <summary>
         /// Construct a MifareApplicationIdentifier from an ushort
         /// </summary>
@@ -151,7 +153,5 @@ namespace Iot.Device.Card.Mifare
         public static MifareApplicationIdentifier AdminSectorNotApplicable = new(0x0005);
 
         #endregion
-
-        private readonly ushort _appId;
     }
 }

--- a/src/devices/Card/Mifare/MifareCard.cs
+++ b/src/devices/Card/Mifare/MifareCard.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using Iot.Device.Common;
 using Iot.Device.Ndef;
 using Microsoft.Extensions.Logging;
@@ -20,12 +21,8 @@ namespace Iot.Device.Card.Mifare
         private const byte BlocksPerSmallSector = 4;
         private const byte BlocksPerLargeSector = 16;
         private const byte NumberOfSmallSectors = 32;
-        private static readonly byte[] Mifare1KBlock1 = new byte[] { 0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
-        private static readonly byte[] Mifare1KBlock2 = new byte[] { 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
-        private static readonly byte[] Mifare1KBlock4 = new byte[] { 0x03, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-        private static readonly byte[] Mifare2KBlock64 = new byte[] { 0xBE, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
-        private static readonly byte[] Mifare2KBlock66 = new byte[] { 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05 };
-        private static readonly byte[] Mifare4KBlock64 = new byte[] { 0xE8, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
+        private static readonly MifareApplicationIdentifier NfcNdefId = new(0xE103);
+        private static readonly byte[] EmptyNdefBlock = new byte[] { 0x03, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
         private static readonly byte[] StaticDefaultKeyA = new byte[6] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
         private static readonly byte[] StaticDefaultKeyB = new byte[6] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
         private static readonly byte[] StaticDefaultFirstBlockNdefKeyA = new byte[6] { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5 };
@@ -810,14 +807,26 @@ namespace Iot.Device.Card.Mifare
         }
 
         /// <summary>
-        /// Format the Card to NDEF
+        /// Format the entire card to NDEF
         /// </summary>
         /// <param name="keyB">The key B to be used for formatting, if empty, will use the default key B</param>
         /// <returns>True if success</returns>
-        /// <remarks>All sectors are configured as NFC Forum sectors</remarks>
-        public bool FormatNdef(ReadOnlySpan<byte> keyB = default)
+        /// <exception cref="ArgumentException">The card size is unknown or the specified KeyB is invalid</exception>
+        public bool FormatNdef(ReadOnlySpan<byte> keyB = default) => FormatNdef(0, keyB);
+
+        /// <summary>
+        /// Format a portion of the card to NDEF
+        /// </summary>
+        /// <param name="numberOfSectors">The number of sectors for NDEF, if zero, use the entire card</param>
+        /// <param name="keyB">The key B to be used for formatting, if empty, will use the default key B</param>
+        /// <returns>True if success</returns>
+        /// <exception cref="ArgumentException">The card size is unknown or the specified KeyB is invalid</exception>
+        /// <remarks>The requested number of sectors are configured as NFC Forum sectors. To reserve some
+        /// space on the card for other purposes, specify a nonzero value for <paramref name="numberOfSectors" />
+        /// and then allocate additional applications using <see cref="MifareDirectory"/> </remarks>
+        public bool FormatNdef(uint numberOfSectors, ReadOnlySpan<byte> keyB = default)
         {
-            if (Capacity is not MifareCardCapacity.Mifare1K or MifareCardCapacity.Mifare2K or MifareCardCapacity.Mifare4K)
+            if (Capacity is not (MifareCardCapacity.Mifare1K or MifareCardCapacity.Mifare2K or MifareCardCapacity.Mifare4K))
             {
                 throw new ArgumentException($"Only Mifare card classic are supported with capacity of 1K, 2K and 4K");
             }
@@ -830,68 +839,18 @@ namespace Iot.Device.Card.Mifare
                 throw new ArgumentException($"{nameof(keyB)} can only be empty or 6 bytes length");
             }
 
-            // First write the Mifare Application Directory for the format
-            // All block data coming from https://www.nxp.com/docs/en/application-note/AN10787.pdf
-            byte[] madSectorTrailer = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x77, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-            DefaultFirstBlockNdefKeyA.CopyTo(madSectorTrailer);
-            madSectorTrailer[9] = Capacity == MifareCardCapacity.Mifare1K ? (byte)0xC1 : (byte)0xC2;
-            keyFormat.CopyTo(madSectorTrailer, 10);
-            var authOk = AuthenticateBlockKeyB(keyFormat, 1);
-            Data = Mifare1KBlock1;
-            authOk &= WriteDataBlock(1);
-            authOk &= AuthenticateBlockKeyB(keyFormat, 2);
-            Data = Mifare1KBlock2;
-            authOk &= WriteDataBlock(2);
-            authOk &= AuthenticateBlockKeyB(keyFormat, 3);
-            Data = madSectorTrailer;
-            authOk &= WriteDataBlock(3);
+            // Create and write the Mifare Application Directory
+            MifareDirectory directory = MifareDirectory.CreateEmpty(this);
+            MifareDirectoryEntry? ndefEntry = directory.Allocate(NfcNdefId, numberOfSectors);
+            var formatOk = (ndefEntry != null) && directory.StoreToCard(keyFormat);
 
-            if (Capacity == MifareCardCapacity.Mifare2K)
-            {
-                byte block = 16 * 4;
-                authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                Data = Mifare2KBlock64;
-                authOk &= WriteDataBlock(block);
-                block++;
-                authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                Data = Mifare1KBlock2; // 65 is same as 2
-                authOk &= WriteDataBlock(block);
-                block++;
-                authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                Data = Mifare2KBlock66;
-                authOk &= WriteDataBlock(block);
-                block++;
-                authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                Data = madSectorTrailer;
-                authOk &= WriteDataBlock(block);
-            }
-            else if (Capacity == MifareCardCapacity.Mifare4K)
-            {
-                byte block = 16 * 4;
-                authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                Data = Mifare4KBlock64;
-                authOk &= WriteDataBlock(block);
-                block++;
-                authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                Data = Mifare1KBlock2; // 65 is same as 2
-                authOk &= WriteDataBlock(block);
-                block++;
-                authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                Data = Mifare1KBlock2; // 66 is same as 2
-                authOk &= WriteDataBlock(block);
-                block++;
-                authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                Data = madSectorTrailer;
-                authOk &= WriteDataBlock(block);
-            }
+            // Write the empty NDEF TLV in the first NFC sector
+            byte ndefBlockNumber = ndefEntry?.GetAllDataBlocks().FirstOrDefault() ?? 0;
+            formatOk &= (ndefBlockNumber != 0) && AuthenticateBlockKeyB(keyFormat, ndefBlockNumber);
+            Data = EmptyNdefBlock;
+            formatOk &= WriteDataBlock(ndefBlockNumber);
 
-            // write the empty NDEF TLV in the first NFC sector
-            authOk &= AuthenticateBlockKeyB(keyFormat, 4);
-            Data = Mifare1KBlock4;
-            authOk &= WriteDataBlock(4);
-
-            // GBP should be 0xC1 for the MAD sectors and 0x40 for the others for a full read/write access
-            // We wrote the MAD sector trailers above, so we write the NFC sector trailers here
+            // We wrote the MAD sector trailers already, so we write the NFC sector trailers here
             Data = new byte[] { 0, 0, 0, 0, 0, 0, 0x7F, 0x07, 0x88, 0x40, 0, 0, 0, 0, 0, 0 };
             DefaultBlocksNdefKeyA.CopyTo(Data);
             keyFormat.CopyTo(Data, 10);
@@ -900,20 +859,25 @@ namespace Iot.Device.Card.Mifare
                 if (sector != 16)
                 {
                     byte block = SectorToBlockNumber(sector, 3);
-                    authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                    authOk &= WriteDataBlock(block);
+                    formatOk &= AuthenticateBlockKeyB(keyFormat, block);
+                    formatOk &= WriteDataBlock(block);
                 }
             }
 
-            return authOk;
+            return formatOk;
         }
 
         /// <summary>
         /// Write an NDEF Message
         /// </summary>
         /// <param name="message">The NDEF Message to write</param>
-        /// <param name="writeKeyA">True to write with Key A</param>
+        /// <param name="writeKeyA">True to write with Key A, false to write with Key B</param>
         /// <returns>True if success</returns>
+        /// <exception cref="ArgumentException">If using KeyB, it must be 6 bytes long</exception>
+        /// <exception cref="InvalidOperationException">The card is not formatted for NDEF</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The message to be written is larger than the available space on the card</exception>
+        /// <remarks>The Mifare application directory indicates range of sectors for NDEF. Normally,
+        /// these begin at sector 1. The message must fit within the allocated space on the card.</remarks>
         public bool WriteNdefMessage(NdefMessage message, bool writeKeyA = true)
         {
             if ((KeyB is not object or { Length: not 6 }) && (!writeKeyA))
@@ -939,194 +903,64 @@ namespace Iot.Device.Card.Mifare
 
             serializedMessage[serializedMessage.Length - 1] = 0xFE;
 
+            // Get NDEF application entry from Mifare application directory
+            MifareDirectory? directory = MifareDirectory.LoadFromCard(this);
+            MifareDirectoryEntry ndefEntry =
+                directory?.TryGetApplication(NfcNdefId) ?? throw new InvalidOperationException("card is not formatted for NDEF");
+
             // Number of blocks to write
-            int nbBlocks = serializedMessage.Length / 16 + (serializedMessage.Length % 16 > 0 ? 1 : 0);
-            switch (Capacity)
+            int nbBlocks = (serializedMessage.Length + BytesPerBlock - 1) / BytesPerBlock;
+            if (nbBlocks > ndefEntry.NumberOfBlocks)
             {
-                default:
-                case MifareCardCapacity.Unknown:
-                case MifareCardCapacity.Mifare300:
-                    throw new ArgumentException($"Mifare card unknown and 300 are not supported for writing");
-                case MifareCardCapacity.Mifare2K:
-                    // Total blocks where we can write = 30 * 3 = 90
-                    if (nbBlocks > 90)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(message), $"NNDEF message too large, maximum {90 * 16} bytes, current size is {nbBlocks * 16}");
-                    }
-
-                    break;
-                case MifareCardCapacity.Mifare4K:
-                    // Total blocks where we can write = 30 * 3 + 8 * 15 = 210
-                    if (nbBlocks > 210)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(message), $"NNDEF message too large, maximum {210 * 16} bytes, current size is {nbBlocks * 16}");
-                    }
-
-                    break;
-                case MifareCardCapacity.Mifare1K:
-                    // Total blocks where we can write = 15 * 3 = 45
-                    if (nbBlocks > 45)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(message), $"NNDEF message too large, maximum {45 * 16} bytes, current size is {nbBlocks * 16}");
-                    }
-
-                    break;
+                uint maximumNumberOfBytes = ndefEntry.NumberOfBlocks * BytesPerBlock;
+                throw new ArgumentOutOfRangeException(nameof(message), $"NDEF message too large, maximum {maximumNumberOfBytes} bytes, current size is {serializedMessage.Length} bytes");
             }
 
-            int inc = 4;
-            bool ret;
-            for (int block = 0; block < nbBlocks; block++)
+            bool Authenticate(byte block) => writeKeyA ? AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, block) : AuthenticateBlockKeyB(KeyB!, block);
+            Data = new byte[BytesPerBlock];
+            bool ret = true;
+            IEnumerator<byte> sectorBlocks = ndefEntry.GetAllDataBlocks().GetEnumerator();
+            for (int byteOffset = 0; byteOffset < serializedMessage.Length; byteOffset += BytesPerBlock)
             {
-                if (IsSectorBlock((byte)(block + inc)))
+                if (!sectorBlocks.MoveNext())
                 {
-                    inc++;
+                    // this "can't happen" because we checked the size above
+                    ret = false;
+                    break;
                 }
 
-                // Skip as well sector 16 for 2K and 4K cards
-                if (block == 16 * 4)
-                {
-                    inc += 4;
-                }
-
-                // Safe cast, max is 255 in all cases
-                if (!writeKeyA)
-                {
-                    ret = AuthenticateBlockKeyB(KeyB!, (byte)(block + inc));
-                }
-                else
-                {
-                    ret = AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, (byte)(block + inc));
-                }
-
-                if (!ret)
-                {
-                    return false;
-                }
-
-                if (block * 16 + 16 <= serializedMessage.Length)
-                {
-                    Data = serializedMessage.Slice(block * 16, 16).ToArray();
-                }
-                else
-                {
-                    Data = new byte[16];
-                    serializedMessage.Slice(block * 16).CopyTo(Data);
-                }
-
-                if (!WriteDataBlock((byte)(block + inc)))
-                {
-                    return false;
-                }
+                // copy the next block, filling with zeros at the end of the last block
+                int dataLen = Math.Min(BytesPerBlock, serializedMessage.Length - byteOffset);
+                serializedMessage.Slice(byteOffset, dataLen).CopyTo(Data);
+                Array.Clear(Data, dataLen, BytesPerBlock - dataLen);
+                ret &= Authenticate(sectorBlocks.Current) && WriteDataBlock(sectorBlocks.Current);
             }
 
-            return true;
+            return ret;
         }
 
         /// <summary>
-        /// Check if the card formated to NDEF
+        /// Check if the card is formatted to NDEF
         /// </summary>
         /// <returns>True if NDEF formatted</returns>
-        /// <remarks>It will only check the first 2 block of the first sector and that the GPB is set properly</remarks>
-        /// TODO: support formatted cards where some sectors are used for other purposes
+        /// <remarks>This checks for a Mifare application directory in sector 0 and
+        /// (for 2K and 4K cards) sector 16, that there is an NDEF application, that
+        /// the sector trailer is readable in all sectors in that application, and
+        /// that the GPB byte is set correctly in the trailers.</remarks>
         public bool IsFormattedNdef()
         {
-            int nbBlocks = GetNumberBlocks();
-
-            if (KeyA is not object or { Length: not 6 })
+            MifareDirectory? directory = MifareDirectory.LoadFromCard(this);
+            MifareDirectoryEntry? ndefEntry = directory?.TryGetApplication(NfcNdefId);
+            bool ret = (ndefEntry != null);
+            foreach (byte sector in ndefEntry?.GetAllSectors() ?? Enumerable.Empty<byte>())
             {
-                throw new ArgumentException($"{nameof(KeyA)} can only be empty or 6 bytes length");
+                byte sectorBlock = SectorToBlockNumber(sector, 3);
+                ret &= AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, sectorBlock);
+                ret &= ReadDataBlock(sectorBlock);
+                ret &= (Data[9] == 0x40);
             }
 
-            if (Data is not object or { Length: not 6 })
-            {
-                Data = new byte[6];
-            }
-
-            // First write the data for the format
-            // All block data coming from https://www.nxp.com/docs/en/application-note/AN10787.pdf
-            var authOk = AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, 1);
-            authOk &= ReadDataBlock(1);
-            authOk &= Data.SequenceEqual(Mifare1KBlock1);
-            authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, 2);
-            authOk &= ReadDataBlock(2);
-            authOk &= Data.SequenceEqual(Mifare1KBlock2);
-
-            if (Capacity == MifareCardCapacity.Mifare2K)
-            {
-                byte block = 16 * 4;
-                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
-                authOk &= ReadDataBlock(block);
-                authOk &= Data.SequenceEqual(Mifare2KBlock64);
-                block++;
-                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
-                authOk &= ReadDataBlock(block);
-                authOk &= Data.SequenceEqual(Mifare1KBlock2); // 65 is same as 2
-                block++;
-                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
-                authOk &= ReadDataBlock(block);
-                authOk &= Data.SequenceEqual(Mifare2KBlock66);
-            }
-            else if (Capacity == MifareCardCapacity.Mifare4K)
-            {
-                byte block = 16 * 4;
-                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
-                authOk &= ReadDataBlock(block);
-                authOk &= Data.SequenceEqual(Mifare4KBlock64);
-                block++;
-                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
-                authOk &= ReadDataBlock(block);
-                authOk &= Data.SequenceEqual(Mifare1KBlock2); // 65 is same as 2
-                block++;
-                authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, block);
-                authOk &= ReadDataBlock(block);
-                authOk &= Data.SequenceEqual(Mifare1KBlock2); // 66 is same as 2
-            }
-
-            // GBP should be 0xC1 for the MAD sectors and 0x40 for the others for a full read/write access
-            for (int block = 0; block < nbBlocks; block++)
-            {
-                // Safe cast, max is 255
-                if (IsSectorBlock((byte)block))
-                {
-                    if ((block == 3) || (block == 67))
-                    {
-                        authOk &= AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, (byte)block);
-                    }
-                    else
-                    {
-                        authOk &= AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, (byte)block);
-                    }
-
-                    if (authOk)
-                    {
-                        authOk &= ReadDataBlock((byte)block);
-                        if (authOk)
-                        {
-                            byte gpb = 0x40;
-                            // Change only the GPB byte
-                            if ((block == 3) || (block == 67))
-                            {
-                                switch (Capacity)
-                                {
-                                    case MifareCardCapacity.Mifare4K:
-                                    case MifareCardCapacity.Mifare2K:
-                                        gpb = 0xC2;
-                                        break;
-                                    case MifareCardCapacity.Unknown:
-                                    case MifareCardCapacity.Mifare300:
-                                    case MifareCardCapacity.Mifare1K:
-                                        gpb = 0xC1;
-                                        break;
-                                }
-                            }
-
-                            authOk &= Data[9] == gpb;
-                        }
-                    }
-                }
-            }
-
-            return authOk;
+            return ret;
         }
 
         /// <summary>
@@ -1162,99 +996,61 @@ namespace Iot.Device.Card.Mifare
         /// </summary>
         /// <param name="message">The NDEF message</param>
         /// <returns>True if success</returns>
+        /// <remarks>The Mifare application directory indicates the range of sectors used for NDEF. Normally
+        /// these begin at sector 1.</remarks>
         public bool TryReadNdefMessage(out NdefMessage message)
         {
-            const int BlockSize = 16;
             message = new NdefMessage();
 
-            int cardSize;
-            switch (Capacity)
+            // Get the NDEF application from the directory
+            MifareDirectory? directory = MifareDirectory.LoadFromCard(this);
+            MifareDirectoryEntry? ndefEntry = directory?.TryGetApplication(NfcNdefId);
+            if (ndefEntry == null)
             {
-                case MifareCardCapacity.Mifare1K:
-                    // 15 sectors, 3 blocks, 16 bytes
-                    cardSize = 720;
-                    break;
-                case MifareCardCapacity.Mifare2K:
-                    // 30 sectors, 3 blocks, 16 bytes
-                    cardSize = 1440;
-                    break;
-                case MifareCardCapacity.Mifare4K:
-                    // 62 sectors, 3 blocks, 16 bytes
-                    cardSize = 2976;
-                    break;
-                /* We don't support those
-                case MifareCardCapacity.Mifare300:
-                case MifareCardCapacity.Unknown */
-                default:
-                    throw new NotSupportedException();
+                return false;
             }
 
-            if (KeyB is not object or { Length: not 6 })
-            {
-                KeyB = StaticDefaultKeyB;
-            }
-
-            // Read block 4 and check for the data, it should be present in this one
-            var authOk = AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, 4);
-            authOk &= ReadDataBlock(4);
-
+            // Read the first NDEF data block
+            IEnumerator<byte> dataBlocks = ndefEntry.GetAllDataBlocks().GetEnumerator();
+            dataBlocks.MoveNext();
+            var authOk = AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, dataBlocks.Current);
+            authOk &= ReadDataBlock(dataBlocks.Current);
             if (!authOk)
             {
                 return false;
             }
 
             var (start, size) = NdefMessage.GetStartSizeNdef(Data.AsSpan());
-
             if ((start < 0) || (size < 0))
             {
                 return false;
             }
 
-            // calculate the size to read
-            int blocksToRead = (size + start) / BlockSize + ((size + start) % BlockSize != 0 ? 1 : 0);
-
-            // We would have to read more available data than the capacity
-            if (cardSize < blocksToRead * BlockSize)
+            // calculate the number of blocks to read, which must fit within the application
+            int blocksToRead = (size + start + BytesPerBlock - 1) / BytesPerBlock;
+            if (ndefEntry.NumberOfBlocks < blocksToRead)
             {
                 return false;
             }
 
-            Span<byte> card = new byte[blocksToRead * BlockSize];
+            Span<byte> card = new byte[blocksToRead * BytesPerBlock];
             Data.CopyTo(card);
 
-            byte idxCard = 1;
-            int block = 5;
-            while (idxCard < blocksToRead)
+            for (int byteIndex = BytesPerBlock; byteIndex < size + start; byteIndex += BytesPerBlock)
             {
-                // Skip sector blocks, safe cast, max is 255
-                if (IsSectorBlock((byte)block))
+                if (!dataBlocks.MoveNext())
                 {
-                    block++;
-                    continue;
+                    // this "can't happen" because we checked the size above
+                    return false;
                 }
 
-                // Skip as well sector 16 for 2K and 4K cards
-                if ((block == 16 * 4) || (block == 16 * 4 + 1) || (block == 16 * 4 + 2) || (block == 16 * 4 + 3))
-                {
-                    block++;
-                    continue;
-                }
-
-                authOk = AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, (byte)block);
-                if (!authOk)
+                if (!AuthenticateBlockKeyA(StaticDefaultBlocksNdefKeyA, dataBlocks.Current) ||
+                    !ReadDataBlock(dataBlocks.Current))
                 {
                     return false;
                 }
 
-                authOk = ReadDataBlock((byte)block);
-                if (!authOk)
-                {
-                    return false;
-                }
-
-                Data.CopyTo(card.Slice(idxCard * BlockSize));
-                idxCard++;
-                block++;
+                Data.CopyTo(card.Slice(byteIndex));
             }
 
             var ndef = NdefMessage.ExtractMessage(card);

--- a/src/devices/Card/Mifare/MifareDirectory.cs
+++ b/src/devices/Card/Mifare/MifareDirectory.cs
@@ -1,0 +1,412 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Iot.Device.Card.Mifare
+{
+    /// <summary>
+    /// Mifare application directory
+    /// This describes the assignent of sectors on the MifareCard to applications.
+    /// The on-card directory is described in https://www.nxp.com/docs/en/application-note/AN10787.pdf
+    /// </summary>
+    public class MifareDirectory
+    {
+        /// <summary>
+        /// Create an empty MifareDirectory for a specified MifareCard
+        /// </summary>
+        /// <param name="card">the card associated with this directory</param>
+        /// <exception cref="ArgumentException">the card capacity must be 1K, 2K, or 4K</exception>
+        /// <remarks>This allocates a maximum size directory (5 blocks == 80 bytes),
+        /// which is stored in sector 0, blocks 1 and 2, and (for 2K and 4K cards)
+        /// in sector 16 blocks 64, 65, and 66. Sectors are marked as free (0);
+        /// sectors beyond the end of the card are marked as NotApplicable.</remarks>
+        public static MifareDirectory CreateEmpty(MifareCard card) => new(card);
+
+        /// <summary>
+        /// Load the MifareDirectory from a specified MifareCard
+        /// The directory blocks must have the correct Akey and access bytes.
+        /// The directory CRC must be valid.
+        /// </summary>
+        /// <param name="card">the card whose directory is being loaded</param>
+        /// <exception cref="ArgumentException">the card capacity must be 1K, 2K, or 4K</exception>
+        /// <returns>new MifareDirectory if success, null if error</returns>
+        /// <remarks>This always returns a maximum size directory (5 blocks == 80 bytes),
+        /// regardless of the card size. Sectors beyond the end of the card are
+        /// marked as NotApplicable.</remarks>
+        public static MifareDirectory? LoadFromCard(MifareCard card)
+        {
+            MifareDirectory directory = new MifareDirectory(card);
+
+            // authenticate to the first block and check the GPB in the sector trailer
+            card.BlockNumber = MifareCard.SectorToBlockNumber(0, 3);
+            card.KeyA = MifareCard.DefaultFirstBlockNdefKeyA.ToArray();
+            card.Command = MifareCardCommand.AuthenticationA;
+            if (card.RunMifareCardCommand() < 0)
+            {
+                return null;
+            }
+
+            card.Command = MifareCardCommand.Read16Bytes;
+            if (card.RunMifareCardCommand() < 0)
+            {
+                return null;
+            }
+
+            if ((card.Capacity == MifareCardCapacity.Mifare1K && card.Data[9] != 0xC1) ||
+                (card.Capacity != MifareCardCapacity.Mifare1K && card.Data[9] != 0xC2))
+            {
+                return null;
+            }
+
+            // read the two directory blocks in sector 0
+            for (byte i = 0; i < 2; i++)
+            {
+                card.BlockNumber = MifareCard.SectorToBlockNumber(0, (byte)(i + 1));
+                if (card.RunMifareCardCommand() < 0)
+                {
+                    return null;
+                }
+
+                card.Data.CopyTo(directory._data, i * 16);
+            }
+
+            // verify the checksum
+            if (CalculateCrc(directory._data.AsSpan(1, 31)) != directory._data[0])
+            {
+                return null;
+            }
+
+            if (card.Capacity == MifareCardCapacity.Mifare2K || card.Capacity == MifareCardCapacity.Mifare4K)
+            {
+                // authenticate to block 16 (second directory block) and check the GPB in its sector trailer
+                card.BlockNumber = MifareCard.SectorToBlockNumber(16, 3);
+                card.Command = MifareCardCommand.AuthenticationA;
+                if (card.RunMifareCardCommand() < 0)
+                {
+                    return null;
+                }
+
+                card.Command = MifareCardCommand.Read16Bytes;
+                if (card.RunMifareCardCommand() < 0)
+                {
+                    return null;
+                }
+
+                if (card.Data[9] != 0xC2)
+                {
+                    return null;
+                }
+
+                // read the three directory blocks in sector 16
+                for (byte i = 0; i < 3; i++)
+                {
+                    card.BlockNumber = MifareCard.SectorToBlockNumber(16, i);
+                    if (card.RunMifareCardCommand() < 0)
+                    {
+                        return null;
+                    }
+
+                    card.Data.CopyTo(directory._data, (i + 2) * 16);
+                }
+
+                // verify the checksum
+                if (CalculateCrc(directory._data.AsSpan(1 + (2 * 16), (3 * 16) - 1)) != directory._data[2 * 16])
+                {
+                    return null;
+                }
+            }
+
+            return directory;
+        }
+
+        /// <summary>
+        /// Calculate the CRC byte for a Mifare application directory segment
+        /// </summary>
+        /// <param name="data">The data bytes in the directory segment</param>
+        /// <returns>Checksum byte</returns>
+        public static byte CalculateCrc(ReadOnlySpan<byte> data)
+        {
+            byte crc = 0xc7;
+            foreach (byte b in data)
+            {
+                crc ^= b;
+                for (int i = 0; i < 8; i++)
+                {
+                    bool msb = (crc & 0x80) != 0;
+                    crc <<= 1;
+                    if (msb)
+                    {
+                        crc ^= 0x1d;
+                    }
+                }
+            }
+
+            return crc;
+        }
+
+        // recalculate the CRC bytes in the two portions of the directory
+        private void RecalculateCrc()
+        {
+            _data[0] = CalculateCrc(_data.AsSpan(1, 2 * 16 - 1));
+            _data[32] = CalculateCrc(_data.AsSpan(1 + (2 * 16), 3 * 16 - 1));
+        }
+
+        // private constructor - callers use CreateNew or LoadFromCard
+        private MifareDirectory(MifareCard card)
+        {
+            if (card.Capacity is not (MifareCardCapacity.Mifare1K or MifareCardCapacity.Mifare2K or MifareCardCapacity.Mifare4K))
+            {
+                throw new ArgumentException("Only MifareCard capacities 1K, 2K and 4K are supported");
+            }
+
+            _card = card;
+            _data = new byte[80];
+            Span<byte> notApplicable = stackalloc byte[2];
+            MifareApplicationIdentifier.AdminSectorNotApplicable.CopyTo(notApplicable);
+            for (int i = card.GetNumberSectors(); i < 40; i++)
+            {
+                notApplicable.CopyTo(_data.AsSpan(i * 2, 2));
+            }
+
+            RecalculateCrc();
+        }
+
+        /// <summary>
+        /// Store the MifareDirectory to its MifareCard
+        /// </summary>
+        /// <param name="keyB">authentication key B for the directory sectors</param>
+        /// <returns>true if successful, false in case of failure</returns>
+        public bool StoreToCard(ReadOnlySpan<byte> keyB)
+        {
+            bool hasSector16 = (_card.Capacity != MifareCardCapacity.Mifare1K);
+            _card.KeyB = keyB.ToArray();
+            byte[] trailerBlocks = hasSector16 ? new byte[] { 3, 67 } : new byte[] { 3 };
+
+            // create the sector trailer for the directory blocks
+            byte[] trailer = new byte[16] { 0, 0, 0, 0, 0, 0, 0x78, 0x77, 0x88, 0xC1, 0, 0, 0, 0, 0, 0 };
+            MifareCard.DefaultFirstBlockNdefKeyA.CopyTo(trailer);
+            trailer[9] = (byte)(hasSector16 ? 0xC2 : 0xC1);
+            keyB.CopyTo(trailer.AsSpan(10));
+
+            // write the sector trailer in block 0 and (if applicable) block 16
+            foreach (byte block in trailerBlocks)
+            {
+                _card.Data = trailer;
+                _card.BlockNumber = block;
+                _card.Command = MifareCardCommand.AuthenticationB;
+                if (_card.RunMifareCardCommand() < 0)
+                {
+                    return false;
+                }
+
+                _card.Command = MifareCardCommand.Write16Bytes;
+                if (_card.RunMifareCardCommand() < 0)
+                {
+                    return false;
+                }
+            }
+
+            // write the directory blocks in sector 0 and (if applicable) sector 16
+            byte[] directoryBlocks = hasSector16 ? new byte[] { 1, 2, 64, 65, 66 } : new byte[] { 1, 2 };
+            _card.Data = new byte[16];
+            for (int i = 0; i < directoryBlocks.Length; i++)
+            {
+                _data.AsSpan(i * 16, 16).CopyTo(_card.Data);
+                _card.BlockNumber = directoryBlocks[i];
+                _card.Command = MifareCardCommand.AuthenticationB;
+                if (_card.RunMifareCardCommand() < 0)
+                {
+                    return false;
+                }
+
+                _card.Command = MifareCardCommand.Write16Bytes;
+                if (_card.RunMifareCardCommand() < 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Card publisher sector (if any)
+        /// If non-zero, this indicates the sector that is allocated to the card publisher.
+        /// </summary>
+        /// <remarks>
+        /// <exception cref="ArgumentOutOfRangeException">the sector number is too large or is equal to 0x10</exception>
+        /// According to https://www.nxp.com/docs/en/application-note/AN10787.pdf , 2K and 4K
+        /// cards can optionally indicate a second card publisher sector in the directory in sector 16.
+        /// This implementation does not support that configuration: it provides no way to get the
+        /// second value, and setting this property will change both to the same value.
+        /// </remarks>
+        public byte CardPublisherSector
+        {
+            get => _data[1];
+            set
+            {
+                if (value == 0x10 || value >= _card.GetNumberSectors())
+                {
+                    throw new ArgumentOutOfRangeException(nameof(CardPublisherSector), "the sector number is too large or is equal to 0x10");
+                }
+
+                _data[1] = value;
+                _data[33] = _data[1];
+                RecalculateCrc();
+            }
+        }
+
+        /// <summary>
+        /// Get directory entries for all applications matching a particular filter criterion
+        /// </summary>
+        /// <param name="matchFilter">match condition for each application ID; if null, matches every non-administrative application</param>
+        /// <returns>all directory entries that match the filter criterion</returns>
+        public IEnumerable<MifareDirectoryEntry> GetApplications(Func<MifareApplicationIdentifier, bool>? matchFilter = null)
+        {
+            if (matchFilter == null)
+            {
+                matchFilter = (appId) => !appId.IsAdmin;
+            }
+
+            for (int startIndex = 2; startIndex < _data.Length;)
+            {
+                ReadOnlySpan<byte> appIdBytes = _data.AsSpan(startIndex, 2);
+                MifareApplicationIdentifier appId = new(appIdBytes);
+                int index = startIndex;
+                uint numberOfSectors = 0;
+                while (index < _data.Length)
+                {
+                    if (index == 32)
+                    {
+                        index += 2;
+                    }
+
+                    if (!appIdBytes.SequenceEqual(_data.AsSpan(index, 2)))
+                    {
+                        break;
+                    }
+
+                    index += 2;
+                    numberOfSectors++;
+                }
+
+                if (matchFilter(appId))
+                {
+                    yield return new MifareDirectoryEntry(appId, (byte)(startIndex / 2), numberOfSectors);
+                }
+
+                startIndex = index;
+            }
+        }
+
+        /// <summary>
+        /// Try to get a directory entry for a particular application ID
+        /// </summary>
+        /// <param name="matchAppId">application ID of desired application</param>
+        /// <returns>directory entry for the specified application (or null if it is not present in the directory)</returns>
+        public MifareDirectoryEntry? TryGetApplication(MifareApplicationIdentifier matchAppId) =>
+            GetApplications((appId) => appId == matchAppId).FirstOrDefault();
+
+        /// <summary>
+        /// Allocate sectors in the directory for a specified application
+        /// This only updates the directory, not the application's data blocks or sector trailers.
+        /// The directory must be written back to the card with <see cref="StoreToCard"/>.
+        /// Specifying an allocation of 0 sectors will cause the largest available contiguous
+        /// set of sectors to be allocated to this application. If the directory is
+        /// empty, this allocates everything.
+        /// </summary>
+        /// <param name="appId">the application to be allocated</param>
+        /// <param name="numberOfSectors">the number of sectors to be allocated</param>
+        /// <returns>a directory entry for the new application or null if the allocation fails</returns>
+        /// <remarks>The allocation is based upon sectors, not blocks. On a 4K card,
+        /// the first 32 sectors are 4 blocks (3 data blocks plus the sector trailer)
+        /// and the last 8 sectors are 16 blocks (15 dsata blocks plus the sector trailer).</remarks>
+        public MifareDirectoryEntry? Allocate(MifareApplicationIdentifier appId, uint numberOfSectors = 0)
+        {
+            if (appId.IsAdmin)
+            {
+                // don't allow allocation with Admin application IDs
+                return null;
+            }
+
+            MifareDirectoryEntry? best = null;
+            foreach (var entry in GetApplications((appId) => appId == MifareApplicationIdentifier.AdminSectorFree))
+            {
+                if (numberOfSectors == 0)
+                {
+                    if (best == null || entry.NumberOfSectors > best.NumberOfSectors)
+                    {
+                        best = entry;
+                    }
+                }
+                else if (entry.NumberOfSectors >= numberOfSectors)
+                {
+                    if (best == null || entry.NumberOfSectors < best.NumberOfSectors)
+                    {
+                        best = entry;
+                    }
+                }
+            }
+
+            if (best != null)
+            {
+                // relabel the sectors in the directory and return the new directory entry
+                return ReassignSectors(best, numberOfSectors != 0 ? numberOfSectors : best.NumberOfSectors, appId);
+            }
+            else
+            {
+                // unable to satisfy the request
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Free the sectors associated with the specified directory entry
+        /// This only updates the directory, not the data blocks or sector trailers.
+        /// The directory must be written back to the card with <see cref="StoreToCard"/>.
+        /// If the sectors cannot be reused for some reason, such as if the authentication key
+        /// has been lost or the sector trailer is read-only, then the sectors should be freed as
+        /// "defective" so that they will not be available for reallocation.
+        /// </summary>
+        /// <param name="entry">the directory entry to be freed</param>
+        /// <param name="defective">if true, the freed sectors will not be available for reallocation</param>
+        public void Free(MifareDirectoryEntry entry, bool defective = true)
+        {
+            var appId = defective ? MifareApplicationIdentifier.AdminSectorDefect : MifareApplicationIdentifier.AdminSectorFree;
+            ReassignSectors(entry, entry.NumberOfSectors, appId);
+        }
+
+        // assign the first numberOfSectors in a directory entry to a specified application identifier
+        private MifareDirectoryEntry ReassignSectors(MifareDirectoryEntry entry, uint numberOfSectors, MifareApplicationIdentifier appId)
+        {
+            if (numberOfSectors > entry.NumberOfSectors)
+            {
+                throw new ArgumentException("number of sectors exceeds the size of the directory entry");
+            }
+
+            Span<byte> appIdBytes = stackalloc byte[2];
+            appId.CopyTo(appIdBytes);
+            int index = entry.FirstSector * 2;
+            for (uint n = 0; n < numberOfSectors; n++)
+            {
+                if (index == 32)
+                {
+                    index += 2;
+                }
+
+                appIdBytes.CopyTo(_data.AsSpan(index));
+                index += 2;
+            }
+
+            RecalculateCrc();
+            return new MifareDirectoryEntry(appId, entry.FirstSector, numberOfSectors);
+        }
+
+        private readonly MifareCard _card;
+        private readonly byte[] _data;
+    }
+}

--- a/src/devices/Card/Mifare/MifareDirectory.cs
+++ b/src/devices/Card/Mifare/MifareDirectory.cs
@@ -15,6 +15,9 @@ namespace Iot.Device.Card.Mifare
     /// </summary>
     public class MifareDirectory
     {
+        private readonly MifareCard _card;
+        private readonly byte[] _data;
+
         /// <summary>
         /// Create an empty MifareDirectory for a specified MifareCard
         /// </summary>
@@ -405,8 +408,5 @@ namespace Iot.Device.Card.Mifare
             RecalculateCrc();
             return new MifareDirectoryEntry(appId, entry.FirstSector, numberOfSectors);
         }
-
-        private readonly MifareCard _card;
-        private readonly byte[] _data;
     }
 }

--- a/src/devices/Card/Mifare/MifareDirectoryEntry.cs
+++ b/src/devices/Card/Mifare/MifareDirectoryEntry.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Iot.Device.Card.Mifare
+{
+    /// <summary>
+    /// Describes the sectors assigned to a Mifare application in the directory.
+    /// Sector 0 and (on cards larger than 1K) sector 16 are used for the directory.
+    /// Mifare applications are assigned a contiguous range of sectors, except
+    /// that the assignment is discontiguous across sector 16 (which is skipped)
+    /// </summary>
+    public class MifareDirectoryEntry
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="appId">application identifier</param>
+        /// <param name="firstSector">first sector assigned to this application</param>
+        /// <param name="numberOfSectors">number of sectors assigned to this application</param>
+        public MifareDirectoryEntry(MifareApplicationIdentifier appId, byte firstSector, uint numberOfSectors)
+        {
+            ApplicationIdentifier = appId;
+            FirstSector = firstSector;
+            NumberOfSectors = numberOfSectors;
+        }
+
+        /// <summary>
+        /// Mifare application identifier
+        /// </summary>
+        public MifareApplicationIdentifier ApplicationIdentifier { get; }
+
+        /// <summary>
+        /// First assigned sector
+        /// </summary>
+        public byte FirstSector { get; }
+
+        /// <summary>
+        /// Number of sectors
+        /// </summary>
+        public uint NumberOfSectors { get; }
+
+        /// <summary>
+        /// Number of data blocks
+        /// This is not simply a multiple of the number of sectors, because the
+        /// last eight sectors on a 4K card are larger than the first 32.
+        /// </summary>
+        public uint NumberOfBlocks
+        {
+            get
+            {
+                // There are two directory sectors (0 and 16), and sectors 32 and above are larger
+                // Determine the number of sectors in three regions: sectors 1 through 15, 17 through 31, and 32 through 39
+                uint adjustedNumberOfSectors = NumberOfSectors + ((FirstSector < 16) && (FirstSector + NumberOfSectors >= 16) ? 1u : 0);
+                uint lowSectors = Math.Min(FirstSector + adjustedNumberOfSectors, 16u) - Math.Min(FirstSector, 16u);
+                uint midSectors = Math.Max(Math.Min(FirstSector + adjustedNumberOfSectors, 32u), 17u) - Math.Max(Math.Min(FirstSector, 32u), 17u);
+                uint highSectors = Math.Max(FirstSector + adjustedNumberOfSectors, 32u) - Math.Max(FirstSector, 32u);
+                return (lowSectors * 3) + (midSectors * 3) + (highSectors * 15);
+            }
+        }
+
+        /// <summary>
+        /// Get all sectors that are assigned to this application
+        /// </summary>
+        /// <returns>enumeration of assigned sector numbers</returns>
+        public IEnumerable<byte> GetAllSectors()
+        {
+            byte sector = FirstSector;
+            for (uint n = 0; n < NumberOfSectors; n++)
+            {
+                if (sector == 16)
+                {
+                    sector++;
+                }
+
+                yield return sector++;
+            }
+        }
+
+        /// <summary>
+        /// Get all data blocks that are assigned to this application
+        /// </summary>
+        /// <returns>enueration of assigned data block numbers</returns>
+        public IEnumerable<byte> GetAllDataBlocks()
+        {
+            foreach (byte sector in GetAllSectors())
+            {
+                byte block = MifareCard.SectorToBlockNumber(sector, 0);
+                for (int n = 0; n < ((sector < 32) ? 3 : 15); n++)
+                {
+                    yield return block++;
+                }
+            }
+        }
+    }
+}

--- a/src/devices/Pn532/samples/Program.cs
+++ b/src/devices/Pn532/samples/Program.cs
@@ -85,18 +85,42 @@ if (pn532.FirmwareVersion is FirmwareVersion version)
         $"Is it a PN532!: {version.IsPn532}, Version: {version.Version}, Version supported: {version.VersionSupported}");
     // To adjust the baud rate, uncomment the next line
     // pn532.SetSerialBaudRate(BaudRate.B0921600);
+    var sampleFunctions = new (Action<Pn532> Fn, string Name)[]
+    {
+        (DumpAllRegisters, nameof(DumpAllRegisters)),
+        (RunTests, nameof(RunTests)),
+        (ProcessUltralight, nameof(ProcessUltralight)),
+        (ReadMiFare, nameof(ReadMiFare)),
+        (MifareReadNdef, nameof(MifareReadNdef)),
+        (MifareWriteNdef, nameof(MifareWriteNdef)),
+        (TestGPIO, nameof(TestGPIO)),
+        (ReadCreditCard, nameof(ReadCreditCard))
+    };
 
-    // To dump all the registers, uncomment the next line
-    // DumpAllRegisters(pn532);
+    while (true)
+    {
+        Console.WriteLine("Select the function you want to run ('Q' or 'X' to exit):");
+        for (int i = 0; i < sampleFunctions.Length; i++)
+        {
+            Console.WriteLine($" {i}: {sampleFunctions[i].Name}");
+        }
 
-    // To run tests, uncomment the next line
-    // RunTests(pn532);
-    ProcessUltralight(pn532);
-    // ReadMiFare(pn532);
-    // TestGPIO(pn532);
+        var functionChoice = Console.ReadKey();
+        Console.WriteLine();
+        if (Char.ToUpper(functionChoice.KeyChar) is 'Q' or 'X')
+        {
+            break;
+        }
 
-    // To read Credit Cards, uncomment the next line
-    // ReadCreditCard(pn532);
+        if (UInt32.TryParse(functionChoice.KeyChar.ToString(), out uint choiceIndex) && choiceIndex < sampleFunctions.Length)
+        {
+            sampleFunctions[choiceIndex].Fn(pn532);
+        }
+        else
+        {
+            Console.WriteLine($"Please enter a number between 0 and {sampleFunctions.Length - 1} (or CR to exit)");
+        }
+    }
 }
 else
 {
@@ -131,7 +155,7 @@ void DumpAllRegisters(Pn532 pn532)
     }
 }
 
-void ReadMiFare(Pn532 pn532)
+MifareCard? DetectMifare(Pn532 pn532)
 {
     byte[]? retData = null;
     while ((!Console.KeyAvailable))
@@ -148,7 +172,7 @@ void ReadMiFare(Pn532 pn532)
 
     if (retData is null)
     {
-        return;
+        return null;
     }
 
     for (int i = 0; i < retData.Length; i++)
@@ -161,11 +185,15 @@ void ReadMiFare(Pn532 pn532)
     var decrypted = pn532.TryDecode106kbpsTypeA(retData.AsSpan().Slice(1));
     if (decrypted is object)
     {
-        Console.WriteLine(
+        Console.Write(
             $"Tg: {decrypted.TargetNumber}, ATQA: {decrypted.Atqa} SAK: {decrypted.Sak}, NFCID: {BitConverter.ToString(decrypted.NfcId)}");
-        if (decrypted.Ats is object)
+        if (decrypted.Ats is object && decrypted.Ats.Length > 0)
         {
             Console.WriteLine($", ATS: {BitConverter.ToString(decrypted.Ats)}");
+        }
+        else
+        {
+            Console.WriteLine();
         }
 
         MifareCard mifareCard = new(pn532, decrypted.TargetNumber)
@@ -175,19 +203,36 @@ void ReadMiFare(Pn532 pn532)
         };
 
         mifareCard.SetCapacity(decrypted.Atqa, decrypted.Sak);
+        if (mifareCard.Capacity == MifareCardCapacity.Unknown)
+        {
+            Console.WriteLine("Not a supported Mifare card");
+            return null;
+        }
+
         mifareCard.SerialNumber = decrypted.NfcId;
         mifareCard.KeyA = new byte[6] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
         mifareCard.KeyB = new byte[6] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-        for (byte block = 0; block < 64; block++)
+        return mifareCard;
+    }
+
+    return null;
+}
+
+void ReadMiFare(Pn532 pn532)
+{
+    var mifareCard = DetectMifare(pn532);
+    if (mifareCard is object)
+    {
+        for (uint blockUint = 0; blockUint < mifareCard.GetNumberBlocks(); blockUint++)
         {
+            byte block = (byte)blockUint;
             mifareCard.BlockNumber = block;
             mifareCard.Command = MifareCardCommand.AuthenticationB;
             var ret = mifareCard.RunMifareCardCommand();
-            // This will reselect the card in case of issue
-            mifareCard.ReselectCard();
             if (ret < 0)
             {
-                // Try another one
+                // Reselect the card in case of issue and try the other key
+                mifareCard.ReselectCard();
                 mifareCard.Command = MifareCardCommand.AuthenticationA;
                 ret = mifareCard.RunMifareCardCommand();
             }
@@ -203,16 +248,18 @@ void ReadMiFare(Pn532 pn532)
                 }
                 else
                 {
+                    mifareCard.ReselectCard();
                     Console.WriteLine($"Error reading bloc: {block}");
                 }
 
-                if (block % 4 == 3 && mifareCard.Data is object)
+                if (mifareCard.IsSectorBlock(block) && mifareCard.Data is object)
                 {
                     // Check what are the permissions
-                    for (byte j = 3; j > 0; j--)
+                    for (byte j = MifareCard.SectorToBlockNumber(MifareCard.BlockNumberToSector(block), 0); j < block; j++)
                     {
-                        var access = mifareCard.BlockAccess((byte)(block - j), mifareCard.Data);
-                        Console.WriteLine($"Bloc: {block - j}, Access: {access}");
+                        var group = MifareCard.BlockNumberToBlockGroup(j);
+                        var access = mifareCard.BlockAccess(group, mifareCard.Data);
+                        Console.WriteLine($"Bloc: {j}, Access: {access}");
                     }
 
                     var sector = mifareCard.SectorTailerAccess(block, mifareCard.Data);
@@ -223,6 +270,137 @@ void ReadMiFare(Pn532 pn532)
             {
                 Console.WriteLine($"Authentication error");
             }
+        }
+    }
+}
+
+void MifareReadNdef(Pn532 pn532)
+{
+    var mifareCard = DetectMifare(pn532);
+    if (mifareCard is object)
+    {
+        NdefMessage message;
+        var res = mifareCard.TryReadNdefMessage(out message);
+        if (res && message.Length != 0)
+        {
+            foreach (var record in message.Records)
+            {
+                Console.WriteLine($"Record length: {record.Length}");
+                if (TextRecord.IsTextRecord(record))
+                {
+                    var text = new TextRecord(record);
+                    Console.WriteLine(text.Text);
+                }
+            }
+        }
+        else
+        {
+            Console.WriteLine("No NDEF message in this ");
+        }
+    }
+}
+
+void MifareWriteNdef(Pn532 pn532)
+{
+    var mifareCard = DetectMifare(pn532);
+    if (mifareCard is null)
+    {
+        return;
+    }
+
+    // If the card is not already formatted for NDEF, then format it.
+    // If the card was already formatted, use it as-is.
+    bool res = true;
+    if (!mifareCard.IsFormattedNdef())
+    {
+        // There are multiple reasons that IsFormattedNdef may fail, including
+        // an authentication failure or insufficient access permission. If this
+        // happens, the card will be in an error state and must be reselected.
+        mifareCard.ReselectCard();
+
+        // Allocate 14 sectors (1 through 14) for NDEF content, and reserve one sector
+        // for issuer-specific information. In cards larger than 1K, the remaining
+        // sectors are free and may be allocated later for other purposes.
+        Console.WriteLine("Attempting to format for NDEF");
+        res = mifareCard.FormatNdef(14);
+        if (res)
+        {
+            // FormatNdef has already created the application directory and allocated
+            // space for NFC-NDEF. Read the directory from the card, and allocate a sector
+            // for the card publisher (the AppID of 0xFF01 is arbitary)
+            var cardIssuerId = new MifareApplicationIdentifier(0xFF01);
+            var directory = MifareDirectory.LoadFromCard(mifareCard);
+            var entry = directory?.Allocate(cardIssuerId, 1);
+            res = entry is object;
+            if (res)
+            {
+                // Set the card publisher sector in the directory and
+                // write the updated directory back to the card.
+                directory!.CardPublisherSector = entry!.FirstSector;
+                res = directory.StoreToCard(mifareCard.KeyB);
+            }
+        }
+
+        if (!res)
+        {
+            Console.WriteLine("NDEF formatting failed");
+        }
+    }
+
+    if (res)
+    {
+        // Display the Mifare application directory
+        var directory = MifareDirectory.LoadFromCard(mifareCard);
+        if (directory is object)
+        {
+            // The directory can optionally indicate which sector belongs to the
+            // card publisher.
+            var cardPublisherSector = directory.CardPublisherSector;
+            if (cardPublisherSector != 0)
+            {
+                Console.WriteLine($"Card directory (CardPublisherSector = {directory.CardPublisherSector}):");
+            }
+            else
+            {
+                Console.WriteLine("Card directory:");
+            }
+
+            // Each directory entry describes a range of sectors that is allocated to an
+            // application. The range is contiguous, except that on 2K and 4K cards it skips
+            // sector 16.
+            foreach (var entry in directory.GetApplications())
+            {
+                Console.WriteLine($"AppId {entry.ApplicationIdentifier}: {entry.NumberOfSectors} sectors");
+                Console.Write("   ");
+                foreach (var sector in entry.GetAllSectors())
+                {
+                    Console.Write($" {sector}");
+                }
+
+                Console.WriteLine();
+            }
+        }
+        else
+        {
+            res = false;
+        }
+    }
+
+    if (res)
+    {
+        // Create a new NDEF message
+        NdefMessage newMessage = new NdefMessage();
+        var timestamp = DateTime.Now.ToString();
+        newMessage.Records.Add(new TextRecord("I ❤ .NET IoT", "en", Encoding.UTF8));
+        newMessage.Records.Add(new TextRecord(timestamp, "en", Encoding.UTF8));
+        res = mifareCard.WriteNdefMessage(newMessage);
+        if (res)
+        {
+            Console.WriteLine($"NDEF data successfully written on the card at {timestamp}.");
+        }
+        else
+        {
+            Console.WriteLine("Error writing NDEF data on card");
         }
     }
 }
@@ -404,7 +582,7 @@ void ProcessUltralight(Pn532 pn532)
     Console.WriteLine();
 
     var card = pn532.TryDecode106kbpsTypeA(retData.AsSpan().Slice(1));
-    if (card is not object)
+    if (card is not object || !UltralightCard.IsUltralightCard(card.Atqa, card.Sak))
     {
         Console.WriteLine("Not a valid card, please try again.");
         return;

--- a/src/devices/Pn532/samples/Program.cs
+++ b/src/devices/Pn532/samples/Program.cs
@@ -355,8 +355,7 @@ void MifareWriteNdef(Pn532 pn532)
         {
             // The directory can optionally indicate which sector belongs to the
             // card publisher.
-            var cardPublisherSector = directory.CardPublisherSector;
-            if (cardPublisherSector != 0)
+            if (directory.CardPublisherSector != 0)
             {
                 Console.WriteLine($"Card directory (CardPublisherSector = {directory.CardPublisherSector}):");
             }


### PR DESCRIPTION
Add support for the Mifare Application Directory, as described in [AN10787](https://www.nxp.com/docs/en/application-note/AN10787.pdf).

The application directory occupies sector 0 (blocks 1 and 2) and - for 2K and 4K cards - sector 16 (blocks 64, 65, and 66). The directory is actually a sector map that defines the assignment of sectors to applications. Applications are identified by a 16-bit value (encoded in little-endian order on two bytes).

Previously, ```MifareCard.FormatNdef``` created the application directory, assigning all sectors to NDEF content. The NDEF content could be read and written with ```TryReadNdefMessage``` and ```WriteNdefMessage```. However, as noted in #2030, these methods assume that the entire card has been formatted for NDEF, so if the directory was formatted elsewhere and specifies something else, they do not work correctly. In addition, they do not handle the last eight sectors of a 4K card correctly (because those sectors are a different size than the first 32 sectors).

This contribution adds a new class ```MifareDirectory``` to manage the Mifare application directory for a ```MifareCard```. The new class ```MifareDirectoryEntry``` describes a directory entry (i.e., the assignment of sectors to an application). The new class ```MifareApplicationIdentifier``` represents an application identifier.

```MifareDirectory.CreateEmpty``` creates an empty ```MifareDirectory``` object for a specified ```MifareCard```.

```MifareDirectory.LoadFromCard``` loads the directory from a specified ```MifareCard```.

```GetApplications``` returns an enumeration of ```MifareDirectoryEntry``` objects representing the directory contents. ```TryGetApplication``` returns the ```MifareDirectoryEntry``` of a specified application, if it exists. Sectors are allocated to applications with ```Allocate``` and freed with ```Free```. After the directory has been modified, it must be written back to the card with ```StoreToCard```.

```FormatNdef```, ```IsFormattedNdef```, ```WriteNdefMessage```, and ```TryReadNdefMessage``` have been reimplemented to use the directory. An overload of ```FormatNdef``` can specify that only a portion of the card is to be allocated to NDEF content. The remainder is free and can be assigned to other applications. For example, to format 14 sectors for NDEF and assign one sector to an issuer-specific application ID, the following could be used:

```C#
        // MifareCard mifareCard was created previously
        var res = mifareCard.FormatNdef(14);
        if (res)
        {
            var cardIssuerId = new MifareApplicationIdentifier(0xFF01);
            var directory = MifareDirectory.LoadFromCard(mifareCard);
            var entry = directory?.Allocate(cardIssuerId, 1);
            res = entry is object;
            if (res)
            {
                directory!.CardPublisherSector = entry!.FirstSector;
                res = directory.StoreToCard(mifareCard.KeyB);
            }
        }
```

This was also added to the Pn532 sample code. In addition, some miscellaneous changes were made to both the Pn532 and Mfrc522 sample code (including a workaround for #1869).


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2067)