### PR TITLE
Remove image sharp

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -35,6 +35,7 @@
       <!-- Run Pack -->
       <_ProjectsToPackage Include="$(MSBuildThisFileDirectory)src\Iot.Device.Bindings\Iot.Device.Bindings.csproj" />
       <_ProjectsToPackage Include="$(MSBuildThisFileDirectory)src\System.Device.Gpio\System.Device.Gpio.csproj" />
+      <_ProjectsToPackage Include="$(MSBuildThisFileDirectory)src\Iot.Device.Bindings.SkiaSharpAdapter\Iot.Device.Bindings.SkiaSharpAdapter.csproj" />
 
       <ProjectReference Condition="'$(BuildPackages)' == 'true'" Include="@(_ProjectsToPackage)" Targets="Pack" />
   </ItemGroup>

--- a/eng/Versions.external.props
+++ b/eng/Versions.external.props
@@ -2,7 +2,6 @@
   <!-- These references to third-party libraries are included in all projects except System.Device.Gpio and the build wrapper project -->
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'System.Device.Gpio' And '$(MSBuildProjectName)' != 'build'">
     <PackageReference Include="UnitsNet" Version="5.1.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
   </ItemGroup>
 
   <!-- Automatically include these assemblies in all test projects -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
     <MicrosoftDotNetGenAPIPackageVersion>7.0.0-beta.23211.2</MicrosoftDotNetGenAPIPackageVersion>
     <!-- dotnet/corefx dependencies -->
-    <SystemDrawingCommonPackageVersion>5.0.3</SystemDrawingCommonPackageVersion>
+    <SystemDrawingCommonPackageVersion>6.0.0</SystemDrawingCommonPackageVersion>
     <SystemIOPortsPackageVersion>5.0.1</SystemIOPortsPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>5.0.0</MicrosoftWin32RegistryPackageVersion>
     <SystemRuntimeWindowsRuntimePackageVersion>4.6.0</SystemRuntimeWindowsRuntimePackageVersion>

--- a/src/Iot.Device.Bindings.SkiaSharpAdapter/Directory.Build.props
+++ b/src/Iot.Device.Bindings.SkiaSharpAdapter/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <!-- Packaging related properties -->
+  <PropertyGroup>
+    <MajorVersion>2</MajorVersion>
+    <MinorVersion>3</MinorVersion>
+    <Description>This package contains the BitmapImage adapter using SkiaSharp. This library is an optional package to provide imaging functionality for Iot.Device.Bidnings.dll</Description>
+    <PackageTags>.NET Core IoT Device Bindings SkiaSharp Adapter</PackageTags>
+    <EnablePackageValidation>false</EnablePackageValidation>
+    <PackageValidationBaselineVersion>2.2.0</PackageValidationBaselineVersion>
+  </PropertyGroup>
+
+  <Import Project="../../Directory.Build.props" />
+</Project>

--- a/src/Iot.Device.Bindings.SkiaSharpAdapter/Iot.Device.Bindings.SkiaSharpAdapter.csproj
+++ b/src/Iot.Device.Bindings.SkiaSharpAdapter/Iot.Device.Bindings.SkiaSharpAdapter.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableDefaultItems>true</EnableDefaultItems>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage)</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Include="../devices/SkiaSharpAdapter/*.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Iot.Device.Bindings\Iot.Device.Bindings.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <!-- The NativeAssets packages for Windows and MacOS are included in the above by default -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
+  </ItemGroup>
+
+
+</Project>

