### PR TITLE
Fixed the CreateWriteMessage for the PN532 chip.

### DIFF
--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -18,6 +18,8 @@ using Iot.Device.Pn532.RfConfiguration;
 using Iot.Device.Rfid;
 using Iot.Device.Pn532;
 using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp.PixelFormats;
+using UnitsNet;
 
 namespace Iot.Device.Pn532
 {
@@ -1530,6 +1532,7 @@ namespace Iot.Device.Pn532
         }
 
         /// <summary>
+        /// Normal Frame:
         /// PREAMBLE 1 byte4
         /// START CODE 2 bytes (0x00 and 0xFF),
         /// LEN 1 byte indicating the number of bytes in the data field
@@ -1559,23 +1562,42 @@ namespace Iot.Device.Pn532
         /// |_____________________________________________ Preamble
         /// If the length is large than 255, then you have LEN and LCS = 0xFF and
         /// 2 additional bytes for the MBS and LBS size of the real length
+        /// Extended Frame:
+        /// The information frame has an extended definition allowing exchanging more data
+        /// between the host controller and the PN532.
+        /// In the firmware implementation of the PN532, the maximum length of the packet data is
+        /// limited to 264 bytes(265 bytes with TFI included).
+        /// The structure of this frame is the following:
+        /// 00 00 FF FF FF LENm LENl LCS TFI PD0 PD1 ……... PDn DCS 00
+        /// -- ----- ----- ---- ---- --- --- ----------------- --- --
+        /// |    |     |     |   |    |   |            |        |  |_ Postamble
+        /// |    |     |     |   |    |   |            |        |____ Packet Data Checksum
+        /// |    |     |     |   |    |   |            |_____________ Packet Data
+        /// |    |     |     |   |    |   |__________________________ Specific PN532 Frame Identifier
+        /// |    |     |     |   |    |______________________________ Packet Length Checksum
+        /// |    |     |     |   |___________________________________ Packet Length LSByte
+        /// |    |     |     |_______________________________________ Packet Length MSByte
+        /// |    |     |_____________________________________________ Fixed for extrended frame
+        /// |    |___________________________________________________ Start codes
+        /// |________________________________________________________ Preamble
         /// </summary>
         /// <param name="commandSet">The command to use</param>
         /// <param name="writeData">The additional data to send</param>
         /// <returns></returns>
         private byte[] CreateWriteMessage(CommandSet commandSet, ReadOnlySpan<byte> writeData)
         {
-            // 7 bytes + writeData length + 2 bytes if preamble
             int correctionPreamble = 2;
             int correctionIndex = 0;
-            int correctionLArgeSizeBuffer = writeData.Length < 250 ? 0 : 2;
+            int correctionLargeBuffer = writeData.Length < 250 ? 0 : 3;
             if (!((_parametersFlags & ParametersFlags.RemovePrePostAmble) == ParametersFlags.RemovePrePostAmble))
             {
                 correctionPreamble = 0;
                 correctionIndex = 1;
             }
 
-            Span<byte> buff = stackalloc byte[7 + writeData.Length + correctionPreamble + correctionLArgeSizeBuffer];
+            // 7 bytes + writeData length + 2 bytes if preamble
+            // 7 bytes + writeData length + 2 bytes if preamble + 3 bytes for extended frame
+            Span<byte> buff = stackalloc byte[7 + writeData.Length + correctionPreamble + correctionLargeBuffer];
             if (correctionPreamble != 0)
             {
                 buff[0] = Preamble;
@@ -1584,7 +1606,7 @@ namespace Iot.Device.Pn532
             buff[1 - correctionIndex] = StartCode1;
             buff[2 - correctionIndex] = StartCode2;
             // Normal frame size
-            if (correctionLArgeSizeBuffer == 0)
+            if (correctionLargeBuffer == 0)
             {
                 // Size for commandSet + size of buffer + 1
                 byte length = (byte)(1 + writeData.Length + 1);
@@ -1597,17 +1619,26 @@ namespace Iot.Device.Pn532
                 // Large frame size
                 buff[3 - correctionIndex] = 0xFF;
                 buff[4 - correctionIndex] = 0xFF;
-                buff[5 - correctionIndex] = (byte)(writeData.Length >> 8);
-                buff[6 - correctionIndex] = (byte)(writeData.Length);
+
+                // Size for commandSet + size of buffer + 1 (tfi)
+                var length = (1 + 1 + writeData.Length);
+                var lenMB = (byte)(length >> 8);
+                var lenLB = (byte)(length & 0xFF);
+                buff[5 - correctionIndex] = lenMB;
+                buff[6 - correctionIndex] = lenLB;
+
+                // CRC for length
+                var lengthCRC = (byte)(~(byte)(lenMB + lenLB) + 1);
+                buff[7 - correctionIndex] = lengthCRC;
             }
 
             // We are writing from Host
-            buff[5 - correctionIndex + correctionLArgeSizeBuffer] = FromHostCheckSumD4;
+            buff[5 - correctionIndex + correctionLargeBuffer] = FromHostCheckSumD4;
             // The command and the data
-            buff[6 - correctionIndex + correctionLArgeSizeBuffer] = (byte)commandSet;
+            buff[6 - correctionIndex + correctionLargeBuffer] = (byte)commandSet;
             if (!writeData.IsEmpty)
             {
-                writeData.CopyTo(buff.Slice(7 - correctionIndex + correctionLArgeSizeBuffer));
+                writeData.CopyTo(buff.Slice(7 - correctionIndex + correctionLargeBuffer));
             }
 
             // Checksum
@@ -1617,10 +1648,10 @@ namespace Iot.Device.Pn532
                 checkSum += writeData[i];
             }
 
-            buff[7 + writeData.Length - correctionIndex + correctionLArgeSizeBuffer] = (byte)(~checkSum + 1);
+            buff[7 + writeData.Length - correctionIndex + correctionLargeBuffer] = (byte)(~checkSum + 1);
             if (correctionPreamble != 0)
             {
-                buff[8 + writeData.Length + correctionLArgeSizeBuffer] = Postamble;
+                buff[8 + writeData.Length - correctionIndex + correctionLargeBuffer] = Postamble;
             }
 
             _logger.LogDebug($"Message to send: {BitConverter.ToString(buff.ToArray())}");

--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -18,8 +18,6 @@ using Iot.Device.Pn532.RfConfiguration;
 using Iot.Device.Rfid;
 using Iot.Device.Pn532;
 using Microsoft.Extensions.Logging;
-using SixLabors.ImageSharp.PixelFormats;
-using UnitsNet;
 
 namespace Iot.Device.Pn532
 {


### PR DESCRIPTION
Fixes #2075 
Fixed the PN532 message factory that now produce extended frames compliant with 1.6 firmware specifications


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2076)