### PR TITLE
Fixes #2094 - Ft232H I2C Create Device always returns 'Device already open'

### DIFF
--- a/src/devices/Ft232H/Ft232HI2cBus.cs
+++ b/src/devices/Ft232H/Ft232HI2cBus.cs
@@ -37,7 +37,7 @@ namespace Iot.Device.Ft232H
         /// <inheritdoc/>
         public override I2cDevice CreateDevice(int deviceAddress)
         {
-            if (!_usedAddresses.ContainsKey(deviceAddress))
+            if (_usedAddresses.ContainsKey(deviceAddress))
             {
                 throw new ArgumentException($"Device with address 0x{deviceAddress,0X2} is already open.", nameof(deviceAddress));
             }


### PR DESCRIPTION
Fixes #2094
Inverted the 'Device Already Open' check so it will work as designed.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2095)

EDIT (@krwq): changed syntax so that issue gets auto closed on merge