### PR TITLE
Changed rock pi 4 board pin numbering to match documentation.

### DIFF
--- a/src/devices/Gpio/Drivers/RockPi4BPlusDriver.cs
+++ b/src/devices/Gpio/Drivers/RockPi4BPlusDriver.cs
@@ -13,26 +13,43 @@ namespace Iot.Device.Gpio.Drivers
     /// </remarks>
     public class RockPi4bPlusDriver : Rk3399Driver
     {
-        private static readonly int[] _pinNumberConverter = new int[]
-        {
-            -1, -1, MapPinNumber(2, 'A', 7), -1, MapPinNumber(2, 'B', 0), -1, MapPinNumber(2, 'B', 3),
-            MapPinNumber(4, 'C', 4), -1, MapPinNumber(4, 'C', 3), MapPinNumber(4, 'C', 2), MapPinNumber(4, 'A', 3),
-            MapPinNumber(4, 'C', 6), -1, MapPinNumber(4, 'C', 5), MapPinNumber(4, 'D', 2), -1, MapPinNumber(4, 'D', 4),
-            MapPinNumber(1, 'B', 0), -1, MapPinNumber(1, 'A', 7), MapPinNumber(4, 'D', 5), MapPinNumber(1, 'B', 1),
-            MapPinNumber(1, 'B', 2), -1, -1, MapPinNumber(2, 'A', 0), MapPinNumber(2, 'A', 1), MapPinNumber(2, 'B', 2),
-            -1, MapPinNumber(2, 'B', 1), MapPinNumber(3, 'C', 0), MapPinNumber(2, 'B', 4), -1, MapPinNumber(4, 'A', 5),
-            MapPinNumber(4, 'A', 4), MapPinNumber(4, 'D', 6), MapPinNumber(4, 'A', 6), -1, MapPinNumber(4, 'A', 7)
-        };
-
         /// <inheritdoc/>
         protected override int PinCount => 40;
 
         /// <inheritdoc/>
         protected override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
         {
-            int num = _pinNumberConverter[pinNumber];
-
-            return num != -1 ? num : throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber));
+            return pinNumber switch
+            {
+                3 => MapPinNumber(2, 'A', 7),
+                5 => MapPinNumber(2, 'B', 0),
+                7 => MapPinNumber(2, 'B', 3),
+                8 => MapPinNumber(4, 'C', 4),
+                10 => MapPinNumber(4, 'C', 3),
+                11 => MapPinNumber(4, 'C', 2),
+                12 => MapPinNumber(4, 'A', 3),
+                13 => MapPinNumber(4, 'C', 6),
+                15 => MapPinNumber(4, 'C', 5),
+                16 => MapPinNumber(4, 'D', 2),
+                18 => MapPinNumber(4, 'D', 4),
+                19 => MapPinNumber(1, 'B', 0),
+                21 => MapPinNumber(1, 'A', 7),
+                22 => MapPinNumber(4, 'D', 5),
+                23 => MapPinNumber(1, 'B', 1),
+                24 => MapPinNumber(1, 'B', 2),
+                27 => MapPinNumber(2, 'A', 0),
+                28 => MapPinNumber(2, 'A', 1),
+                29 => MapPinNumber(2, 'B', 2),
+                31 => MapPinNumber(2, 'B', 1),
+                32 => MapPinNumber(3, 'C', 0),
+                33 => MapPinNumber(2, 'B', 4),
+                35 => MapPinNumber(4, 'A', 5),
+                36 => MapPinNumber(4, 'A', 4),
+                37 => MapPinNumber(4, 'D', 6),
+                38 => MapPinNumber(4, 'A', 6),
+                40 => MapPinNumber(4, 'A', 7),
+                _ => throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber))
+            };
         }
     }
 }


### PR DESCRIPTION
This corrects the board pin numbers used by the RockPi4bPlusDriver to match the numbering in the documentation (see [this product brief](https://dl.radxa.com/rockpi4/docs/hw/rockpi4/radxa_rock4bp_product_brief_Revision_1.1.pdf) for the official documentation. 

The original implementation used pin numbers that were 1 less than what the board document specified. If you wanted GPIO code that would work on both the raspberry pi and the rock 4 (their form factor and GPIO header are almost identical), you'd need to apply a -1 to the pin numbers if you were running on a rock 4 board.

This will break existing code using this driver with board pin numbering. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2082)