### PR TITLE
[SHT4x] Read serial number of sensor module

### DIFF
--- a/src/devices/Sht4x/Sht4x.cs
+++ b/src/devices/Sht4x/Sht4x.cs
@@ -81,6 +81,25 @@ namespace Iot.Device.Sht4x
         }
 
         /// <summary>
+        /// Reads the serial number of the device
+        /// </summary>
+        /// <returns>
+        /// A 32 bit integer with the serial number.
+        /// If a CRC check failed for a reading, it will be <see langword="null"/>.
+        /// </returns>
+        public int? ReadSerialNumber()
+        {
+            Span<byte> buffer = stackalloc byte[6];
+            _device.WriteByte((byte)0x89);
+            _device.Read(buffer);
+
+            ushort? msb = Sensirion.ReadUInt16BigEndianAndCRC8(buffer);
+            ushort? lsb = Sensirion.ReadUInt16BigEndianAndCRC8(buffer.Slice(3, 3));
+
+            return lsb + (msb << 16);
+        }
+
+        /// <summary>
         /// Reads relative humidity and temperature.
         /// </summary>
         /// <returns>

--- a/src/devices/Sht4x/samples/Program.cs
+++ b/src/devices/Sht4x/samples/Program.cs
@@ -13,6 +13,9 @@ I2cConnectionSettings settings = new(1, Sht4x.DefaultI2cAddress);
 using I2cDevice device = I2cDevice.Create(settings);
 using Sht4x sensor = new(device);
 
+// Read serial number
+Console.WriteLine($"Serial number: {sensor.ReadSerialNumber()}");
+
 // Async loop.
 for (int i = 0; i < 3; ++i)
 {


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->
The current module has no implementation for reading the serial number of the SHT4x device. 
This PR implements the reading of the serial number of the SHT4x device.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2091)