### PR TITLE
improve Pn532 I2C performance by reducing response buffer size

### DIFF
--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -26,7 +26,9 @@ namespace Iot.Device.Pn532
     /// </summary>
     public class Pn532 : CardTransceiver, IDisposable
     {
-        private const int I2cMaxBuffer = 1024;
+        // Host-controller frame size
+        private const int MaxPacketData = 264;      // maximum length of packet data
+        private const int MaxPacketFraming = 12;    // maximum additional number of bytes for framing
         // Communication way
         private const byte ToHostCheckSumD5 = 0xD5;
         private const byte FromHostCheckSumD4 = 0xD4;
@@ -544,7 +546,7 @@ namespace Iot.Device.Pn532
             }
 
             // TODO: check what is the real maximum size
-            Span<byte> listData = stackalloc byte[1024];
+            Span<byte> listData = stackalloc byte[MaxPacketData];
             ret = ReadResponse(CommandSet.InListPassiveTarget, listData);
             _logger.LogDebug($"{nameof(ListPassiveTarget)}: {ret}, number tags: {listData[0]}");
             if ((ret >= 0) && (listData[0] > 0))
@@ -879,7 +881,7 @@ namespace Iot.Device.Pn532
                 return null;
             }
 
-            Span<byte> receivedData = stackalloc byte[1024];
+            Span<byte> receivedData = stackalloc byte[MaxPacketData];
             ret = ReadResponse(CommandSet.InAutoPoll, receivedData);
             _logger.LogDebug($"{nameof(AutoPoll)}, success: {ret}");
             if (ret >= 0)
@@ -925,7 +927,7 @@ namespace Iot.Device.Pn532
                 return (null, null);
             }
 
-            Span<byte> receivedData = stackalloc byte[1024];
+            Span<byte> receivedData = stackalloc byte[MaxPacketData];
             ret = ReadResponse(CommandSet.TgInitAsTarget, receivedData);
             _logger.LogDebug($"{nameof(InitAsTarget)}, success: {ret}");
             if (ret >= 0)
@@ -1200,9 +1202,7 @@ namespace Iot.Device.Pn532
             // For example if you write on a register that is creating an output
             // So this buffer is here only to avoid having an exception when writing to
             // A register that will create an output
-            // The maximum amount of data return if 260 but writing specific register can
-            // Generate a larger amount
-            Span<byte> returnVal = stackalloc byte[1024];
+            Span<byte> returnVal = stackalloc byte[MaxPacketData];
             ret = ReadResponse(CommandSet.ReadRegister, returnVal);
             _logger.LogDebug($"{nameof(WriteRegister)}: {ret}");
             return ret >= 0;
@@ -1998,9 +1998,9 @@ namespace Iot.Device.Pn532
                 }
             }
 
-            // For I2C, we need to read at least 2 bytes other wise it things we're still trying
+            // For I2C, we need to read at least 2 bytes other wise it thinks we're still trying
             // to check the status
-            byte[] preamb = new byte[I2cMaxBuffer];
+            Span<byte> preamb = stackalloc byte[readData.Length + MaxPacketFraming];
             _i2cDevice.Read(preamb);
             int idxPreamb = 0;
             // Dropping the first byte, it is 0x01 and read previously in the pooling
@@ -2069,7 +2069,7 @@ namespace Iot.Device.Pn532
             // Finally, we can read the data
             if (length - 2 > 0)
             {
-                preamb.AsSpan().Slice(idxPreamb, length - 2).CopyTo(readData);
+                preamb.Slice(idxPreamb, length - 2).CopyTo(readData);
                 idxPreamb += length - 2;
             }
 


### PR DESCRIPTION
```ReadResponseI2C``` waits for the PN532 to be ready (using ```IsReady```) and then does an ```_i2cDevice.Read``` with a read buffer size of ```MaxPacketData``` (1024). I2C is slow, so this read takes a long time (I measured it as more than 100ms).

The largest packet data size that the PN532 supports is 264 bytes. When wrapped in an extended information frame, this would require a total size of 276 bytes. However, many responses are much shorter than this. For instance, the response payload for reading a block of a Mifare Classic card is 16 bytes.

The second argument to ```ReadResponseI2C``` is a ```Span<byte>``` into which the response will be written. This PR changes ```ReadResponseI2C``` to ```stackalloc``` a buffer for the I2C response based upon the payload size plus the additional bytes required for framing, rather than using a fixed size of 1024. This is much smaller and significantly improves the performance of the PN532 over I2C.

There are a few places in the code where the caller of ```ReadResponse``` allocates a buffer of size 1024. The response cannot be larger than the maximum packet size of 264 bytes (as per the data sheet). Therefore, these are redefined as buffers of size ```MaxPacketData``` (264). It is left as an exercise to the reader (or a future PR author) to replace these fixed-size allocations with the (much smaller) maximum possible response sizes in each case.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2077)