### PR TITLE
Bind to explicit major version of libgpiod

### DIFF
--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
@@ -15,7 +15,7 @@ internal partial class Interop
 {
     internal partial class libgpiod
     {
-        // Binding to the 2.x mayor version of libgpiod which comes installed on most distros today.
+        // Binding to the 2.x major version of libgpiod which comes installed on most distros today.
         private const string LibgpiodLibrary = "libgpiod.so.2";
         internal static IntPtr InvalidHandleValue = new IntPtr(-1);
 

--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/Interop.libgpiod.cs
@@ -15,7 +15,8 @@ internal partial class Interop
 {
     internal partial class libgpiod
     {
-        private const string LibgpiodLibrary = "libgpiod";
+        // Binding to the 2.x mayor version of libgpiod which comes installed on most distros today.
+        private const string LibgpiodLibrary = "libgpiod.so.2";
         internal static IntPtr InvalidHandleValue = new IntPtr(-1);
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/iot/issues/1070

cc: @rafal-mz @Ellerbach @krwq @pgrawehr 

Things that I need help with for testing this:

- [ ] Ensure that libgpiod driver still works as expected when picking it manually
- [ ] Ensure that libgpiod driver is now the default in boards that haven't installed the `libgpiod-dev` package
- [ ] If possible, Ensure that this works in several boards, not just a Raspberry Pi.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2090)