--- a/src/Iot.Device.Bindings/CompatibilitySuppressions.xml
+++ b/src/Iot.Device.Bindings/CompatibilitySuppressions.xml
@@ -3,6 +3,20 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:BuildHat.Models.BuildHatInformation</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:BuildHat.Models.LedMode</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Iot.Device.Common.ValueArray`1</Target>
     <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
@@ -18,6 +32,13 @@
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Iot.Device.Ft232H.Ft232HI2c</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Iot.Device.Media.PixelFormat</Target>
     <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -150,6 +171,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:BuildHat.Models.BuildHatInformation</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:BuildHat.Models.LedMode</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Iot.Device.Display.BarColor</Target>
     <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
@@ -159,6 +194,27 @@
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Iot.Device.Ft232H.Ft232HI2c</Target>
     <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Iot.Device.Media.PixelFormat</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:BuildHat.Models.BuildHatInformation</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:BuildHat.Models.LedMode</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
@@ -179,6 +235,13 @@
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Iot.Device.Ft232H.Ft232HI2c</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Iot.Device.Media.PixelFormat</Target>
     <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -276,6 +339,34 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.Hd44780.#ctor(SixLabors.ImageSharp.Size,Iot.Device.CharacterLcd.LcdInterface)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.LcdRgb.#ctor(SixLabors.ImageSharp.Size,Iot.Device.CharacterLcd.LcdInterface,System.Device.I2c.I2cDevice)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.LcdRgb.#ctor(SixLabors.ImageSharp.Size,System.Device.I2c.I2cDevice,System.Device.I2c.I2cDevice)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.LcdRgb.SetBacklightColor(SixLabors.ImageSharp.Color)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Iot.Device.Common.GeographicPosition.GetDegreesMinutesSeconds(System.Double,System.Int32,System.Double@,System.Double@,System.Double@,System.Double@)</Target>
     <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
@@ -298,6 +389,118 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Iot.Device.Display.BiColorBarGraph.Fill(Iot.Device.Display.BarColor)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawLine(SixLabors.ImageSharp.Point,SixLabors.ImageSharp.Point,System.Boolean)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawPoint(SixLabors.ImageSharp.Point,System.Boolean)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawRectangle(SixLabors.ImageSharp.Point,SixLabors.ImageSharp.Size,System.Boolean,System.Boolean)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawRectangle(SixLabors.ImageSharp.Rectangle,System.Boolean,System.Boolean)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.#ctor(System.Byte[],System.Int32,System.Int32,System.Int32)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.get_Data</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor.BeginInvoke(SixLabors.ImageSharp.PixelFormats.IPixel,System.AsyncCallback,System.Object)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor.Invoke(SixLabors.ImageSharp.PixelFormats.IPixel)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.LinearBrightnessConvertor(SixLabors.ImageSharp.PixelFormats.IPixel)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.ShowImageWith16Com``1(Iot.Device.Ht1632.Ht1632,SixLabors.ImageSharp.Image{``0},Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.ShowImageWith8Com``1(Iot.Device.Ht1632.Ht1632,SixLabors.ImageSharp.Image{``0},Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.LEDMatrix.RGBLedMatrix.DrawBitmap(System.Int32,System.Int32,System.Drawing.Bitmap,System.Boolean)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.LEDMatrix.RGBLedMatrix.DrawBitmap(System.Int32,System.Int32,System.Drawing.Bitmap,System.Byte,System.Byte,System.Byte,System.Byte,System.Byte,System.Byte,System.Boolean)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoConnectionSettings.#ctor(System.Int32,System.ValueTuple{System.UInt32,System.UInt32},Iot.Device.Media.PixelFormat)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoDevice.GetPixelFormatResolutions(Iot.Device.Media.PixelFormat)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoDevice.RgbToBitmap(System.ValueTuple{System.UInt32,System.UInt32},System.Drawing.Color[],System.Drawing.Imaging.PixelFormat)</Target>
     <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -340,6 +543,41 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Iot.Device.Nmea0183.Sentences.DepthBelowSurface.get_Left</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.GetBitmapPixelData(System.Drawing.Bitmap,System.Drawing.Rectangle)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.SendBitmap(System.Drawing.Bitmap,System.Drawing.Point,System.Drawing.Rectangle)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.SendBitmap(System.Drawing.Bitmap,System.Drawing.Rectangle)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.SendBitmap(System.Drawing.Bitmap)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ws28xx.Ws28xx.#ctor(System.Device.Spi.SpiDevice,Iot.Device.Graphics.BitmapImage)</Target>
     <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -388,6 +626,34 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.Hd44780.#ctor(SixLabors.ImageSharp.Size,Iot.Device.CharacterLcd.LcdInterface)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.LcdRgb.#ctor(SixLabors.ImageSharp.Size,Iot.Device.CharacterLcd.LcdInterface,System.Device.I2c.I2cDevice)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.LcdRgb.#ctor(SixLabors.ImageSharp.Size,System.Device.I2c.I2cDevice,System.Device.I2c.I2cDevice)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.LcdRgb.SetBacklightColor(SixLabors.ImageSharp.Color)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Iot.Device.Common.GeographicPosition.GetDegreesMinutesSeconds(System.Double,System.Int32,System.Double@,System.Double@,System.Double@,System.Double@)</Target>
     <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
@@ -410,6 +676,118 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Iot.Device.Display.BiColorBarGraph.Fill(Iot.Device.Display.BarColor)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawLine(SixLabors.ImageSharp.Point,SixLabors.ImageSharp.Point,System.Boolean)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawPoint(SixLabors.ImageSharp.Point,System.Boolean)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawRectangle(SixLabors.ImageSharp.Point,SixLabors.ImageSharp.Size,System.Boolean,System.Boolean)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawRectangle(SixLabors.ImageSharp.Rectangle,System.Boolean,System.Boolean)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.#ctor(System.Byte[],System.Int32,System.Int32,System.Int32)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.get_Data</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor.BeginInvoke(SixLabors.ImageSharp.PixelFormats.IPixel,System.AsyncCallback,System.Object)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor.Invoke(SixLabors.ImageSharp.PixelFormats.IPixel)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.LinearBrightnessConvertor(SixLabors.ImageSharp.PixelFormats.IPixel)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.ShowImageWith16Com``1(Iot.Device.Ht1632.Ht1632,SixLabors.ImageSharp.Image{``0},Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.ShowImageWith8Com``1(Iot.Device.Ht1632.Ht1632,SixLabors.ImageSharp.Image{``0},Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.LEDMatrix.RGBLedMatrix.DrawBitmap(System.Int32,System.Int32,System.Drawing.Bitmap,System.Boolean)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.LEDMatrix.RGBLedMatrix.DrawBitmap(System.Int32,System.Int32,System.Drawing.Bitmap,System.Byte,System.Byte,System.Byte,System.Byte,System.Byte,System.Byte,System.Boolean)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoConnectionSettings.#ctor(System.Int32,System.ValueTuple{System.UInt32,System.UInt32},Iot.Device.Media.PixelFormat)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoDevice.GetPixelFormatResolutions(Iot.Device.Media.PixelFormat)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoDevice.RgbToBitmap(System.ValueTuple{System.UInt32,System.UInt32},System.Drawing.Color[],System.Drawing.Imaging.PixelFormat)</Target>
     <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -452,6 +830,41 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Iot.Device.Nmea0183.Sentences.DepthBelowSurface.get_Left</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.GetBitmapPixelData(System.Drawing.Bitmap,System.Drawing.Rectangle)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.SendBitmap(System.Drawing.Bitmap,System.Drawing.Point,System.Drawing.Rectangle)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.SendBitmap(System.Drawing.Bitmap,System.Drawing.Rectangle)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.SendBitmap(System.Drawing.Bitmap)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ws28xx.Ws28xx.#ctor(System.Device.Spi.SpiDevice,Iot.Device.Graphics.BitmapImage)</Target>
     <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -493,6 +906,34 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.Hd44780.#ctor(SixLabors.ImageSharp.Size,Iot.Device.CharacterLcd.LcdInterface)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.LcdRgb.#ctor(SixLabors.ImageSharp.Size,Iot.Device.CharacterLcd.LcdInterface,System.Device.I2c.I2cDevice)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.LcdRgb.#ctor(SixLabors.ImageSharp.Size,System.Device.I2c.I2cDevice,System.Device.I2c.I2cDevice)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.CharacterLcd.LcdRgb.SetBacklightColor(SixLabors.ImageSharp.Color)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Iot.Device.Common.GeographicPosition.GetDegreesMinutesSeconds(System.Double,System.Int32,System.Double@,System.Double@,System.Double@,System.Double@)</Target>
     <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
@@ -515,6 +956,118 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Iot.Device.Display.BiColorBarGraph.Fill(Iot.Device.Display.BarColor)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawLine(SixLabors.ImageSharp.Point,SixLabors.ImageSharp.Point,System.Boolean)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawPoint(SixLabors.ImageSharp.Point,System.Boolean)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawRectangle(SixLabors.ImageSharp.Point,SixLabors.ImageSharp.Size,System.Boolean,System.Boolean)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Display.Pcd8544.DrawRectangle(SixLabors.ImageSharp.Rectangle,System.Boolean,System.Boolean)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.#ctor(System.Byte[],System.Int32,System.Int32,System.Int32)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.get_Data</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor.BeginInvoke(SixLabors.ImageSharp.PixelFormats.IPixel,System.AsyncCallback,System.Object)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor.Invoke(SixLabors.ImageSharp.PixelFormats.IPixel)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.LinearBrightnessConvertor(SixLabors.ImageSharp.PixelFormats.IPixel)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.ShowImageWith16Com``1(Iot.Device.Ht1632.Ht1632,SixLabors.ImageSharp.Image{``0},Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ht1632.Ht1632ImageSending.ShowImageWith8Com``1(Iot.Device.Ht1632.Ht1632,SixLabors.ImageSharp.Image{``0},Iot.Device.Ht1632.Ht1632ImageSending.BrightnessConvertor)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.LEDMatrix.RGBLedMatrix.DrawBitmap(System.Int32,System.Int32,System.Drawing.Bitmap,System.Boolean)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.LEDMatrix.RGBLedMatrix.DrawBitmap(System.Int32,System.Int32,System.Drawing.Bitmap,System.Byte,System.Byte,System.Byte,System.Byte,System.Byte,System.Byte,System.Boolean)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoConnectionSettings.#ctor(System.Int32,System.ValueTuple{System.UInt32,System.UInt32},Iot.Device.Media.PixelFormat)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoDevice.GetPixelFormatResolutions(Iot.Device.Media.PixelFormat)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoDevice.RgbToBitmap(System.ValueTuple{System.UInt32,System.UInt32},System.Drawing.Color[],System.Drawing.Imaging.PixelFormat)</Target>
     <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -557,6 +1110,41 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Iot.Device.Nmea0183.Sentences.DepthBelowSurface.get_Left</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.GetBitmapPixelData(System.Drawing.Bitmap,System.Drawing.Rectangle)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.SendBitmap(System.Drawing.Bitmap,System.Drawing.Point,System.Drawing.Rectangle)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.SendBitmap(System.Drawing.Bitmap,System.Drawing.Rectangle)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ssd1351.Ssd1351.SendBitmap(System.Drawing.Bitmap)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Ws28xx.Ws28xx.#ctor(System.Device.Spi.SpiDevice,Iot.Device.Graphics.BitmapImage)</Target>
     <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -578,6 +1166,48 @@
   <Suppression>
     <DiagnosticId>CP0005</DiagnosticId>
     <Target>M:Iot.Device.Card.CardTransceiver.Transceive(System.Byte,System.ReadOnlySpan{System.Byte},System.Span{System.Byte},Iot.Device.Card.NfcProtocol)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.AsByteSpan</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.Dispose(System.Boolean)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.GetDrawingApi</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.GetPixel(System.Int32,System.Int32)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.SaveToStream(System.IO.Stream,Iot.Device.Graphics.ImageFileType)</Target>
+    <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoDevice.GetPixelFormatResolutions(Iot.Device.Media.VideoPixelFormat)</Target>
     <Left>lib/net6.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/net6.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -619,6 +1249,48 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.AsByteSpan</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.Dispose(System.Boolean)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.GetDrawingApi</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.GetPixel(System.Int32,System.Int32)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.SaveToStream(System.IO.Stream,Iot.Device.Graphics.ImageFileType)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoDevice.GetPixelFormatResolutions(Iot.Device.Media.VideoPixelFormat)</Target>
+    <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
     <Target>P:Iot.Device.Card.CardTransceiver.MaximumReadSize</Target>
     <Left>lib/netcoreapp3.1/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
@@ -648,6 +1320,48 @@
   <Suppression>
     <DiagnosticId>CP0005</DiagnosticId>
     <Target>M:Iot.Device.Card.CardTransceiver.Transceive(System.Byte,System.ReadOnlySpan{System.Byte},System.Span{System.Byte},Iot.Device.Card.NfcProtocol)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.AsByteSpan</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.Dispose(System.Boolean)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.GetDrawingApi</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.GetPixel(System.Int32,System.Int32)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Graphics.BitmapImage.SaveToStream(System.IO.Stream,Iot.Device.Graphics.ImageFileType)</Target>
+    <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0005</DiagnosticId>
+    <Target>M:Iot.Device.Media.VideoDevice.GetPixelFormatResolutions(Iot.Device.Media.VideoPixelFormat)</Target>
     <Left>lib/netstandard2.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/netstandard2.0/Iot.Device.Bindings.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
+++ b/src/Iot.Device.Bindings/Iot.Device.Bindings.csproj
@@ -22,6 +22,7 @@
     <!-- Excluding samples and test projects when getting source files -->
     <_ExcludeProjectReferences Include="$(DeviceRoot)**/samples/**/*.csproj" />
     <_ExcludeProjectReferences Include="$(DeviceRoot)**/tests/**/*.csproj" />
+    <_ExcludeProjectReferences Include="$(DeviceRoot)SkiaSharpAdapter/*.csproj" />
   </ItemGroup>
 
   <!-- The following ItemGroup is in charge of getting the source files we will compile on each TFM -->
@@ -30,12 +31,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
     <PackageReference Include="System.IO.Ports" Version="$(SystemIOPortsPackageVersion)" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
     <PackageReference Include="System.Management" Version="$(SystemManagementPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
+    <!-- This package is only used for windows specific stuff. -->
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />

--- a/src/devices/Arduino/samples/ApiChecker/Arduino.sample.csproj
+++ b/src/devices/Arduino/samples/ApiChecker/Arduino.sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultSampleTfms)</TargetFrameworks>
     <RootNamespace>Iot.Device.Arduino.Sample</RootNamespace>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AssemblyName>Arduino.sample</AssemblyName>

--- a/src/devices/Arduino/samples/ApiChecker/RgbLedTest.cs
+++ b/src/devices/Arduino/samples/ApiChecker/RgbLedTest.cs
@@ -3,11 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using SixLabors.ImageSharp.ColorSpaces;
-using SixLabors.ImageSharp.ColorSpaces.Conversion;
 using static System.Threading.Thread;
 
 namespace Iot.Device.Arduino.Sample
@@ -47,7 +46,6 @@ namespace Iot.Device.Arduino.Sample
             redChannel.DutyCycle = 0;
             Sleep(1000);
 
-            var converter = new ColorSpaceConverter();
             float angle = 0.0f;
             float hv = 1.0f;
             float hvDelta = 0; // 0.001f;
@@ -57,8 +55,7 @@ namespace Iot.Device.Arduino.Sample
             float blueCorrection = 0.95f;
             while (!Console.KeyAvailable)
             {
-                var hsv = new Hsv(angle, 1.0f, 1.0f);
-                var rgb = converter.ToRgb(hsv);
+                Color rgb = Color.Blue;
                 redChannel.DutyCycle = rgb.R;
                 blueChannel.DutyCycle = rgb.B * blueCorrection;
                 greenChannel.DutyCycle = rgb.G * greenCorrection;

--- a/src/devices/BuildHat/Brick.cs
+++ b/src/devices/BuildHat/Brick.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Device.Gpio;
 using System.Diagnostics;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.IO.Ports;
@@ -13,13 +14,11 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
-using BuildHat.Models;
 using Iot.Device.BuildHat.Models;
 using Iot.Device.BuildHat.Motors;
 using Iot.Device.BuildHat.Sensors;
 using Iot.Device.Common;
 using Microsoft.Extensions.Logging;
-using SixLabors.ImageSharp;
 using UnitsNet;
 
 namespace Iot.Device.BuildHat
@@ -1159,10 +1158,12 @@ namespace Iot.Device.BuildHat
                                                 case 5:
                                                     if (_sensorType[port] == SensorType.SpikePrimeColorSensor)
                                                     {
-                                                        color.Color = Color.FromRgba((byte)(Convert.ToInt32(elements[inc++]) * 255 / 1024),
-                                                            (byte)(Convert.ToInt32(elements[inc++]) * 255 / 1024),
-                                                            (byte)(Convert.ToInt32(elements[inc++]) * 255 / 1024),
-                                                            (byte)(Convert.ToInt32(elements[inc++]) * 255 / 1024));
+                                                        // Verify the colors here (a and b could be exchanged)
+                                                        color.Color = Color.FromArgb((byte)(Convert.ToInt32(elements[inc + 3]) * 255 / 1024),
+                                                            (byte)(Convert.ToInt32(elements[inc + 1]) * 255 / 1024),
+                                                            (byte)(Convert.ToInt32(elements[inc + 2]) * 255 / 1024),
+                                                            (byte)(Convert.ToInt32(elements[inc + 0]) * 255 / 1024));
+                                                        inc += 4;
                                                         color.IsColorDetected = true;
                                                     }
                                                     else
@@ -1186,7 +1187,7 @@ namespace Iot.Device.BuildHat
                                                     // Normal color mode
                                                     if (!isCombi)
                                                     {
-                                                        color.Color = Color.FromRgb((byte)(Convert.ToInt32(elements[inc++]) * 255 / 400),
+                                                        color.Color = Color.FromArgb((byte)(Convert.ToInt32(elements[inc++]) * 255 / 400),
                                                             (byte)(Convert.ToInt32(elements[inc++]) * 255 / 400),
                                                             (byte)(Convert.ToInt32(elements[inc++]) * 255 / 400));
                                                         color.IsColorDetected = true;

--- a/src/devices/BuildHat/BuildHat.sln
+++ b/src/devices/BuildHat/BuildHat.sln
@@ -9,7 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildHat.samples", "samples
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildHatTests", "tests\BuildHatTests\BuildHatTests.csproj", "{CD468E74-AF86-48D8-96AA-1E267084AB2F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonHelpers", "..\Common\CommonHelpers.csproj", "{F0563C1E-F8B4-47A7-9C1F-A700FF9F5C65}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\Common\Common.csproj", "{F0563C1E-F8B4-47A7-9C1F-A700FF9F5C65}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/devices/BuildHat/Models/BuildHatInformation.cs
+++ b/src/devices/BuildHat/Models/BuildHatInformation.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace BuildHat.Models
+namespace Iot.Device.BuildHat.Models
 {
     /// <summary>
     /// Class containing the board information.

--- a/src/devices/BuildHat/Models/LedMode.cs
+++ b/src/devices/BuildHat/Models/LedMode.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace BuildHat.Models
+namespace Iot.Device.BuildHat.Models
 {
     /// <summary>
     /// Led mode for the leds on the Build HAT.

--- a/src/devices/BuildHat/Sensors/ColorSensor.cs
+++ b/src/devices/BuildHat/Sensors/ColorSensor.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
 using System.IO;
 using Iot.Device.BuildHat.Models;
-using SixLabors.ImageSharp;
 
 namespace Iot.Device.BuildHat.Sensors
 {

--- a/src/devices/BuildHat/Sensors/WeDoTiltSensor.cs
+++ b/src/devices/BuildHat/Sensors/WeDoTiltSensor.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
 using System.IO;
 using Iot.Device.BuildHat.Models;
-using SixLabors.ImageSharp;
 
 namespace Iot.Device.BuildHat.Sensors
 {

--- a/src/devices/Button/GpioButton.cs
+++ b/src/devices/Button/GpioButton.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Device.Gpio;
 
-using SixLabors.ImageSharp.Formats.Gif;
-
 namespace Iot.Device.Button
 {
     /// <summary>

--- a/src/devices/CharacterLcd/Hd44780.cs
+++ b/src/devices/CharacterLcd/Hd44780.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Buffers;
-using SixLabors.ImageSharp;
+using System.Drawing;
 
 namespace Iot.Device.CharacterLcd
 {

--- a/src/devices/CharacterLcd/ICharacterLcd.cs
+++ b/src/devices/CharacterLcd/ICharacterLcd.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using SixLabors.ImageSharp;
+using System.Drawing;
 
 namespace Iot.Device.CharacterLcd
 {

--- a/src/devices/CharacterLcd/Lcd1602.cs
+++ b/src/devices/CharacterLcd/Lcd1602.cs
@@ -3,7 +3,7 @@
 
 using System.Device.Gpio;
 using System.Device.I2c;
-using SixLabors.ImageSharp;
+using System.Drawing;
 
 namespace Iot.Device.CharacterLcd
 {

--- a/src/devices/CharacterLcd/Lcd2004.cs
+++ b/src/devices/CharacterLcd/Lcd2004.cs
@@ -3,7 +3,7 @@
 
 using System.Device.Gpio;
 using System.Device.I2c;
-using SixLabors.ImageSharp;
+using System.Drawing;
 
 namespace Iot.Device.CharacterLcd
 {

--- a/src/devices/CharacterLcd/LcdConsole.cs
+++ b/src/devices/CharacterLcd/LcdConsole.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Globalization;
-using SixLabors.ImageSharp;
+using System.Drawing;
 using Iot.Device.Graphics;
 
 namespace Iot.Device.CharacterLcd

--- a/src/devices/CharacterLcd/LcdRgb.cs
+++ b/src/devices/CharacterLcd/LcdRgb.cs
@@ -3,8 +3,7 @@
 
 using System;
 using System.Device.I2c;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
+using System.Drawing;
 
 namespace Iot.Device.CharacterLcd
 {
@@ -82,10 +81,9 @@ namespace Iot.Device.CharacterLcd
         /// <param name="color">The color to set.</param>
         private void ForceSetBacklightColor(Color color)
         {
-            var col = color.ToPixel<Rgba32>();
-            SetRgbRegister(RgbRegisters.REG_RED, col.R);
-            SetRgbRegister(RgbRegisters.REG_GREEN, col.G);
-            SetRgbRegister(RgbRegisters.REG_BLUE, col.B);
+            SetRgbRegister(RgbRegisters.REG_RED, color.R);
+            SetRgbRegister(RgbRegisters.REG_GREEN, color.G);
+            SetRgbRegister(RgbRegisters.REG_BLUE, color.B);
         }
 
         /// <summary>

--- a/src/devices/CharacterLcd/samples/Hd44780.ExtendedSample.cs
+++ b/src/devices/CharacterLcd/samples/Hd44780.ExtendedSample.cs
@@ -4,12 +4,12 @@
 using System;
 using System.Device.I2c;
 using System.Diagnostics;
+using System.Drawing;
 using System.Text;
 using System.Threading;
 using System.Timers;
 using System.Globalization;
 using Iot.Device.Mcp23xxx;
-using SixLabors.ImageSharp;
 
 namespace Iot.Device.CharacterLcd.Samples
 {
@@ -204,7 +204,7 @@ namespace Iot.Device.CharacterLcd.Samples
             foreach (var color in colors)
             {
                 lcd.Clear();
-                lcd.Write(color.ToHex());
+                lcd.Write(color.ToArgb().ToString("X8", CultureInfo.CurrentCulture));
 
                 colorLcd.SetBacklightColor(color);
                 System.Threading.Thread.Sleep(1000);

--- a/src/devices/CharacterLcd/samples/LcdConsole.Samples.cs
+++ b/src/devices/CharacterLcd/samples/LcdConsole.Samples.cs
@@ -163,5 +163,91 @@ namespace Iot.Device.CharacterLcd.Samples
             console.Write("Test finished");
             console.Dispose();
         }
+
+        /// <summary>
+        /// A test method
+        /// </summary>
+        /// <param name="lcd">The lcd driver</param>
+        public static void ValueTest(ICharacterLcd lcd)
+        {
+            Random random = new Random(1234);
+            Console.WriteLine("Value and unit test - big font (press any key to go to the next test)");
+            Console.WriteLine("Displaying time, culture de-CH");
+            LcdValueUnitDisplay val = new LcdValueUnitDisplay(lcd, CultureInfo.CreateSpecificCulture("de-CH"));
+            val.InitForRom("A00");
+            while (Console.KeyAvailable == false)
+            {
+                val.DisplayTime(DateTime.Now);
+                Thread.Sleep(100);
+            }
+
+            Console.ReadKey(true);
+            Console.WriteLine("Same, now long time format");
+            while (Console.KeyAvailable == false)
+            {
+                val.DisplayTime(DateTime.Now, "T");
+                Thread.Sleep(100);
+            }
+
+            Console.ReadKey(true);
+            Console.WriteLine("Now with en-US culture");
+            val = new LcdValueUnitDisplay(lcd, CultureInfo.CreateSpecificCulture("en-US"));
+            val.InitForRom("A00");
+            while (Console.KeyAvailable == false)
+            {
+                val.DisplayTime(DateTime.Now);
+                Thread.Sleep(100);
+            }
+
+            Console.ReadKey(true);
+            Console.WriteLine("Now something a bit more technical");
+            while (Console.KeyAvailable == false)
+            {
+                double voltage = random.NextDouble();
+                val.DisplayValue(voltage.ToString("F3") + "kV", "Supply Voltage");
+                Thread.Sleep(500);
+            }
+
+            Console.ReadKey(true);
+            Console.WriteLine("Common units");
+            string unitsToDisplay = "kV mA nF μF pF MΩ";
+            int index = 0;
+            while (Console.KeyAvailable == false)
+            {
+                string current = unitsToDisplay.Substring(index);
+                val.DisplayValue(current);
+                index = (index + 1) % unitsToDisplay.Length;
+                Thread.Sleep(500);
+            }
+
+            Console.ReadKey(true);
+            Console.WriteLine("And the letters of the latin alphabet");
+            char[] chars = new[] { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z' };
+            int idx = 0;
+            while (Console.KeyAvailable == false)
+            {
+                string letter = chars[idx].ToString();
+                letter = letter + letter.ToLower(val.Culture);
+                val.DisplayValue(letter, letter);
+                idx = (idx + 1) % chars.Length;
+                Thread.Sleep(1000);
+            }
+
+            Console.ReadKey(true);
+            CancellationTokenSource ts = new CancellationTokenSource();
+            Task t = val.DisplayBigTextAsync("The quick brown fox jumps over the lazy dog.", TimeSpan.FromSeconds(1), ts.Token);
+            while ((Console.KeyAvailable == false) && (t.IsCompleted == false))
+            {
+                // Do nothing
+                Thread.Sleep(50);
+            }
+
+            Console.ReadKey();
+            ts.Cancel();
+            t.Wait();
+            ts.Dispose();
+            Console.WriteLine("Big font tests done. Press Enter to continue");
+            Console.ReadLine();
+        }
     }
 }

--- a/src/devices/CharacterLcd/samples/Pcf8574tSample.cs
+++ b/src/devices/CharacterLcd/samples/Pcf8574tSample.cs
@@ -7,8 +7,8 @@ using System.Device.I2c;
 using System.Diagnostics;
 using System.Text;
 using System.Timers;
+using System.Drawing;
 using Iot.Device.Pcx857x;
-using SixLabors.ImageSharp;
 
 namespace Iot.Device.CharacterLcd.Samples
 {
@@ -216,7 +216,7 @@ namespace Iot.Device.CharacterLcd.Samples
             foreach (var color in colors)
             {
                 lcd.Clear();
-                lcd.Write(color.ToHex());
+                lcd.Write(color.ToString());
 
                 lcd.SetBacklightColor(color);
                 System.Threading.Thread.Sleep(1000);

--- a/src/devices/CharacterLcd/samples/Program.cs
+++ b/src/devices/CharacterLcd/samples/Program.cs
@@ -5,13 +5,13 @@ using System;
 using System.Device.Gpio;
 using System.Device.I2c;
 using System.Device.Spi;
+using System.Drawing;
 using CharacterLcd.Samples;
 using Iot.Device.Arduino;
 using Iot.Device.Mcp23xxx;
 using Iot.Device.CharacterLcd;
 using Iot.Device.CharacterLcd.Samples;
 using Iot.Device.Multiplexing;
-using SixLabors.ImageSharp;
 
 // Choose the right setup for your display:
 // UsingGpioPins();

--- a/src/devices/CharacterLcd/tests/LcdConsoleTests.cs
+++ b/src/devices/CharacterLcd/tests/LcdConsoleTests.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Globalization;
 using System.Text;
 using Iot.Device.CharacterLcd;
 using Iot.Device.Graphics;
 using Moq;
-using SixLabors.ImageSharp;
 using Xunit;
 
 namespace CharacterLcd.Tests

--- a/src/devices/CharacterLcd/tests/LcdValueUnitDisplayTests.cs
+++ b/src/devices/CharacterLcd/tests/LcdValueUnitDisplayTests.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using System.Drawing;
 using Iot.Device.CharacterLcd;
 using Moq;
-using SixLabors.ImageSharp;
 using Xunit;
 
 namespace CharacterLcd.Tests

--- a/src/devices/Common/Common.csproj
+++ b/src/devices/Common/Common.csproj
@@ -21,6 +21,8 @@
     <Compile Include="System/Device/Spi/*.cs" />
     <Compile Include="Interop/**/*.cs" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
+    <!-- The following is supported on windows only. We need it to take screenshots under windows -->
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="FrameworkCompatibilityExtensions.cs" />

--- a/src/devices/Common/Iot/Device/Graphics/BitmapImage.cs
+++ b/src/devices/Common/Iot/Device/Graphics/BitmapImage.cs
@@ -175,15 +175,6 @@ namespace Iot.Device.Graphics
         public abstract Span<byte> AsByteSpan();
 
         /// <summary>
-        /// Return the data pointer as a raw span of integers. For 32bit images, this equals to one pixel per entry.
-        /// </summary>
-        /// <returns>A span of integers</returns>
-        public virtual Span<int> AsIntSpan()
-        {
-            return MemoryMarshal.Cast<byte, int>(AsByteSpan());
-        }
-
-        /// <summary>
         /// Saves this bitmap to a file
         /// </summary>
         /// <param name="filename">The filename to save it to</param>
@@ -191,7 +182,7 @@ namespace Iot.Device.Graphics
         /// <remarks>
         /// Generally, the method is not checking that the filename extension matches the file type provided.
         /// </remarks>
-        public virtual void SaveToFile(string filename, ImageFileType fileType)
+        public void SaveToFile(string filename, ImageFileType fileType)
         {
             using (var fs = new FileStream(filename, FileMode.CreateNew))
             {

--- a/src/devices/Common/Iot/Device/Graphics/BitmapImage.cs
+++ b/src/devices/Common/Iot/Device/Graphics/BitmapImage.cs
@@ -3,35 +3,42 @@
 
 using System;
 using System.Drawing;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace Iot.Device.Graphics
 {
     /// <summary>
-    /// Represents bitmap image
+    /// An abstract class for a bitmap image, to be implemented by an image provider.
+    /// This class is also the factory to create new bitmaps with the current image factory.
+    /// The image factory must implement <see cref="IImageFactory"/> and must be registered using a call to
+    /// <see cref="RegisterImageFactory"/>.
     /// </summary>
-    public abstract class BitmapImage
+    /// <remarks>
+    /// This class does not have an implementation within Iot.Device.Bindings.dll. You can use the Iot.Device.Bindings.SkiaSharpAdapter.dll
+    /// as a supported operating-system independent implementation of this class or write your own implementation.
+    /// </remarks>
+    public abstract class BitmapImage : IDisposable
     {
+        /// <summary>
+        /// The currently registered image factory
+        /// </summary>
+        private static IImageFactory? s_currentFactory;
+
         /// <summary>
         /// Initializes a <see cref="T:Iot.Device.Graphics.BitmapImage" /> instance with the specified data, width, height and stride.
         /// </summary>
-        /// <param name="data">Data representing the image (derived class defines a specific format)</param>
         /// <param name="width">Width of the image</param>
         /// <param name="height">Height of the image</param>
         /// <param name="stride">Number of bytes per row</param>
-        protected BitmapImage(byte[] data, int width, int height, int stride)
+        /// <param name="pixelFormat">The pixel format of the data</param>
+        protected BitmapImage(int width, int height, int stride, PixelFormat pixelFormat)
         {
-            _data = data;
             Width = width;
             Height = height;
             Stride = stride;
+            PixelFormat = pixelFormat;
         }
-
-        private readonly byte[] _data;
-
-        /// <summary>
-        /// Data related to the image (derived class defines a specific format)
-        /// </summary>
-        public Span<byte> Data => _data;
 
         /// <summary>
         /// Width of the image
@@ -49,12 +56,82 @@ namespace Iot.Device.Graphics
         public int Stride { get; }
 
         /// <summary>
-        /// Sets pixel at specific position
+        /// The format of the image
         /// </summary>
-        /// <param name="x">X coordinate of the pixel</param>
-        /// <param name="y">Y coordinate of the pixel</param>
-        /// <param name="color">Color to set the pixel to</param>
-        public abstract void SetPixel(int x, int y, Color color);
+        public PixelFormat PixelFormat { get; }
+
+        /// <summary>
+        /// Accesses the pixel at the given position
+        /// </summary>
+        /// <param name="x">Pixel X position</param>
+        /// <param name="y">Pixel Y position</param>
+        public Color this[int x, int y]
+        {
+            get
+            {
+                return GetPixel(x, y);
+            }
+            set
+            {
+                SetPixel(x, y, value);
+            }
+        }
+
+        /// <summary>
+        /// Register an image factory.
+        /// </summary>
+        /// <param name="factory">The image factory to register</param>
+        public static void RegisterImageFactory(IImageFactory factory)
+        {
+            s_currentFactory = factory;
+        }
+
+        /// <summary>
+        /// Creates a bitmap using the active factory. This requires an implementation to be registered.
+        /// See <see cref="BitmapImage"/> for details.
+        /// </summary>
+        /// <param name="width">Width of the image, in pixels</param>
+        /// <param name="height">Height of the image, in pixels</param>
+        /// <param name="pixelFormat">Desired pixel format</param>
+        /// <returns>A new bitmap with the provided size</returns>
+        public static BitmapImage CreateBitmap(int width, int height, PixelFormat pixelFormat)
+        {
+            VerifyFactoryAvailable();
+            return s_currentFactory!.CreateBitmap(width, height, pixelFormat);
+        }
+
+        private static void VerifyFactoryAvailable()
+        {
+            if (s_currentFactory == null)
+            {
+                throw new InvalidOperationException("No image factory registered. Call BitmapImage.RegisterImageFactory() with a suitable implementation first. Consult the documentation for further information");
+            }
+        }
+
+        /// <summary>
+        /// Create a bitmap from a file. This requires an implementation to be registered.
+        /// See <see cref="BitmapImage"/> for details.
+        /// </summary>
+        /// <param name="filename">The file to load</param>
+        /// <returns>A bitmap</returns>
+        public static BitmapImage CreateFromFile(string filename)
+        {
+            VerifyFactoryAvailable();
+            using var s = new FileStream(filename, FileMode.Open);
+            return s_currentFactory!.CreateFromStream(s);
+        }
+
+        /// <summary>
+        /// Create a bitmap from an open stream. This requires an implementation to be registered.
+        /// See <see cref="BitmapImage"/> for details.
+        /// </summary>
+        /// <param name="data">The data stream</param>
+        /// <returns>A bitmap</returns>
+        public static BitmapImage CreateFromStream(Stream data)
+        {
+            VerifyFactoryAvailable();
+            return s_currentFactory!.CreateFromStream(data);
+        }
 
         /// <summary>
         /// Clears the image to specific color
@@ -70,5 +147,83 @@ namespace Iot.Device.Graphics
                 }
             }
         }
+
+        /// <summary>
+        /// Sets pixel at specific position
+        /// </summary>
+        /// <param name="x">X coordinate of the pixel</param>
+        /// <param name="y">Y coordinate of the pixel</param>
+        /// <param name="color">Color to set the pixel to</param>
+        /// <remarks>The use of <see cref="SetPixel"/> and <see cref="GetPixel"/> is usually slow. For fast image updates, grab the underlying
+        /// raw buffer by calling <see cref="AsByteSpan"/> or use the <see cref="GetDrawingApi"/> method and use high-level drawing functions.</remarks>
+        public abstract void SetPixel(int x, int y, Color color);
+
+        /// <summary>
+        /// Gets the color of the pixel at the given position
+        /// </summary>
+        /// <param name="x">X coordinate of the pixel</param>
+        /// <param name="y">Y coordinate of the pixel</param>
+        /// <returns>The color of the pixel</returns>
+        /// <remarks>The use of <see cref="SetPixel"/> and <see cref="GetPixel"/> is usually slow. For fast image updates, grab the underlying
+        /// raw buffer by calling <see cref="AsByteSpan"/> or use the <see cref="GetDrawingApi"/> method and use high-level drawing functions.</remarks>
+        public abstract Color GetPixel(int x, int y);
+
+        /// <summary>
+        /// Return the data pointer as a raw span of bytes
+        /// </summary>
+        /// <returns>A span of bytes</returns>
+        public abstract Span<byte> AsByteSpan();
+
+        /// <summary>
+        /// Return the data pointer as a raw span of integers. For 32bit images, this equals to one pixel per entry.
+        /// </summary>
+        /// <returns>A span of integers</returns>
+        public virtual Span<int> AsIntSpan()
+        {
+            return MemoryMarshal.Cast<byte, int>(AsByteSpan());
+        }
+
+        /// <summary>
+        /// Saves this bitmap to a file
+        /// </summary>
+        /// <param name="filename">The filename to save it to</param>
+        /// <param name="fileType">The filetype to use.</param>
+        /// <remarks>
+        /// Generally, the method is not checking that the filename extension matches the file type provided.
+        /// </remarks>
+        public virtual void SaveToFile(string filename, ImageFileType fileType)
+        {
+            using (var fs = new FileStream(filename, FileMode.CreateNew))
+            {
+                SaveToStream(fs, fileType);
+            }
+        }
+
+        /// <summary>
+        /// Save the image to a stream
+        /// </summary>
+        /// <param name="stream">The stream to save the data to</param>
+        /// <param name="format">The image format</param>
+        public abstract void SaveToStream(Stream stream, ImageFileType format);
+
+        /// <summary>
+        /// Disposes this instance
+        /// </summary>
+        /// <param name="disposing">True if disposing, false if called from finalizer</param>
+        protected abstract void Dispose(bool disposing);
+
+        /// <summary>
+        /// Disposes this instance. Correctly disposing instance of this class is important to prevent memory leaks or overload of the garbage collector.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Returns an abstraction interface for drawing to this bitmap.
+        /// </summary>
+        public abstract IGraphics GetDrawingApi();
     }
 }

--- a/src/devices/Common/Iot/Device/Graphics/Converters.cs
+++ b/src/devices/Common/Iot/Device/Graphics/Converters.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Iot.Device.Graphics
+{
+    /// <summary>
+    /// Contains a set of converters from <see cref="System.Drawing.Bitmap"/> to <see cref="BitmapImage"/>, for
+    /// easy conversion of legacy code that still uses the obsolete System.Drawing library
+    /// </summary>
+    public static class Converters
+    {
+        /// <summary>
+        /// Convert a <see cref="System.Drawing.Bitmap"/> to a <see cref="BitmapImage"/>
+        /// </summary>
+        /// <param name="bmp">Input bitmap</param>
+        /// <returns>An image</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="bmp"/> is null</exception>
+        /// <exception cref="NotSupportedException">The input format is not supported</exception>
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatform("windows")]
+#endif
+        public static unsafe BitmapImage ToBitmapImage(Bitmap bmp)
+        {
+            if (bmp == null)
+            {
+                throw new ArgumentNullException(nameof(bmp));
+            }
+
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                throw new PlatformNotSupportedException("This operation is only supported on Windows");
+            }
+
+            if (bmp.PixelFormat == System.Drawing.Imaging.PixelFormat.Format32bppArgb)
+            {
+                var target = BitmapImage.CreateBitmap(bmp.Width, bmp.Height, PixelFormat.Format32bppArgb);
+
+                var bmd = bmp.LockBits(new System.Drawing.Rectangle(0, 0, bmp.Width, bmp.Height), System.Drawing.Imaging.ImageLockMode.ReadOnly, bmp.PixelFormat);
+
+                for (int i = 0; i < bmp.Height; i++)
+                {
+                    IntPtr offsetSource = bmd.Scan0 + (bmd.Stride * i);
+                    void* sourcePtr = offsetSource.ToPointer();
+                    Span<byte> source = new Span<byte>(sourcePtr, bmd.Stride);
+                    Span<byte> dest = target.AsByteSpan().Slice(bmd.Stride * i, bmd.Stride);
+                    source.CopyTo(dest);
+                }
+
+                bmp.UnlockBits(bmd);
+
+                return target;
+            }
+
+            throw new NotSupportedException($"Converting images of type {bmp.PixelFormat} is not supported");
+        }
+
+        /// <summary>
+        /// Adjusts the target position and size so that a given image can be copied to a target image without scaling and without further cropping.
+        /// This ensures the destination rectangle, starting at the given point lies within the image.
+        /// </summary>
+        /// <param name="image">The input image size</param>
+        /// <param name="leftTop">[in, out] The top left corner of the input image to show. If at the bottom or right edge of the destination, this will be
+        /// reset so that the right edge of the input image is at the right edge of the destination</param>
+        /// <param name="destination">The destination rectangle. If this is larger than the input image, the size will be cropped</param>
+        public static void AdjustImageDestination(BitmapImage image, ref Point leftTop, ref Rectangle destination)
+        {
+            int left = leftTop.X;
+            int top = leftTop.Y;
+
+            if (destination.Width > image.Width)
+            {
+                // Rectangle is a struct, so this has no effect on the caller (yet)
+                destination.Width = image.Width;
+            }
+
+            if (destination.Height > image.Height)
+            {
+                destination.Height = image.Height;
+            }
+
+            if (left < 0)
+            {
+                left = 0;
+            }
+
+            if (left > image.Width - destination.Width)
+            {
+                left = image.Width - destination.Width;
+            }
+
+            if (top < 0)
+            {
+                top = 0;
+            }
+
+            if (top > image.Height - destination.Height)
+            {
+                top = image.Height - destination.Height;
+            }
+
+            leftTop = new Point(left, top);
+            destination = new Rectangle(destination.X, destination.Y, destination.Width, destination.Height);
+        }
+    }
+}

--- a/src/devices/Common/Iot/Device/Graphics/IGraphics.cs
+++ b/src/devices/Common/Iot/Device/Graphics/IGraphics.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Iot.Device.Graphics
+{
+    /// <summary>
+    /// This declarative interface provides the basis for drawing functions using image specific APIs.
+    /// This interface is empty. The implementation is provided via extension methods.
+    /// </summary>
+    public interface IGraphics : IDisposable
+    {
+    }
+}

--- a/src/devices/Common/Iot/Device/Graphics/IImageFactory.cs
+++ b/src/devices/Common/Iot/Device/Graphics/IImageFactory.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Iot.Device.Graphics
+{
+    /// <summary>
+    /// Factory interface for creating bitmaps.
+    /// An instance of this interface shall be provided by library-specific adapter classes.
+    /// The class <see cref="BitmapImage"/> requires an instance of this interface to work properly.
+    /// </summary>
+    public interface IImageFactory
+    {
+        /// <summary>
+        /// Creates a bitmap with the given size and format
+        /// </summary>
+        /// <param name="width">Width of the bitmap, in pixels</param>
+        /// <param name="height">Height of the bitmap in pixels</param>
+        /// <param name="pixelFormat">The desired pixel format</param>
+        /// <returns>An empty bitmap of the given size</returns>
+        BitmapImage CreateBitmap(int width, int height, PixelFormat pixelFormat);
+
+        /// <summary>
+        /// Creates a bitmap from a stream (e.g. an image file)
+        /// </summary>
+        /// <param name="file">The stream to open</param>
+        /// <returns>A bitmap from the given stream</returns>
+        BitmapImage CreateFromStream(Stream file);
+    }
+}

--- a/src/devices/Common/Iot/Device/Graphics/ImageFileType.cs
+++ b/src/devices/Common/Iot/Device/Graphics/ImageFileType.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Iot.Device.Graphics
+{
+    /// <summary>
+    /// Image file type list
+    /// </summary>
+    public enum ImageFileType
+    {
+        /// <summary>
+        /// Undefined
+        /// </summary>
+        Undefined,
+
+        /// <summary>
+        /// Png file
+        /// </summary>
+        Png,
+
+        /// <summary>
+        /// Windows Bitmap
+        /// </summary>
+        Bmp,
+
+        /// <summary>
+        /// Jpeg file
+        /// </summary>
+        Jpg,
+    }
+}

--- a/src/devices/Common/Iot/Device/Graphics/PixelFormat.cs
+++ b/src/devices/Common/Iot/Device/Graphics/PixelFormat.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Iot.Device.Graphics
+{
+    /// <summary>
+    /// Specifies the pixel format of an image.
+    /// </summary>
+    public enum PixelFormat
+    {
+        /// <summary>
+        /// The format is unspecified.
+        /// </summary>
+        Unspecified,
+
+        /// <summary>
+        /// The standard 32 bit image format
+        /// </summary>
+        Format32bppArgb,
+
+        /// <summary>
+        /// 32 bit image format with ignored alpha
+        /// </summary>
+        Format32bppXrgb,
+    }
+}

--- a/src/devices/Ht1632/Ht1632.sln
+++ b/src/devices/Ht1632/Ht1632.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31702.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33326.253
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{DA6C1243-517A-4827-A7B0-05DDCEFA88A5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ht1632", "Ht1632.csproj", "{93FDF758-A983-47E1-9D5D-12312B9FDD5E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ht1632.Sample", "samples\Ht1632.Sample.csproj", "{FDEFDC73-80AF-4FBF-95CC-DEE8824AD9DA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharpConnector", "..\SkiaSharpConnector\SkiaSharpConnector.csproj", "{8A705490-39A3-4F68-9B42-DC3B9318A161}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,6 +25,10 @@ Global
 		{FDEFDC73-80AF-4FBF-95CC-DEE8824AD9DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDEFDC73-80AF-4FBF-95CC-DEE8824AD9DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDEFDC73-80AF-4FBF-95CC-DEE8824AD9DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A705490-39A3-4F68-9B42-DC3B9318A161}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A705490-39A3-4F68-9B42-DC3B9318A161}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A705490-39A3-4F68-9B42-DC3B9318A161}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A705490-39A3-4F68-9B42-DC3B9318A161}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/devices/Ht1632/Ht1632ImageSending.cs
+++ b/src/devices/Ht1632/Ht1632ImageSending.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
+using System.Drawing;
+using Iot.Device.Graphics;
 
 namespace Iot.Device.Ht1632
 {
@@ -17,7 +17,7 @@ namespace Iot.Device.Ht1632
         /// </summary>
         /// <param name="pixel">Input pixel</param>
         /// <returns>True if lit.</returns>
-        public delegate bool BrightnessConvertor(IPixel pixel);
+        public delegate bool BrightnessConvertor(Color pixel);
 
         /// <summary>
         /// Show image with 8-Com mode
@@ -25,8 +25,8 @@ namespace Iot.Device.Ht1632
         /// <param name="ht1632">HT1632 device</param>
         /// <param name="image">Image to show. Width at least 8 pixels, height at least 32 pixels </param>
         /// <param name="brightnessConvertor">Method for whether pixel is lit or not. Use <see cref="LinearBrightnessConvertor"/> if null.</param>
-        public static void ShowImageWith8Com<TPixel>(this Ht1632 ht1632, Image<TPixel> image, BrightnessConvertor? brightnessConvertor = null)
-            where TPixel : unmanaged, IPixel<TPixel> => ht1632.ShowImage(image, 8, 32, brightnessConvertor ?? LinearBrightnessConvertor);
+        public static void ShowImageWith8Com(this Ht1632 ht1632, BitmapImage image, BrightnessConvertor? brightnessConvertor = null)
+            => ht1632.ShowImage(image, 8, 32, brightnessConvertor ?? LinearBrightnessConvertor);
 
         /// <summary>
         /// Show image with 16-Com mode
@@ -34,22 +34,20 @@ namespace Iot.Device.Ht1632
         /// <param name="ht1632">HT1632 device</param>
         /// <param name="image">Image to show. Width at least 16 pixels, height at least 24 pixels </param>
         /// <param name="brightnessConvertor">Method for whether pixel is lit or not. Use <see cref="LinearBrightnessConvertor"/> if null.</param>
-        public static void ShowImageWith16Com<TPixel>(this Ht1632 ht1632, Image<TPixel> image, BrightnessConvertor? brightnessConvertor = null)
-            where TPixel : unmanaged, IPixel<TPixel> => ht1632.ShowImage(image, 16, 24, brightnessConvertor ?? LinearBrightnessConvertor);
+        public static void ShowImageWith16Com(this Ht1632 ht1632, BitmapImage image, BrightnessConvertor? brightnessConvertor = null)
+            => ht1632.ShowImage(image, 16, 24, brightnessConvertor ?? LinearBrightnessConvertor);
 
         /// <summary>
         /// Lit if average value of RGB is greater than half.
         /// </summary>
         /// <param name="pixel">Input pixel</param>
         /// <returns>True if average value of RGB is greater than half.</returns>
-        public static bool LinearBrightnessConvertor(IPixel pixel)
+        public static bool LinearBrightnessConvertor(Color pixel)
         {
-            var vector = pixel.ToScaledVector4();
-            return vector.X + vector.Y + vector.Z > 1.5;
+            return pixel.R + pixel.G + pixel.B > (3 * 127);
         }
 
-        private static void ShowImage<TPixel>(this Ht1632 ht1632, Image<TPixel> image, int com, int row, BrightnessConvertor brightnessConvertor)
-            where TPixel : unmanaged, IPixel<TPixel>
+        private static void ShowImage(this Ht1632 ht1632, BitmapImage image, int com, int row, BrightnessConvertor brightnessConvertor)
         {
             if (image.Width < com || image.Height < row)
             {

--- a/src/devices/Ht1632/samples/Ht1632.Sample.csproj
+++ b/src/devices/Ht1632/samples/Ht1632.Sample.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
 <ItemGroup>
+    <ProjectReference Include="..\..\SkiaSharpAdapter\SkiaSharpAdapter.csproj" />
     <ProjectReference Include="..\Ht1632.csproj" />
   </ItemGroup>
 

--- a/src/devices/Ht1632/samples/Program.cs
+++ b/src/devices/Ht1632/samples/Program.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Drawing;
 using System.Device.Gpio;
+using Iot.Device.Graphics;
+using Iot.Device.Graphics.SkiaSharpAdapter;
 using Iot.Device.Ht1632;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
+SkiaSharpAdapter.Register();
 Console.WriteLine("Initialize HT1632 with 24-ROW x 16-COM, RC-primary, PWM 1/16 duty.");
 Console.WriteLine("cs: 27, wr: 22, data: 17");
 using var ht1632 = new Ht1632(new Ht1632PinMapping(cs: 27, wr: 22, data: 17), new GpioController())
@@ -56,6 +58,6 @@ void ShowImage()
 {
     Console.WriteLine("Show image");
 
-    var image = Image.Load<Rgb24>("./dotnet-bot.bmp");
+    var image = BitmapImage.CreateFromFile("./dotnet-bot.bmp");
     ht1632.ShowImageWith16Com(image);
 }

--- a/src/devices/Ili9341/Ili9341.sln
+++ b/src/devices/Ili9341/Ili9341.sln
@@ -1,0 +1,67 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33326.253
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{0D478BAB-AFEA-4AF1-866C-E3AC32E11C5A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ili9341.Samples", "samples\Ili9341.Samples.csproj", "{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ili9341", "Ili9341.csproj", "{1398DC14-97F0-4048-965A-CCB3D44BFE06}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\Common\Common.csproj", "{4E04A275-4671-4262-B463-1DDD8E795E79}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Debug|x64.Build.0 = Debug|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Debug|x86.Build.0 = Debug|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Release|x64.ActiveCfg = Release|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Release|x64.Build.0 = Release|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Release|x86.ActiveCfg = Release|Any CPU
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6}.Release|x86.Build.0 = Release|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Debug|x64.Build.0 = Debug|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Debug|x86.Build.0 = Debug|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Release|x64.ActiveCfg = Release|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Release|x64.Build.0 = Release|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Release|x86.ActiveCfg = Release|Any CPU
+		{1398DC14-97F0-4048-965A-CCB3D44BFE06}.Release|x86.Build.0 = Release|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Debug|x64.Build.0 = Debug|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Debug|x86.Build.0 = Debug|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Release|x64.ActiveCfg = Release|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Release|x64.Build.0 = Release|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Release|x86.ActiveCfg = Release|Any CPU
+		{4E04A275-4671-4262-B463-1DDD8E795E79}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D9FEFE08-18E7-458A-8ECC-73A8D1E078F6} = {0D478BAB-AFEA-4AF1-866C-E3AC32E11C5A}
+	EndGlobalSection
+EndGlobal

--- a/src/devices/Ili9341/Ili9341Imaging.cs
+++ b/src/devices/Ili9341/Ili9341Imaging.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 
+#pragma warning disable CA1416 // Temporarily, will be removed after binding is updated
 namespace Iot.Device.Ili9341
 {
     public partial class Ili9341

--- a/src/devices/Ili9341/samples/Program.cs
+++ b/src/devices/Ili9341/samples/Program.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Iot.Device.Ft4222;
 using Iot.Device.Ili9341;
-
+#pragma warning disable CA1416 // Temporarily, will be removed after binding is updated
 Console.WriteLine("Are you using Ft4222? Type 'yes' and press ENTER if so, anything else will be treated as no.");
 bool isFt4222 = Console.ReadLine() == "yes";
 

--- a/src/devices/Is31fl3731/BreakoutRgb5x5.cs
+++ b/src/devices/Is31fl3731/BreakoutRgb5x5.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Device.I2c;
+using System.Drawing;
 using System.Threading;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace Iot.Device.Display
 {
@@ -71,10 +70,9 @@ namespace Iot.Device.Display
         public void WritePixelRgb(int x, int y, Color color)
         {
             x += y * 5;
-            Rgb24 pixel = color.ToPixel<Rgb24>();
-            this[x, 0] = pixel.R;
-            this[x, 1] = pixel.G;
-            this[x, 2] = pixel.B;
+            this[x, 0] = color.R;
+            this[x, 1] = color.G;
+            this[x, 2] = color.B;
         }
     }
 }

--- a/src/devices/Is31fl3731/LedShimRgb28x1.cs
+++ b/src/devices/Is31fl3731/LedShimRgb28x1.cs
@@ -3,8 +3,7 @@
 
 using System;
 using System.Device.I2c;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
+using System.Drawing;
 
 namespace Iot.Device.Display
 {
@@ -70,10 +69,9 @@ namespace Iot.Device.Display
         /// <param name="color">Color value.</param>
         public void WritePixelRgb(int x, Color color)
         {
-            Rgb24 pixel = color.ToPixel<Rgb24>();
-            this[x, 0] = pixel.R;
-            this[x, 1] = pixel.G;
-            this[x, 2] = pixel.B;
+            this[x, 0] = color.R;
+            this[x, 1] = color.G;
+            this[x, 2] = color.B;
         }
 
     }

--- a/src/devices/Is31fl3731/samples/LedShim28x1/Program.cs
+++ b/src/devices/Is31fl3731/samples/LedShim28x1/Program.cs
@@ -3,10 +3,10 @@
 using System;
 using System.Collections.Generic;
 using System.Device.I2c;
+using System.Drawing;
 using System.Linq;
 using System.Threading;
 using Iot.Device.Display;
-using SixLabors.ImageSharp;
 
 // For 28x1 LED Shim
 // https://shop.pimoroni.com/products/led-shim
@@ -45,7 +45,7 @@ while (true)
         foreach (int x in Enumerable.Range(0, 28))
         {
             var (r, g, b) = rainbow[(x + offset) % 28];
-            Color color = Color.FromRgb(r, g, b);
+            Color color = Color.FromArgb(r, g, b);
             shim.WritePixelRgb(x, color);
         }
     }

--- a/src/devices/Is31fl3731/samples/MatrixRgb/Program.cs
+++ b/src/devices/Is31fl3731/samples/MatrixRgb/Program.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Device.I2c;
+using System.Drawing;
 using System.Linq;
 using System.Threading;
 using Iot.Device.Display;
-using SixLabors.ImageSharp;
 
 // Port of https://github.com/adafruit/Adafruit_CircuitPython_IS31FL3731/blob/main/examples/is31fl3731_rgbmatrix5x5_rainbow.py
 using I2cDevice i2cdevice = I2cDevice.Create(new I2cConnectionSettings(busId: 1, BreakoutRgb5x5.DefaultI2cAddress));
@@ -80,7 +80,7 @@ void TestPixels(byte r, byte g, byte b)
         foreach (int x in Enumerable.Range(0, 5))
         {
             matrix.Fill(0);  // Clear display
-            Color color = Color.FromRgb(r, g, b);
+            Color color = Color.FromArgb(r, g, b);
             matrix.WritePixelRgb(x, y, color);
             Thread.Sleep(50);
         }
@@ -89,7 +89,7 @@ void TestPixels(byte r, byte g, byte b)
 
 void TestRows(byte r, byte g, byte b)
 {
-    Color color = Color.FromRgb(r, g, b);
+    Color color = Color.FromArgb(r, g, b);
     // Draw full rows from top to bottom
     foreach (int y in Enumerable.Range(0, 5))
     {
@@ -105,7 +105,7 @@ void TestRows(byte r, byte g, byte b)
 
 void TestColumns(byte r, byte g, byte b)
 {
-    Color color = Color.FromRgb(r, g, b);
+    Color color = Color.FromArgb(r, g, b);
     // Draw full columns from left to right
     foreach (int x in Enumerable.Range(0, 5))
     {
@@ -135,7 +135,7 @@ void TestRainbowSweep()
                 pixel_hue = pixel_hue - Math.Floor(pixel_hue);
 
                 var (r, g, b) = HsvToRgb(pixel_hue, 1, 1);
-                Color color = Color.FromRgb((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+                Color color = Color.FromArgb((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
                 matrix.WritePixelRgb(x, y, color);
             }
 

--- a/src/devices/Lp55231/Lp55231.cs
+++ b/src/devices/Lp55231/Lp55231.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Device.I2c;
+using System.Drawing;
 using System.IO;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace Iot.Device.Lp55231
 {
@@ -56,9 +55,9 @@ namespace Iot.Device.Lp55231
 
             _leds = new[]
             {
-                Color.FromRgba(0, 0, 0, byte.MaxValue),
-                Color.FromRgba(0, 0, 0, byte.MaxValue),
-                Color.FromRgba(0, 0, 0, byte.MaxValue)
+                Color.FromArgb(255, 0, 0, 0),
+                Color.FromArgb(255, 0, 0, 0),
+                Color.FromArgb(255, 0, 0, 0)
             };
         }
 
@@ -176,11 +175,9 @@ namespace Iot.Device.Lp55231
 
                 if (value != _leds[index])
                 {
-                    var color = value.ToPixel<Rgba32>();
-
-                    SetIntensity(RedChannel(index), color.R);
-                    SetIntensity(GreenChannel(index), color.G);
-                    SetIntensity(BlueChannel(index), color.B);
+                    SetIntensity(RedChannel(index), value.R);
+                    SetIntensity(GreenChannel(index), value.G);
+                    SetIntensity(BlueChannel(index), value.B);
 
                     _leds[index] = value;
                 }

--- a/src/devices/Lp55231/samples/Lp55231.Samples.csproj
+++ b/src/devices/Lp55231/samples/Lp55231.Samples.csproj
@@ -4,10 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DefaultSampleTfms)</TargetFramework>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Lp55231.csproj" />

--- a/src/devices/Lp55231/samples/Program.cs
+++ b/src/devices/Lp55231/samples/Program.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Device.I2c;
+using System.Drawing;
 using System.Threading;
 using Iot.Device.Lp55231;
-using SixLabors.ImageSharp;
 
 var i2cDevice = I2cDevice.Create(new I2cConnectionSettings(1, Lp55231.DefaultI2cAddress));
 
@@ -22,8 +22,8 @@ ledDriver.Misc = MiscFlags.ClockSourceSelection
                | MiscFlags.ChargeModeGainHighBit
                | MiscFlags.AddressAutoIncrementEnable;
 
-ledDriver[0] = Color.FromRgba(255, 0, 0, byte.MaxValue);
-ledDriver[1] = Color.FromRgba(0, 255, 0, byte.MaxValue);
-ledDriver[2] = Color.FromRgba(0, 0, 255, byte.MaxValue);
+ledDriver[0] = Color.FromArgb(255, 0, 0);
+ledDriver[1] = Color.FromArgb(0, 255, 0);
+ledDriver[2] = Color.FromArgb(0, 0, 255);
 
 Console.WriteLine("Should be showing red, green, blue");

--- a/src/devices/Media/Media.csproj
+++ b/src/devices/Media/Media.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="VideoDevice/*.cs" />
     <Compile Include="VideoDevice/Devices/*.cs" />
     <Compile Include="SoundDevice/*.cs" />

--- a/src/devices/Media/Media.sln
+++ b/src/devices/Media/Media.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MjpegStream", "VideoDevice\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\Common\Common.csproj", "{2EDE86C6-43D3-42AA-A8E0-1AE61BD5F6EB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharpConnector", "..\SkiaSharpConnector\SkiaSharpConnector.csproj", "{02C24406-6764-45EC-967E-E9AAB5EA92E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,18 @@ Global
 		{2EDE86C6-43D3-42AA-A8E0-1AE61BD5F6EB}.Release|x64.Build.0 = Release|Any CPU
 		{2EDE86C6-43D3-42AA-A8E0-1AE61BD5F6EB}.Release|x86.ActiveCfg = Release|Any CPU
 		{2EDE86C6-43D3-42AA-A8E0-1AE61BD5F6EB}.Release|x86.Build.0 = Release|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Debug|x64.Build.0 = Debug|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Debug|x86.Build.0 = Debug|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Release|x64.ActiveCfg = Release|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Release|x64.Build.0 = Release|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Release|x86.ActiveCfg = Release|Any CPU
+		{02C24406-6764-45EC-967E-E9AAB5EA92E1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/devices/Media/VideoDevice/Devices/Interop.videodev2.struct.cs
+++ b/src/devices/Media/VideoDevice/Devices/Interop.videodev2.struct.cs
@@ -89,7 +89,7 @@ internal partial class InteropVideodev2
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
         public string description;
 
-        public PixelFormat pixelformat;
+        public VideoPixelFormat pixelformat;
 
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
         public uint[] reserved;
@@ -152,7 +152,7 @@ internal partial class InteropVideodev2
         [FieldOffset(4)]
         public uint height;
         [FieldOffset(8)]
-        public PixelFormat pixelformat;
+        public VideoPixelFormat pixelformat;
         [FieldOffset(12)]
         public v4l2_field field;
         [FieldOffset(16)]
@@ -228,7 +228,7 @@ internal partial class InteropVideodev2
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct v4l2_sdr_format
     {
-        public PixelFormat pixelformat;
+        public VideoPixelFormat pixelformat;
         public uint buffersize;
         public fixed byte reserved[24];
     }
@@ -373,7 +373,7 @@ internal partial class InteropVideodev2
         [FieldOffset(0)]
         public uint index;
         [FieldOffset(4)]
-        public PixelFormat pixel_format;
+        public VideoPixelFormat pixel_format;
         [FieldOffset(8)]
         public v4l2_frmsizetypes type;
         [FieldOffset(12)]

--- a/src/devices/Media/VideoDevice/Devices/UnixVideoDevice.cs
+++ b/src/devices/Media/VideoDevice/Devices/UnixVideoDevice.cs
@@ -182,7 +182,7 @@ namespace Iot.Device.Media
         /// Get all the pixel formats supported by the device.
         /// </summary>
         /// <returns>Supported pixel formats.</returns>
-        public override IEnumerable<PixelFormat> GetSupportedPixelFormats()
+        public override IEnumerable<VideoPixelFormat> GetSupportedPixelFormats()
         {
             Initialize();
 
@@ -192,7 +192,7 @@ namespace Iot.Device.Media
                 type = InteropVideodev2.v4l2_buf_type.V4L2_BUF_TYPE_VIDEO_CAPTURE
             };
 
-            List<PixelFormat> result = new List<PixelFormat>();
+            List<VideoPixelFormat> result = new List<VideoPixelFormat>();
             while (V4l2Struct(InteropVideodev2.V4l2Request.VIDIOC_ENUM_FMT, ref fmtdesc) != -1)
             {
                 result.Add(fmtdesc.pixelformat);
@@ -207,7 +207,7 @@ namespace Iot.Device.Media
         /// </summary>
         /// <param name="format">Pixel format.</param>
         /// <returns>Supported resolution.</returns>
-        public override IEnumerable<Resolution> GetPixelFormatResolutions(PixelFormat format)
+        public override IEnumerable<Resolution> GetPixelFormatResolutions(VideoPixelFormat format)
         {
             Initialize();
 

--- a/src/devices/Media/VideoDevice/PixelFormat.cs
+++ b/src/devices/Media/VideoDevice/PixelFormat.cs
@@ -10,7 +10,7 @@ namespace Iot.Device.Media
     /// <summary>
     /// The pixel format of a video device.
     /// </summary>
-    public enum PixelFormat : uint
+    public enum VideoPixelFormat : uint
     {
         /// <summary>
         /// RGB332

--- a/src/devices/Media/VideoDevice/VideoConnectionSettings.cs
+++ b/src/devices/Media/VideoDevice/VideoConnectionSettings.cs
@@ -14,7 +14,7 @@ namespace Iot.Device.Media
         /// <param name="busId">The bus ID the video device is connected to.</param>
         /// <param name="captureSize">The size of video device captured image.</param>
         /// <param name="pixelFormat">The pixel format of video device captured image.</param>
-        public VideoConnectionSettings(int busId, (uint Width, uint Height) captureSize, PixelFormat pixelFormat = PixelFormat.YUYV)
+        public VideoConnectionSettings(int busId, (uint Width, uint Height) captureSize, VideoPixelFormat pixelFormat = VideoPixelFormat.YUYV)
         {
             BusId = busId;
             CaptureSize = captureSize;
@@ -34,7 +34,7 @@ namespace Iot.Device.Media
         /// <summary>
         /// The pixel format of video device captured image.
         /// </summary>
-        public PixelFormat PixelFormat { get; set; }
+        public VideoPixelFormat PixelFormat { get; set; }
 
         /// <summary>
         /// The exposure type of video device.

--- a/src/devices/Media/VideoDevice/VideoDevice.Converter.cs
+++ b/src/devices/Media/VideoDevice/VideoDevice.Converter.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using Iot.Device.Graphics;
 
 namespace Iot.Device.Media
 {
@@ -133,11 +134,11 @@ namespace Iot.Device.Media
         /// <param name="colors">RGB data.</param>
         /// <param name="format">Bitmap pixel format</param>
         /// <returns>Bitmap</returns>
-        public static Bitmap RgbToBitmap((uint Width, uint Height) size, Color[] colors, System.Drawing.Imaging.PixelFormat format = System.Drawing.Imaging.PixelFormat.Format24bppRgb)
+        public static BitmapImage RgbToBitmap((uint Width, uint Height) size, Color[] colors, Iot.Device.Graphics.PixelFormat format = Iot.Device.Graphics.PixelFormat.Format32bppXrgb)
         {
             int width = (int)size.Width, height = (int)size.Height;
 
-            Bitmap pic = new Bitmap(width, height, format);
+            BitmapImage pic = BitmapImage.CreateBitmap(width, height, format);
 
             for (int x = 0; x < width; x++)
             {

--- a/src/devices/Media/VideoDevice/VideoDevice.cs
+++ b/src/devices/Media/VideoDevice/VideoDevice.cs
@@ -124,14 +124,14 @@ namespace Iot.Device.Media
         /// Get all the pixel formats supported by the device.
         /// </summary>
         /// <returns>Supported pixel formats.</returns>
-        public abstract IEnumerable<PixelFormat> GetSupportedPixelFormats();
+        public abstract IEnumerable<VideoPixelFormat> GetSupportedPixelFormats();
 
         /// <summary>
         /// Get all the resolutions supported by the specified pixel format.
         /// </summary>
         /// <param name="format">Pixel format.</param>
         /// <returns>Supported resolution.</returns>
-        public abstract IEnumerable<Resolution> GetPixelFormatResolutions(PixelFormat format);
+        public abstract IEnumerable<Resolution> GetPixelFormatResolutions(VideoPixelFormat format);
 
         /// <inheritdoc/>
         public void Dispose()

--- a/src/devices/Media/VideoDevice/samples/MjpegStream/Camera.cs
+++ b/src/devices/Media/VideoDevice/samples/MjpegStream/Camera.cs
@@ -34,7 +34,7 @@ namespace CameraIoT
         public Camera()
         {
             // You can select other size and other format, this is a very basic one supported by all types of webcams including old ones
-            VideoConnectionSettings settings = new VideoConnectionSettings(0, (640, 480), Iot.Device.Media.PixelFormat.JPEG);
+            VideoConnectionSettings settings = new VideoConnectionSettings(0, (640, 480), Iot.Device.Media.VideoPixelFormat.JPEG);
             _device = VideoDevice.Create(settings);
             // if the device has sufficent ram, enabling pooling significantly improves frames per second by preventing GC.
             _device.ImageBufferPoolingEnabled = true;

--- a/src/devices/Media/VideoDevice/samples/MjpegStream/MjpegStream.csproj
+++ b/src/devices/Media/VideoDevice/samples/MjpegStream/MjpegStream.csproj
@@ -7,6 +7,7 @@
   
   <ItemGroup>
     <ProjectReference Include="../../../Media.csproj" />
+    <ProjectReference Include="..\..\..\..\SkiaSharpAdapter\SkiaSharpAdapter.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/Media/VideoDevice/samples/MjpegStream/MjpegStream.csproj
+++ b/src/devices/Media/VideoDevice/samples/MjpegStream/MjpegStream.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <ProjectReference Include="../../../Media.csproj" />
+    <ProjectReference Include="..\..\..\Media.csproj" />
     <ProjectReference Include="..\..\..\..\SkiaSharpAdapter\SkiaSharpAdapter.csproj" />
   </ItemGroup>
 

--- a/src/devices/Media/VideoDevice/samples/Program.cs
+++ b/src/devices/Media/VideoDevice/samples/Program.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Drawing;
 using System.IO;
+using Iot.Device.Graphics;
 using Iot.Device.Media;
 
-VideoConnectionSettings settings = new(0, (2560, 1920), PixelFormat.JPEG);
+VideoConnectionSettings settings = new(0, (2560, 1920), VideoPixelFormat.JPEG);
 using VideoDevice device = VideoDevice.Create(settings);
 
 // Get the supported formats of the device
-foreach (PixelFormat item in device.GetSupportedPixelFormats())
+foreach (VideoPixelFormat item in device.GetSupportedPixelFormats())
 {
     Console.Write($"{item} ");
 }
@@ -18,7 +19,7 @@ foreach (PixelFormat item in device.GetSupportedPixelFormats())
 Console.WriteLine();
 
 // Get the resolutions of the format
-foreach (var resolution in device.GetPixelFormatResolutions(PixelFormat.YUYV))
+foreach (var resolution in device.GetPixelFormatResolutions(VideoPixelFormat.YUYV))
 {
     Console.Write($"[{resolution.MinWidth}x{resolution.MinHeight}]->[{resolution.MaxWidth}x{resolution.MaxHeight}], Step [{resolution.StepWidth},{resolution.StepHeight}] ");
 }
@@ -35,10 +36,10 @@ string path = Directory.GetCurrentDirectory();
 device.Capture($"{path}/jpg_direct_output.jpg");
 
 // Change capture setting
-device.Settings.PixelFormat = PixelFormat.YUV420;
+device.Settings.PixelFormat = VideoPixelFormat.YUV420;
 
 // Convert pixel format
 using var stream = new MemoryStream(device.Capture());
 Color[] colors = VideoDevice.Yv12ToRgb(stream, settings.CaptureSize);
-Bitmap bitmap = VideoDevice.RgbToBitmap(settings.CaptureSize, colors);
-bitmap.Save($"{path}/yuyv_to_jpg.jpg", System.Drawing.Imaging.ImageFormat.Jpeg);
+var bitmap = VideoDevice.RgbToBitmap(settings.CaptureSize, colors);
+bitmap.SaveToFile($"{path}/yuyv_to_jpg.jpg", ImageFileType.Jpg);

--- a/src/devices/Pcd8544/Pcd8544.cs
+++ b/src/devices/Pcd8544/Pcd8544.cs
@@ -6,9 +6,9 @@ using System.Device.Gpio;
 using System.Device.Spi;
 using System.Device.Pwm;
 using System.Threading;
+using System.Drawing;
 using System.Collections.Generic;
 using Iot.Device.Display.Pcd8544Enums;
-using SixLabors.ImageSharp;
 using Iot.Device.CharacterLcd;
 using Iot.Device.Graphics;
 

--- a/src/devices/Pcd8544/Pcd8544.sln
+++ b/src/devices/Pcd8544/Pcd8544.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30804.86
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33326.253
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pcd8544", "Pcd8544.csproj", "{11BF29C0-463C-4423-B028-92833F068001}"
 EndProject
@@ -14,6 +14,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\Common\Common.csproj", "{85E17B98-0745-407A-894B-214F25BAE20F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CharacterLcd.Tests", "..\CharacterLcd\tests\CharacterLcd.Tests.csproj", "{9395365B-927A-4E84-9294-AD243BB167D8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharpConnector", "..\SkiaSharpConnector\SkiaSharpConnector.csproj", "{1388471B-70A2-4749-AE47-1D73BD43FA10}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +47,10 @@ Global
 		{9395365B-927A-4E84-9294-AD243BB167D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9395365B-927A-4E84-9294-AD243BB167D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9395365B-927A-4E84-9294-AD243BB167D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1388471B-70A2-4749-AE47-1D73BD43FA10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1388471B-70A2-4749-AE47-1D73BD43FA10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1388471B-70A2-4749-AE47-1D73BD43FA10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1388471B-70A2-4749-AE47-1D73BD43FA10}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/devices/Pcd8544/samples/Pcd8544.samples.csproj
+++ b/src/devices/Pcd8544/samples/Pcd8544.samples.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(DefaultSampleTfms)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\SkiaSharpAdapter\SkiaSharpAdapter.csproj" />
     <ProjectReference Include="..\Pcd8544.csproj" />
     <ProjectReference Include="..\..\Ft4222\Ft4222.csproj" />
     <ProjectReference Include="..\..\SoftPwm\SoftwarePwm.csproj" />

--- a/src/devices/Pcd8544/samples/Program.cs
+++ b/src/devices/Pcd8544/samples/Program.cs
@@ -10,13 +10,14 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Globalization;
+using System.Drawing;
 using Iot.Device.Display;
 using Iot.Device.Ft4222;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 using Iot.Device.CharacterLcd;
+using Iot.Device.Graphics;
+using Iot.Device.Graphics.SkiaSharpAdapter;
 
+SkiaSharpAdapter.Register();
 Console.WriteLine("Hello PCD8544, screen of Nokia 5110!");
 Console.WriteLine("Please select the platform you want to use:");
 Console.WriteLine("  1. Native device like a Raspberry Pi");
@@ -289,15 +290,15 @@ void DisplayTextChangePositionBlink()
 void DisplayingBitmap()
 {
     Console.WriteLine("Displaying bitmap, text, resizing them");
-    using Image<Rgba32> bitmapMe = Image.Load<Rgba32>(Path.Combine("me.bmp"));
+    using BitmapImage bitmapMe = BitmapImage.CreateFromFile(Path.Combine("me.bmp"));
     var bitmap1 = BitmapToByteArray(bitmapMe);
-    using Image<Rgba32> bitmapNokia = Image.Load<Rgba32>(Path.Combine("nokia_bw.bmp"));
+    using BitmapImage bitmapNokia = BitmapImage.CreateFromFile(Path.Combine("nokia_bw.bmp"));
     var bitmap2 = BitmapToByteArray(bitmapNokia);
 
     // Open a non bitmap and resize it
-    using Image<Rgba32> bitmapLarge = Image.Load<Rgba32>(Path.Combine("nonbmp.jpg"));
-    bitmapLarge.Mutate(x => x.Resize(Pcd8544.PixelScreenSize));
-    bitmapLarge.Mutate(x => x.BlackWhite());
+    BitmapImage bitmapLarge = BitmapImage.CreateFromFile(Path.Combine("nonbmp.jpg"));
+    bitmapLarge = bitmapLarge.Resize(Pcd8544.PixelScreenSize);
+    bitmapLarge.Clear();
     var bitmap3 = BitmapToByteArray(bitmapLarge);
 
     for (byte i = 0; i < 2; i++)
@@ -337,6 +338,8 @@ void DisplayingBitmap()
         lcd.Draw();
         Thread.Sleep(1500);
     }
+
+    bitmapLarge.Dispose();
 }
 
 void DisplayLinesPointsRectabngles()
@@ -463,7 +466,7 @@ lcd.Dispose();
 // In case we're using FT4222, gpio needs to be disposed after the screen
 gpio?.Dispose();
 
-byte[] BitmapToByteArray(Image<Rgba32> bitmap)
+byte[] BitmapToByteArray(BitmapImage bitmap)
 {
     if (bitmap is not object)
     {
@@ -477,7 +480,7 @@ byte[] BitmapToByteArray(Image<Rgba32> bitmap)
 
     byte[] toReturn = new byte[Pcd8544.ScreenBufferByteSize];
     int width = Pcd8544.PixelScreenSize.Width;
-    Rgba32 colWhite = new(255, 255, 255);
+    Color colWhite = Color.White;
     for (int position = 0; position < Pcd8544.ScreenBufferByteSize; position++)
     {
         byte toStore = 0;

--- a/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
+++ b/src/devices/RGBLedMatrix/RGBLedMatrix.csproj
@@ -4,9 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
-  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="Gpio.cs" />
     <Compile Include="PinMapping.cs" />

--- a/src/devices/RGBLedMatrix/RGBLedMatrix.sln
+++ b/src/devices/RGBLedMatrix/RGBLedMatrix.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31205.134
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33326.253
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{C5A43465-133D-4092-AFD5-DE329B3ED9E4}"
 EndProject
@@ -10,6 +10,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RGBLedMatrix", "RGBLedMatrix.csproj", "{40A8EFFD-B81F-4A1E-A41C-27F12848D16D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\Common\Common.csproj", "{C9339537-8395-4950-AED4-C58910870439}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharpConnector", "..\SkiaSharpConnector\SkiaSharpConnector.csproj", "{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +59,18 @@ Global
 		{C9339537-8395-4950-AED4-C58910870439}.Release|x64.Build.0 = Release|Any CPU
 		{C9339537-8395-4950-AED4-C58910870439}.Release|x86.ActiveCfg = Release|Any CPU
 		{C9339537-8395-4950-AED4-C58910870439}.Release|x86.Build.0 = Release|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|x64.Build.0 = Debug|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|x86.Build.0 = Debug|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|x64.Build.0 = Release|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|x86.ActiveCfg = Release|Any CPU
+		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/devices/RGBLedMatrix/RGBLedMatrix.sln
+++ b/src/devices/RGBLedMatrix/RGBLedMatrix.sln
@@ -11,7 +11,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RGBLedMatrix", "RGBLedMatri
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\Common\Common.csproj", "{C9339537-8395-4950-AED4-C58910870439}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharpConnector", "..\SkiaSharpConnector\SkiaSharpConnector.csproj", "{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharpAdapter", "..\SkiaSharpAdapter\SkiaSharpAdapter.csproj", "{49F4A159-CA11-4466-9AB4-691C1831BB1D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,18 +59,18 @@ Global
 		{C9339537-8395-4950-AED4-C58910870439}.Release|x64.Build.0 = Release|Any CPU
 		{C9339537-8395-4950-AED4-C58910870439}.Release|x86.ActiveCfg = Release|Any CPU
 		{C9339537-8395-4950-AED4-C58910870439}.Release|x86.Build.0 = Release|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|x64.Build.0 = Debug|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Debug|x86.Build.0 = Debug|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|x64.ActiveCfg = Release|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|x64.Build.0 = Release|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|x86.ActiveCfg = Release|Any CPU
-		{15B5CD3A-2F61-47D9-888A-E20C7866A0F5}.Release|x86.Build.0 = Release|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Debug|x64.Build.0 = Debug|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Debug|x86.Build.0 = Debug|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Release|x64.ActiveCfg = Release|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Release|x64.Build.0 = Release|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Release|x86.ActiveCfg = Release|Any CPU
+		{49F4A159-CA11-4466-9AB4-691C1831BB1D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/devices/RGBLedMatrix/RgbLedMatrix.cs
+++ b/src/devices/RGBLedMatrix/RgbLedMatrix.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
@@ -386,7 +385,7 @@ namespace Iot.Device.LEDMatrix
         /// <param name="y">Upper left y coordinate on the display</param>
         /// <param name="bitmap">System.Drawing.Bitmap object to draw</param>
         /// <param name="backBuffer">true if want use back buffer, false otherwise</param>
-        public unsafe void DrawBitmap(int x, int y, Bitmap bitmap, bool backBuffer = false)
+        public unsafe void DrawBitmap(int x, int y, BitmapImage bitmap, bool backBuffer = false)
         {
             if (y >= Height || x >= Width || x + bitmap.Width <= 0 || y + bitmap.Height <= 0)
             {
@@ -395,36 +394,25 @@ namespace Iot.Device.LEDMatrix
 
             byte[] buffer = backBuffer ? _colorsBackBuffer : _colorsBuffer;
 
-            Rectangle fullImageRectangle = new Rectangle(0, 0, bitmap.Width, bitmap.Height);
             Rectangle partialBitmap = new Rectangle(x, y, bitmap.Width, bitmap.Height);
             partialBitmap.Intersect(new Rectangle(0, 0, Width, Height));
 
-            BitmapData bitmapData =
-                bitmap.LockBits(fullImageRectangle, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
+            int bmpStride = bitmap.Width * 4;
+            int pos = 3 * ((y < 0 ? Math.Abs(y) * bitmap.Width : 0) + (x < 0 ? Math.Abs(x) : 0));
+            int stride = (bmpStride - 3 * bitmap.Width) + 3 * (bitmap.Width - partialBitmap.Width);
 
-            try
+            Span<byte> span = bitmap.AsByteSpan();
+
+            for (int j = 0; j < partialBitmap.Height; j++)
             {
-                int pos = 3 * ((y < 0 ? Math.Abs(y) * bitmap.Width : 0) + (x < 0 ? Math.Abs(x) : 0));
-                int stride = (bitmapData.Stride - 3 * bitmap.Width) + 3 * (bitmap.Width - partialBitmap.Width);
-
-                Span<byte> span = new Span<byte>((void*)bitmapData.Scan0,
-                    fullImageRectangle.Width * fullImageRectangle.Height * 3);
-
-                for (int j = 0; j < partialBitmap.Height; j++)
+                for (int i = 0; i < partialBitmap.Width; i++)
                 {
-                    for (int i = 0; i < partialBitmap.Width; i++)
-                    {
-                        SetPixel(partialBitmap.X + i, partialBitmap.Y + j, span[pos + 2], span[pos + 1], span[pos],
-                            buffer);
-                        pos += 3;
-                    }
-
-                    pos += stride;
+                    SetPixel(partialBitmap.X + i, partialBitmap.Y + j, span[pos + 2], span[pos + 1], span[pos],
+                        buffer);
+                    pos += 3;
                 }
-            }
-            finally
-            {
-                bitmap.UnlockBits(bitmapData);
+
+                pos += stride;
             }
         }
 
@@ -442,7 +430,7 @@ namespace Iot.Device.LEDMatrix
         /// <param name="repGreen">replacement color for the green color</param>
         /// <param name="repBlue">replacement color for the blue color</param>
         /// <param name="backBuffer">true if want use back buffer, false otherwise</param>
-        public unsafe void DrawBitmap(int x, int y, Bitmap bitmap, byte red, byte green, byte blue, byte repRed,
+        public unsafe void DrawBitmap(int x, int y, BitmapImage bitmap, byte red, byte green, byte blue, byte repRed,
             byte repGreen, byte repBlue, bool backBuffer = false)
         {
             if (y >= Height || x >= Width || x + bitmap.Width <= 0 || y + bitmap.Height <= 0)
@@ -459,38 +447,29 @@ namespace Iot.Device.LEDMatrix
             int coorX = Math.Max(0, x);
             int coorY = Math.Max(0, y);
 
-            BitmapData bitmapData = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height),
-                ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
+            int bmpStride = bitmap.Width * 4; // BitmapImage is (currently) always ARGB8888 or XRGB0888
+            int pos = 3 * (bitmapY * bitmap.Width + bitmapX);
+            int stride = (bmpStride - 3 * bitmap.Width) + 3 * (bitmap.Width - bitmapWidth);
 
-            try
+            Span<byte> span = bitmap.AsByteSpan();
+
+            for (int j = 0; j < bitmapHeight; j++)
             {
-                int pos = 3 * (bitmapY * bitmap.Width + bitmapX);
-                int stride = (bitmapData.Stride - 3 * bitmap.Width) + 3 * (bitmap.Width - bitmapWidth);
-
-                Span<byte> span = new Span<byte>((void*)bitmapData.Scan0, bitmapData.Stride * bitmap.Height);
-
-                for (int j = 0; j < bitmapHeight; j++)
+                for (int i = 0; i < bitmapWidth; i++)
                 {
-                    for (int i = 0; i < bitmapWidth; i++)
+                    if (red == span[pos + 2] && green == span[pos + 1] && blue == span[pos])
                     {
-                        if (red == span[pos + 2] && green == span[pos + 1] && blue == span[pos])
-                        {
-                            SetPixel(coorX + i, coorY + j, repRed, repGreen, repBlue, buffer);
-                        }
-                        else
-                        {
-                            SetPixel(coorX + i, coorY + j, span[pos + 2], span[pos + 1], span[pos], buffer);
-                        }
-
-                        pos += 3;
+                        SetPixel(coorX + i, coorY + j, repRed, repGreen, repBlue, buffer);
+                    }
+                    else
+                    {
+                        SetPixel(coorX + i, coorY + j, span[pos + 2], span[pos + 1], span[pos], buffer);
                     }
 
-                    pos += stride;
+                    pos += 3;
                 }
-            }
-            finally
-            {
-                bitmap.UnlockBits(bitmapData);
+
+                pos += stride;
             }
         }
 

--- a/src/devices/RGBLedMatrix/RgbLedMatrix.cs
+++ b/src/devices/RGBLedMatrix/RgbLedMatrix.cs
@@ -385,7 +385,7 @@ namespace Iot.Device.LEDMatrix
         /// <param name="y">Upper left y coordinate on the display</param>
         /// <param name="bitmap">System.Drawing.Bitmap object to draw</param>
         /// <param name="backBuffer">true if want use back buffer, false otherwise</param>
-        public unsafe void DrawBitmap(int x, int y, BitmapImage bitmap, bool backBuffer = false)
+        public void DrawBitmap(int x, int y, BitmapImage bitmap, bool backBuffer = false)
         {
             if (y >= Height || x >= Width || x + bitmap.Width <= 0 || y + bitmap.Height <= 0)
             {
@@ -397,7 +397,7 @@ namespace Iot.Device.LEDMatrix
             Rectangle partialBitmap = new Rectangle(x, y, bitmap.Width, bitmap.Height);
             partialBitmap.Intersect(new Rectangle(0, 0, Width, Height));
 
-            int bmpStride = bitmap.Width * 4;
+            int bmpStride = bitmap.Stride;
             int pos = 3 * ((y < 0 ? Math.Abs(y) * bitmap.Width : 0) + (x < 0 ? Math.Abs(x) : 0));
             int stride = (bmpStride - 3 * bitmap.Width) + 3 * (bitmap.Width - partialBitmap.Width);
 
@@ -430,7 +430,7 @@ namespace Iot.Device.LEDMatrix
         /// <param name="repGreen">replacement color for the green color</param>
         /// <param name="repBlue">replacement color for the blue color</param>
         /// <param name="backBuffer">true if want use back buffer, false otherwise</param>
-        public unsafe void DrawBitmap(int x, int y, BitmapImage bitmap, byte red, byte green, byte blue, byte repRed,
+        public void DrawBitmap(int x, int y, BitmapImage bitmap, byte red, byte green, byte blue, byte repRed,
             byte repGreen, byte repBlue, bool backBuffer = false)
         {
             if (y >= Height || x >= Width || x + bitmap.Width <= 0 || y + bitmap.Height <= 0)
@@ -447,7 +447,7 @@ namespace Iot.Device.LEDMatrix
             int coorX = Math.Max(0, x);
             int coorY = Math.Max(0, y);
 
-            int bmpStride = bitmap.Width * 4; // BitmapImage is (currently) always ARGB8888 or XRGB0888
+            int bmpStride = bitmap.Stride;
             int pos = 3 * (bitmapY * bitmap.Width + bitmapX);
             int stride = (bmpStride - 3 * bitmap.Width) + 3 * (bitmap.Width - bitmapWidth);
 

--- a/src/devices/RGBLedMatrix/samples/Program.cs
+++ b/src/devices/RGBLedMatrix/samples/Program.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Iot.Device.LEDMatrix;
 using Iot.Device.Graphics;
+using Iot.Device.Graphics.SkiaSharpAdapter;
 
 bool play = false;
 int scenario = 2;
@@ -35,6 +36,8 @@ CityData[] citiesData = new CityData[]
     new("Cairo", "EG", "Africa/Cairo"),
     new("Riyadh", "SA", "Asia/Riyadh")
 };
+
+SkiaSharpAdapter.Register();
 
 Console.WriteLine($"Hello Matrix World!");
 
@@ -327,8 +330,8 @@ unsafe void Demo4(RGBLedMatrix matrix)
     BdfFont font = BdfFont.Load(@"fonts/6x12.bdf");
     BdfFont font1 = BdfFont.Load(@"fonts/5x7.bdf");
 
-    Bitmap? weatherIcon = null;
-    Bitmap defaultIcon = new Bitmap("bitmaps/01d.bmp");
+    BitmapImage? weatherIcon = null;
+    BitmapImage defaultIcon = BitmapImage.CreateFromFile("bitmaps/01d.bmp");
     string? lastIcon = null;
     string description = string.Empty;
 
@@ -351,7 +354,7 @@ unsafe void Demo4(RGBLedMatrix matrix)
 
             if (lastIcon != icon)
             {
-                weatherIcon = new Bitmap("bitmaps/" + icon ?? defaultIcon + ".bmp");
+                weatherIcon = BitmapImage.CreateFromFile("bitmaps/" + icon ?? defaultIcon + ".bmp");
             }
 
             matrix.DrawBitmap(20, 2, weatherIcon ?? defaultIcon, 255, 255, 255, 0, 0, blue);
@@ -402,10 +405,10 @@ unsafe void Demo6(RGBLedMatrix matrix)
     {
         matrix.Fill(0, 0, 0);
 
-        Bitmap[] bitmaps = new Bitmap[]
+        BitmapImage[] bitmaps = new BitmapImage[]
         {
-            new Bitmap(@"bitmaps/dotnet-bot-branded-32x32.bmp"),
-            new Bitmap(@"bitmaps/i-love-dotnet.bmp")
+            BitmapImage.CreateFromFile(@"bitmaps/dotnet-bot-branded-32x32.bmp"),
+            BitmapImage.CreateFromFile(@"bitmaps/i-love-dotnet.bmp")
         };
 
         int x = matrix.Width - 1;

--- a/src/devices/RGBLedMatrix/samples/RGBLedMatrix.sample.csproj
+++ b/src/devices/RGBLedMatrix/samples/RGBLedMatrix.sample.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../RGBLedMatrix.csproj" />
+    <ProjectReference Include="..\..\SkiaSharpAdapter\SkiaSharpAdapter.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devices/RGBLedMatrix/samples/RGBLedMatrix.sample.csproj
+++ b/src/devices/RGBLedMatrix/samples/RGBLedMatrix.sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../RGBLedMatrix.csproj" />
+    <ProjectReference Include="..\RGBLedMatrix.csproj" />
     <ProjectReference Include="..\..\SkiaSharpAdapter\SkiaSharpAdapter.csproj" />
   </ItemGroup>
 

--- a/src/devices/SkiaSharpAdapter/README.md
+++ b/src/devices/SkiaSharpAdapter/README.md
@@ -1,0 +1,12 @@
+﻿# SkiaSharp graphics library adapter
+
+## Summary
+
+This folder contains the SkiaSharp adapter for Iot.Device.Bindings. It provides an implementation for BitmapImage that uses the
+[SkiaSharp](https://github.com/mono/SkiaSharp) multi-platform graphics library. This folder is compiled into its own .nuget file, so that no external dependencies
+are included when they're not needed.
+
+See [Ili934x](../Ili934x/Readme.md) for an usage example.
+
+To use SkiaSharp as image library with Iot.Device.Bindings, reference (in addition to `Iot.Device.Bindings.nuget`) the `Iot.Device.Bindings.SkiaSharpAdapter.nuget`
+and put a line with `SkiaSharpAdapter.Register()` somewhere at the beginning of your application.

--- a/src/devices/SkiaSharpAdapter/README.md
+++ b/src/devices/SkiaSharpAdapter/README.md
@@ -6,7 +6,7 @@ This folder contains the SkiaSharp adapter for Iot.Device.Bindings. It provides 
 [SkiaSharp](https://github.com/mono/SkiaSharp) multi-platform graphics library. This folder is compiled into its own .nuget file, so that no external dependencies
 are included when they're not needed.
 
-See [Ili934x](../Ili934x/Readme.md) for an usage example.
+See [Ili934x](../Ili9341/Readme.md) for an usage example.
 
 To use SkiaSharp as image library with Iot.Device.Bindings, reference (in addition to `Iot.Device.Bindings.nuget`) the `Iot.Device.Bindings.SkiaSharpAdapter.nuget`
 and put a line with `SkiaSharpAdapter.Register()` somewhere at the beginning of your application.

--- a/src/devices/SkiaSharpAdapter/SkiaSharpAdapter.cs
+++ b/src/devices/SkiaSharpAdapter/SkiaSharpAdapter.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Device.Gpio;
+using System.Device.I2c;
+using System.Device.Spi;
+
+namespace Iot.Device.Graphics.SkiaSharpAdapter
+{
+    /// <summary>
+    /// Image factory registry helper.
+    /// </summary>
+    public static class SkiaSharpAdapter
+    {
+        /// <summary>
+        /// Registers this factory as the default image factory.
+        /// Call this method once at startup to use SkiaSharp as image backend.
+        /// </summary>
+        public static void Register()
+        {
+            BitmapImage.RegisterImageFactory(new SkiaSharpImageFactory());
+        }
+    }
+}

--- a/src/devices/SkiaSharpAdapter/SkiaSharpAdapter.csproj
+++ b/src/devices/SkiaSharpAdapter/SkiaSharpAdapter.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
     <!--Disabling default items so samples source won't get build by the main library-->
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>9</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>Iot.Device.Graphics.SkiaSharpAdapter</RootNamespace>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/devices/SkiaSharpAdapter/SkiaSharpAdapter.csproj
+++ b/src/devices/SkiaSharpAdapter/SkiaSharpAdapter.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(DefaultBindingTfms)</TargetFrameworks>
+    <!--Disabling default items so samples source won't get build by the main library-->
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <LangVersion>9</LangVersion>
+    <RootNamespace>Iot.Device.Graphics.SkiaSharpAdapter</RootNamespace>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="*.cs" />
+    <None Include="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/devices/SkiaSharpAdapter/SkiaSharpAdapter.sln
+++ b/src/devices/SkiaSharpAdapter/SkiaSharpAdapter.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33326.253
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharpAdapter", "SkiaSharpAdapter.csproj", "{B82C190A-642B-465B-BD3F-DB56FFF22253}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|x64.Build.0 = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Debug|x86.Build.0 = Debug|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|x64.ActiveCfg = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|x64.Build.0 = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|x86.ActiveCfg = Release|Any CPU
+		{B82C190A-642B-465B-BD3F-DB56FFF22253}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {88F2ACC7-6A5A-425A-81EA-7EC63893AB55}
+	EndGlobalSection
+EndGlobal

--- a/src/devices/SkiaSharpAdapter/SkiaSharpBitmap.cs
+++ b/src/devices/SkiaSharpAdapter/SkiaSharpBitmap.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SkiaSharp;
+
+namespace Iot.Device.Graphics.SkiaSharpAdapter
+{
+    internal class SkiaSharpBitmap : BitmapImage
+    {
+        private SKBitmap _bitmap;
+
+        public SkiaSharpBitmap(int width, int height, PixelFormat pixelFormat)
+            : base(width, height, width * 4, pixelFormat)
+        {
+            if (pixelFormat == PixelFormat.Format32bppArgb)
+            {
+                _bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+            }
+            else if (pixelFormat == PixelFormat.Format32bppXrgb)
+            {
+                _bitmap = new SKBitmap(width, height, SKColorType.Rgb888x, SKAlphaType.Opaque);
+            }
+            else
+            {
+                throw new NotSupportedException($"Pixelformat {pixelFormat} is not currently supported");
+            }
+        }
+
+        internal SKBitmap WrappedBitmap => _bitmap;
+
+        public SkiaSharpBitmap(SKBitmap bitmap, PixelFormat pixelFormat)
+            : base(bitmap.Width, bitmap.Height, bitmap.Width * 4, pixelFormat)
+        {
+            _bitmap = bitmap;
+        }
+
+        public override void SetPixel(int x, int y, Color color)
+        {
+            _bitmap.SetPixel(x, y, ConvertColor(color));
+        }
+
+        public override Color GetPixel(int x, int y)
+        {
+            return ConvertColor(_bitmap.GetPixel(x, y));
+        }
+
+        public override unsafe Span<byte> AsByteSpan()
+        {
+            // GetPixelSpan() returns a ReadonlySpan for some reason, therefore work around this.
+            IntPtr ptr = IntPtr.Zero;
+            ptr = _bitmap.GetPixels(out IntPtr length);
+            return new Span<byte>(ptr.ToPointer(), length.ToInt32());
+        }
+
+        public override void SaveToStream(Stream stream, ImageFileType fileType)
+        {
+            using var img = SKImage.FromBitmap(WrappedBitmap);
+
+            SKEncodedImageFormat encodingFormat = fileType switch
+            {
+                ImageFileType.Bmp => SKEncodedImageFormat.Bmp,
+                ImageFileType.Png => SKEncodedImageFormat.Png,
+                ImageFileType.Jpg => SKEncodedImageFormat.Jpeg,
+                _ => throw new NotSupportedException($"File type {fileType} is not supported")
+            };
+
+            var data = img.Encode(encodingFormat, 100);
+            data.SaveTo(stream);
+        }
+
+        private SKColor ConvertColor(Color c)
+        {
+            return new SKColor(c.R, c.G, c.B, c.A);
+        }
+
+        private Color ConvertColor(SKColor color)
+        {
+            return Color.FromArgb(color.Alpha, color.Red, color.Green, color.Blue);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _bitmap?.Dispose();
+            _bitmap = null!;
+        }
+
+        public override IGraphics GetDrawingApi()
+        {
+            return new BitmapCanvas(_bitmap);
+        }
+
+        internal class BitmapCanvas : IGraphics
+        {
+            private SKCanvas _canvas;
+            private SKBitmap _bitmap;
+
+            public BitmapCanvas(SKBitmap bitmap)
+            {
+                _bitmap = bitmap;
+                _canvas = new SKCanvas(_bitmap);
+            }
+
+            public SKCanvas Canvas => _canvas;
+
+            public void Dispose()
+            {
+                // Do not dispose the bitmap, it's not ours
+                _canvas.Dispose();
+            }
+        }
+    }
+}

--- a/src/devices/SkiaSharpAdapter/SkiaSharpGraphicsExtensions.cs
+++ b/src/devices/SkiaSharpAdapter/SkiaSharpGraphicsExtensions.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SkiaSharp;
+
+namespace Iot.Device.Graphics.SkiaSharpAdapter
+{
+    /// <summary>
+    /// Contains extension methods that operate on <see cref="IGraphics"/>
+    /// </summary>
+    public static class SkiaSharpGraphicsExtensions
+    {
+        /// <summary>
+        /// Resizes an image. Extension method for SkiaSharp
+        /// </summary>
+        /// <param name="image">The image to resize</param>
+        /// <param name="size">The new size</param>
+        /// <returns>A new image. The old image is unaffected</returns>
+        /// <exception cref="NotSupportedException">The image is not a SkiaSharpBitmap, meaning more than one image connector is in scope</exception>
+        public static BitmapImage Resize(this BitmapImage image, Size size)
+        {
+            if (image is SkiaSharpBitmap img)
+            {
+                var resized = img.WrappedBitmap.Resize(new SKSizeI(size.Width, size.Height), SKFilterQuality.Medium);
+                return new SkiaSharpBitmap(resized, image.PixelFormat);
+            }
+
+            throw new NotSupportedException("This overload can only Resize SkiaSharpImage instances");
+        }
+
+        /// <summary>
+        /// Draws text to the bitmap
+        /// </summary>
+        public static void DrawText(this IGraphics graphics, string text, string fontFamilyName, int size, Color color, Point position)
+        {
+            var canvas = GetCanvas(graphics);
+            SKFont fnt = new SKFont(SKTypeface.FromFamilyName(fontFamilyName), size);
+            var paint = new SKPaint(fnt);
+            paint.Color = new SKColor((uint)color.ToArgb());
+            paint.TextAlign = SKTextAlign.Left;
+            paint.TextEncoding = SKTextEncoding.Utf16;
+            int lineSpacing = size + 2;
+            SKPoint currentPosition = new SKPoint(position.X, position.Y + size); // drawing begins to the right and above the given point.
+            var texts = text.Split(new char[]
+            {
+                '\r', '\n'
+            }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim());
+
+            // The DrawText implementation of SkiaSharp does not work with line breaks, so do that manually.
+            foreach (var t in texts)
+            {
+                canvas.DrawText(t, currentPosition, paint);
+                currentPosition.Y += lineSpacing;
+            }
+        }
+
+        /// <summary>
+        /// Draws another image into this one, at the given position and without scaling
+        /// </summary>
+        /// <param name="graphics">The target bitmap</param>
+        /// <param name="source">The source bitmap</param>
+        /// <param name="x">The x coordinate of the source bitmap in the resulting target bitmap</param>
+        /// <param name="y">The y coordinate of the source bitmap in the resulting target bitmap</param>
+        public static void DrawImage(this IGraphics graphics, BitmapImage source, int x, int y)
+        {
+            var sourceBmp = (SkiaSharpBitmap)source;
+            var targetCanvas = GetCanvas(graphics);
+            targetCanvas.DrawBitmap(sourceBmp.WrappedBitmap, x, y, null);
+        }
+
+        /// <summary>
+        /// Draws another image into this one, at the given position and without scaling
+        /// </summary>
+        /// <param name="graphics">The target bitmap</param>
+        /// <param name="source">The source bitmap</param>
+        /// <param name="sourceRectangle">Rectangle in source image from where to draw</param>
+        /// <param name="targetRectangle">Rectangle in target image where to draw to</param>
+        public static void DrawImage(this IGraphics graphics, BitmapImage source, Rectangle sourceRectangle, Rectangle targetRectangle)
+        {
+            var sourceBmp = (SkiaSharpBitmap)source;
+            var targetCanvas = GetCanvas(graphics);
+            targetCanvas.DrawBitmap(sourceBmp.WrappedBitmap, new SKRect(sourceRectangle.Left, sourceRectangle.Top, sourceRectangle.Right, sourceRectangle.Bottom),
+                new SKRect(targetRectangle.Left, targetRectangle.Top, targetRectangle.Right, targetRectangle.Bottom));
+        }
+
+        /// <summary>
+        /// Get the internal SKCanvas instance, to manually draw to the target bitmap.
+        /// </summary>
+        /// <param name="graphics">The reference to the image</param>
+        /// <returns>An instance that can be used in calls for drawing methods</returns>
+        public static SKCanvas GetCanvas(this IGraphics graphics)
+        {
+            if (graphics == null)
+            {
+                throw new ArgumentNullException(nameof(graphics));
+            }
+
+            if (graphics is SkiaSharpBitmap.BitmapCanvas bitmapCanvas)
+            {
+                return bitmapCanvas.Canvas;
+            }
+
+            throw new ArgumentException("These extension methods can only be used on SkiaSharpBitmap instances", nameof(graphics));
+        }
+    }
+}

--- a/src/devices/SkiaSharpAdapter/SkiaSharpImageFactory.cs
+++ b/src/devices/SkiaSharpAdapter/SkiaSharpImageFactory.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SkiaSharp;
+
+namespace Iot.Device.Graphics.SkiaSharpAdapter
+{
+    /// <summary>
+    /// This image factory uses SkiaSharp as backend
+    /// </summary>
+    public class SkiaSharpImageFactory : IImageFactory
+    {
+        /// <inheritdoc />
+        public BitmapImage CreateBitmap(int width, int height, PixelFormat pixelFormat)
+        {
+            return new SkiaSharpBitmap(width, height, pixelFormat);
+        }
+
+        /// <inheritdoc />
+        public BitmapImage CreateFromStream(Stream file)
+        {
+            using var image = SKImage.FromEncodedData(file);
+            PixelFormat pf;
+            if (image.ColorType == SKColorType.Rgb888x)
+            {
+                pf = PixelFormat.Format32bppXrgb;
+            }
+            else if (image.ColorType == SKColorType.Bgra8888)
+            {
+                pf = PixelFormat.Format32bppArgb;
+            }
+            else
+            {
+                throw new NotSupportedException($"The stream contains an image with color type {image.ColorType}, which is currently not supported");
+            }
+
+            return new SkiaSharpBitmap(SKBitmap.FromImage(image), pf);
+        }
+    }
+}

--- a/src/devices/SkiaSharpAdapter/category.txt
+++ b/src/devices/SkiaSharpAdapter/category.txt
@@ -1,0 +1,2 @@
+display
+media

--- a/src/devices/Ssd1351/Ssd1351.csproj
+++ b/src/devices/Ssd1351/Ssd1351.csproj
@@ -8,6 +8,8 @@
     <Compile Include="Command\*.cs" />
     <Compile Include="*.cs" />
     <None Include="README.md" />
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SkiaSharpAdapter\SkiaSharpAdapter.csproj" />
   </ItemGroup>
 </Project>

--- a/src/devices/Ssd1351/Ssd1351.sln
+++ b/src/devices/Ssd1351/Ssd1351.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33326.253
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{63A74A67-FAF7-420A-BE38-95210B3A00C0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ssd1351.Samples", "samples\Ssd1351.Samples.csproj", "{6CED0849-578E-4918-A2B9-D830BE2FE09F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ssd1351.Samples", "samples\Ssd1351.Samples.csproj", "{6CED0849-578E-4918-A2B9-D830BE2FE09F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ssd1351", "Ssd1351.csproj", "{15AC2845-9E0A-42D0-8AA9-C09D12104D3C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ssd1351", "Ssd1351.csproj", "{15AC2845-9E0A-42D0-8AA9-C09D12104D3C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharpConnector", "..\SkiaSharpConnector\SkiaSharpConnector.csproj", "{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6CED0849-578E-4918-A2B9-D830BE2FE09F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -46,6 +45,21 @@ Global
 		{15AC2845-9E0A-42D0-8AA9-C09D12104D3C}.Release|x64.Build.0 = Release|Any CPU
 		{15AC2845-9E0A-42D0-8AA9-C09D12104D3C}.Release|x86.ActiveCfg = Release|Any CPU
 		{15AC2845-9E0A-42D0-8AA9-C09D12104D3C}.Release|x86.Build.0 = Release|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Debug|x64.Build.0 = Debug|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Debug|x86.Build.0 = Debug|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Release|x64.ActiveCfg = Release|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Release|x64.Build.0 = Release|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Release|x86.ActiveCfg = Release|Any CPU
+		{21B87B4E-8B54-4FEF-AE74-E20B23A0A70F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{6CED0849-578E-4918-A2B9-D830BE2FE09F} = {63A74A67-FAF7-420A-BE38-95210B3A00C0}

--- a/src/devices/Ssd1351/Ssd1351Commands.cs
+++ b/src/devices/Ssd1351/Ssd1351Commands.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 
 namespace Iot.Device.Ssd1351

--- a/src/devices/Ssd1351/samples/Program.cs
+++ b/src/devices/Ssd1351/samples/Program.cs
@@ -6,13 +6,15 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Iot.Device.Graphics;
+using Iot.Device.Graphics.SkiaSharpAdapter;
 using Iot.Device.Ssd1351;
 
 const int pinID_DC = 23;
 const int pinID_Reset = 24;
 
-using Bitmap dotnetBM = new(128, 128);
-using Graphics g = Graphics.FromImage(dotnetBM);
+SkiaSharpAdapter.Register();
+using BitmapImage dotnetBM = BitmapImage.CreateBitmap(128, 128, PixelFormat.Format32bppArgb);
 using SpiDevice displaySPI = SpiDevice.Create(new SpiConnectionSettings(0, 0) { Mode = SpiMode.Mode3, DataBitLength = 8, ClockFrequency = 12_000_000 /* 12MHz */ });
 using Ssd1351 ssd1351 = new(displaySPI, pinID_DC, pinID_Reset);
 ssd1351.ResetDisplayAsync().Wait();
@@ -22,10 +24,10 @@ while (true)
 {
     foreach (string filepath in Directory.GetFiles(@"images", "*.png").OrderBy(f => f))
     {
-        using Bitmap bm = (Bitmap)Bitmap.FromFile(filepath);
-        g.Clear(Color.Black);
-        g.DrawImageUnscaled(bm, 0, 0);
-        ssd1351.SendBitmap(dotnetBM);
+        using BitmapImage bm = BitmapImage.CreateFromFile(filepath);
+        dotnetBM.Clear(Color.Black);
+        dotnetBM.GetDrawingApi().DrawImage(bm, 0, 0);
+        ssd1351.SendBitmap(bm);
         Task.Delay(1000).Wait();
     }
 }

--- a/src/devices/Ssd1351/samples/Ssd1351.Samples.csproj
+++ b/src/devices/Ssd1351/samples/Ssd1351.Samples.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>$(DefaultSampleTfms)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Ssd1351.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/devices/Ws28xx/BitmapImageNeo4.cs
+++ b/src/devices/Ws28xx/BitmapImageNeo4.cs
@@ -3,10 +3,9 @@
 
 using System.Drawing;
 using Iot.Device.Graphics;
-
 namespace Iot.Device.Ws28xx
 {
-    internal class BitmapImageNeo4 : BitmapImage
+    internal class BitmapImageNeo4 : RawPixelContainer
     {
         private const int BytesPerComponent = 3;
         private const int BytesPerPixel = BytesPerComponent * 4;

--- a/src/devices/Ws28xx/BitmapImageWs2808.cs
+++ b/src/devices/Ws28xx/BitmapImageWs2808.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Xml.Linq;
 using Iot.Device.Graphics;
 
 namespace Iot.Device.Ws28xx
 {
-    internal class BitmapImageWs2808 : BitmapImage
+    internal class BitmapImageWs2808 : RawPixelContainer
     {
         private const int BytesPerPixel = 3;
 

--- a/src/devices/Ws28xx/RawPixelContainer.cs
+++ b/src/devices/Ws28xx/RawPixelContainer.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Drawing;
+
+namespace Iot.Device.Ws28xx
+{
+    /// <summary>
+    /// An abstract class that acts as a data container for device-dependent pixel arrays
+    /// </summary>
+    public abstract class RawPixelContainer
+    {
+        private byte[] _data;
+
+        /// <summary>
+        /// Constructs a container with the given values
+        /// </summary>
+        /// <param name="data">The data array. Should be of size <paramref name="width"/> * <paramref name="height"/> * bytesPerPixel</param>
+        /// <param name="width">Width of the image, in pixels</param>
+        /// <param name="height">Height of the image, in pixels</param>
+        /// <param name="stride">Image width * bytes per pixel (number of bytes per image scanline)</param>
+        protected RawPixelContainer(byte[] data, int width, int height, int stride)
+        {
+            _data = data;
+            Width = width;
+            Height = height;
+            Stride = stride;
+        }
+
+        /// <summary>
+        /// Image width
+        /// </summary>
+        public int Width
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Image Height
+        /// </summary>
+        public int Height
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Image Stride (number of bytes per scanline)
+        /// </summary>
+        public int Stride
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Retrieves the raw pixels. Addressing and color format is device-dependent!
+        /// </summary>
+        public Span<byte> Data => _data;
+
+        /// <summary>
+        /// Sets a pixel to a specific color
+        /// </summary>
+        /// <param name="x">X coordinate</param>
+        /// <param name="y">Y coordinate</param>
+        /// <param name="c">Color to set, will be adjusted to the color format of the target hardware</param>
+        public abstract void SetPixel(int x, int y, Color c);
+
+        /// <summary>
+        /// Clears the image to specific color
+        /// </summary>
+        /// <param name="color">Color to clear the image. Defaults to black.</param>
+        public virtual void Clear(Color color = default)
+        {
+            for (int y = 0; y < Height; y++)
+            {
+                for (int x = 0; x < Width; x++)
+                {
+                    SetPixel(x, y, color);
+                }
+            }
+        }
+    }
+}

--- a/src/devices/Ws28xx/Ws28xx.cs
+++ b/src/devices/Ws28xx/Ws28xx.cs
@@ -20,14 +20,14 @@ namespace Iot.Device.Ws28xx
         /// <summary>
         /// Backing image to be updated on the driver
         /// </summary>
-        public BitmapImage Image { get; }
+        public RawPixelContainer Image { get; }
 
         /// <summary>
         /// Constructs Ws28xx instance
         /// </summary>
         /// <param name="spiDevice">SPI device used for communication with the LED driver.</param>
         /// <param name="image">The bitmap that represents the screen or led strip.</param>
-        public Ws28xx(SpiDevice spiDevice, BitmapImage image)
+        public Ws28xx(SpiDevice spiDevice, RawPixelContainer image)
         {
             _spiDevice = spiDevice ?? throw new ArgumentNullException(nameof(spiDevice));
             Image = image;

--- a/src/devices/Ws28xx/samples/LEDStripSample/Animations.cs
+++ b/src/devices/Ws28xx/samples/LEDStripSample/Animations.cs
@@ -13,14 +13,14 @@ namespace LEDStripSample
     public class Animations
     {
         private int _ledCount;
-        private Ws28xx _ledStrip;
+        private Iot.Device.Ws28xx.Ws28xx _ledStrip;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Animations"/> class.
         /// </summary>
         /// <param name="ledStrip">The led strip.</param>
         /// <param name="ledCount">The led count.</param>
-        public Animations(Ws28xx ledStrip, int ledCount)
+        public Animations(Iot.Device.Ws28xx.Ws28xx ledStrip, int ledCount)
         {
             _ledStrip = ledStrip;
             _ledCount = ledCount;
@@ -126,7 +126,7 @@ namespace LEDStripSample
         /// <param name="token">The token.</param>
         public void Rainbow(CancellationToken token)
         {
-            BitmapImage img = _ledStrip.Image;
+            RawPixelContainer img = _ledStrip.Image;
             while (!token.IsCancellationRequested)
             {
                 for (var i = 0; i < 255; i++)
@@ -159,7 +159,7 @@ namespace LEDStripSample
         /// <param name="count">The count.</param>
         public void SetColor(Color color, int count)
         {
-            BitmapImage img = _ledStrip.Image;
+            RawPixelContainer img = _ledStrip.Image;
             for (var i = 0; i < count; i++)
             {
                 img.SetPixel(i, 0, color);
@@ -197,7 +197,7 @@ namespace LEDStripSample
         /// <param name="token">The token.</param>
         public void TheatreChase(Color color, Color blankColor, CancellationToken token)
         {
-            BitmapImage img = _ledStrip.Image;
+            RawPixelContainer img = _ledStrip.Image;
             while (!token.IsCancellationRequested)
             {
                 for (var j = 0; j < 3; j++)


### PR DESCRIPTION
Fixes #1767 (and probably a few others)

- Removes all references to ImageSharp from Iot.Device.Bindings.dll
- Replace standard types (Point, Color, Size, Rectangle) with the types from `System.Drawing.Primitives.dll` (these are supported on all platforms and even part of the core runtime)
- Provide a new `BitmapImage` class, which is an abstract image type
- Provide a `ImageFactoryRegistry` static class to create instances of images
- Provide a `SkiaSharpConnector` as (one possible) adapter that provides the actual implementation.

I suggest to create a new package for the SkiaSharpConnector (maybe better name it SkiaSharpAdapter?), because other adapters are possible (e.g. plain old System.Drawing.Imaging would do if only used on Windows) and because SkiaSharp is a quite heavy dependency (~100MB with the native dependencies)

Rough testing done, but a quick test of all the heavier affected bindings would be good:
- VideoDevice (@raffaeler ?)
- RgbLedMatrix (@richlander ?)
- Ws28xx (@krwq ?)
- Ssd1351 (TBD)
- BuildHat (@Ellerbach ?)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2069)