### PR TITLE
Add Retries to Button tests which can be flaky

### DIFF
--- a/src/devices/Button/tests/Button.tests.csproj
+++ b/src/devices/Button/tests/Button.tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\System.Device.Gpio.Tests\RetryHelper.cs" />
     <ProjectReference Include="..\Button.csproj" />
   </ItemGroup>
 

--- a/src/devices/Button/tests/ButtonTests.cs
+++ b/src/devices/Button/tests/ButtonTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Device.Gpio.Tests;
 using System.Threading;
 
 using Xunit;
@@ -13,279 +14,301 @@ namespace Iot.Device.Button.Tests
         [Fact]
         public void If_Button_Is_Once_Pressed_Press_Event_Fires()
         {
-            bool pressed = false;
-            bool holding = false;
-            bool doublePressed = false;
-
-            TestButton button = new TestButton();
-
-            button.Press += (sender, e) =>
+            RetryHelper.Execute(() =>
             {
-                pressed = true;
-            };
+                bool pressed = false;
+                bool holding = false;
+                bool doublePressed = false;
 
-            button.Holding += (sender, e) =>
-            {
-                holding = true;
-            };
+                TestButton button = new TestButton();
 
-            button.DoublePress += (sender, e) =>
-            {
-                doublePressed = true;
-            };
+                button.Press += (sender, e) =>
+                {
+                    pressed = true;
+                };
 
-            button.PressButton();
+                button.Holding += (sender, e) =>
+                {
+                    holding = true;
+                };
 
-            // Wait a little bit to mimic actual user behavior.
-            Thread.Sleep(100);
+                button.DoublePress += (sender, e) =>
+                {
+                    doublePressed = true;
+                };
 
-            button.ReleaseButton();
+                button.PressButton();
 
-            Assert.True(pressed);
-            Assert.False(holding);
-            Assert.False(doublePressed);
+                // Wait a little bit to mimic actual user behavior.
+                Thread.Sleep(100);
+
+                button.ReleaseButton();
+
+                Assert.True(pressed);
+                Assert.False(holding);
+                Assert.False(doublePressed);
+            });
         }
 
         [Fact]
         public void If_Button_Is_Held_Holding_Event_Fires()
         {
-            bool pressed = false;
-            bool holding = false;
-            bool doublePressed = false;
-
-            TestButton button = new TestButton();
-            button.IsHoldingEnabled = true;
-
-            button.Press += (sender, e) =>
+            RetryHelper.Execute(() =>
             {
-                pressed = true;
-            };
+                bool pressed = false;
+                bool holding = false;
+                bool doublePressed = false;
 
-            button.Holding += (sender, e) =>
-            {
-                holding = true;
-            };
+                TestButton button = new TestButton();
+                button.IsHoldingEnabled = true;
 
-            button.DoublePress += (sender, e) =>
-            {
-                doublePressed = true;
-            };
+                button.Press += (sender, e) =>
+                {
+                    pressed = true;
+                };
 
-            button.PressButton();
+                button.Holding += (sender, e) =>
+                {
+                    holding = true;
+                };
 
-            // Wait longer than default holding threshold milliseconds, for the click to be recognized as a holding event.
-            Thread.Sleep(2100);
+                button.DoublePress += (sender, e) =>
+                {
+                    doublePressed = true;
+                };
 
-            button.ReleaseButton();
+                button.PressButton();
 
-            Assert.True(holding, "holding");
-            Assert.True(pressed, "pressed");
-            Assert.False(doublePressed, "doublePressed");
+                // Wait longer than default holding threshold milliseconds, for the click to be recognized as a holding event.
+                Thread.Sleep(2100);
+
+                button.ReleaseButton();
+
+                Assert.True(holding, "holding");
+                Assert.True(pressed, "pressed");
+                Assert.False(doublePressed, "doublePressed");
+            });
         }
 
         [Fact]
         public void If_Button_Is_Held_And_Holding_Is_Disabled_Holding_Event_Does_Not_Fire()
         {
-            bool pressed = false;
-            bool holding = false;
-            bool doublePressed = false;
-
-            TestButton button = new TestButton();
-            button.IsHoldingEnabled = false;
-
-            button.Press += (sender, e) =>
+            RetryHelper.Execute(() =>
             {
-                pressed = true;
-            };
+                bool pressed = false;
+                bool holding = false;
+                bool doublePressed = false;
 
-            button.Holding += (sender, e) =>
-            {
-                holding = true;
-            };
+                TestButton button = new TestButton();
+                button.IsHoldingEnabled = false;
 
-            button.DoublePress += (sender, e) =>
-            {
-                doublePressed = true;
-            };
+                button.Press += (sender, e) =>
+                {
+                    pressed = true;
+                };
 
-            button.PressButton();
+                button.Holding += (sender, e) =>
+                {
+                    holding = true;
+                };
 
-            // Wait longer than default holding threshold milliseconds, for the press to be recognized as a holding event.
-            Thread.Sleep(2100);
+                button.DoublePress += (sender, e) =>
+                {
+                    doublePressed = true;
+                };
 
-            button.ReleaseButton();
+                button.PressButton();
 
-            Assert.True(pressed);
-            Assert.False(holding);
-            Assert.False(doublePressed);
+                // Wait longer than default holding threshold milliseconds, for the press to be recognized as a holding event.
+                Thread.Sleep(2100);
+
+                button.ReleaseButton();
+
+                Assert.True(pressed);
+                Assert.False(holding);
+                Assert.False(doublePressed);
+            });
         }
 
         [Fact]
         public void If_Button_Is_Double_Pressed_DoublePress_Event_Fires()
         {
-            bool pressed = false;
-            bool holding = false;
-            bool doublePressed = false;
-
-            TestButton button = new TestButton();
-            button.IsDoublePressEnabled = true;
-
-            button.Press += (sender, e) =>
+            RetryHelper.Execute(() =>
             {
-                pressed = true;
-            };
+                bool pressed = false;
+                bool holding = false;
+                bool doublePressed = false;
 
-            button.Holding += (sender, e) =>
-            {
-                holding = true;
-            };
+                TestButton button = new TestButton();
+                button.IsDoublePressEnabled = true;
 
-            button.DoublePress += (sender, e) =>
-            {
-                doublePressed = true;
-            };
+                button.Press += (sender, e) =>
+                {
+                    pressed = true;
+                };
 
-            button.PressButton();
+                button.Holding += (sender, e) =>
+                {
+                    holding = true;
+                };
 
-            // Wait a little bit to mimic actual user behavior.
-            Thread.Sleep(100);
+                button.DoublePress += (sender, e) =>
+                {
+                    doublePressed = true;
+                };
 
-            button.ReleaseButton();
+                button.PressButton();
 
-            // Wait shorter than default double press threshold milliseconds, for the press to be recognized as a double press event.
-            Thread.Sleep(200);
+                // Wait a little bit to mimic actual user behavior.
+                Thread.Sleep(100);
 
-            button.PressButton();
+                button.ReleaseButton();
 
-            // Wait a little bit to mimic actual user behavior.
-            Thread.Sleep(100);
+                // Wait shorter than default double press threshold milliseconds, for the press to be recognized as a double press event.
+                Thread.Sleep(200);
 
-            button.ReleaseButton();
+                button.PressButton();
 
-            Assert.True(pressed);
-            Assert.False(holding);
-            Assert.True(doublePressed);
+                // Wait a little bit to mimic actual user behavior.
+                Thread.Sleep(100);
+
+                button.ReleaseButton();
+
+                Assert.True(pressed);
+                Assert.False(holding);
+                Assert.True(doublePressed);
+            });
         }
 
         [Fact]
         public void If_Button_Is_Pressed_Twice_DoublePress_Event_Does_Not_Fire()
         {
-            bool pressed = false;
-            bool holding = false;
-            bool doublePressed = false;
-
-            TestButton button = new TestButton();
-
-            button.IsDoublePressEnabled = true;
-
-            button.Press += (sender, e) =>
+            RetryHelper.Execute(() =>
             {
-                pressed = true;
-            };
+                bool pressed = false;
+                bool holding = false;
+                bool doublePressed = false;
 
-            button.Holding += (sender, e) =>
-            {
-                holding = true;
-            };
+                TestButton button = new()
+                {
+                    IsDoublePressEnabled = true
+                };
 
-            button.DoublePress += (sender, e) =>
-            {
-                doublePressed = true;
-            };
+                button.Press += (sender, e) =>
+                {
+                    pressed = true;
+                };
 
-            button.PressButton();
+                button.Holding += (sender, e) =>
+                {
+                    holding = true;
+                };
 
-            // Wait a little bit to mimic actual user behavior.
-            Thread.Sleep(100);
+                button.DoublePress += (sender, e) =>
+                {
+                    doublePressed = true;
+                };
 
-            button.ReleaseButton();
+                button.PressButton();
 
-            // Wait longer than default double press threshold milliseconds, for the press to be recognized as two separate presses.
-            Thread.Sleep(3000);
+                // Wait a little bit to mimic actual user behavior.
+                Thread.Sleep(100);
 
-            button.PressButton();
+                button.ReleaseButton();
 
-            // Wait a little bit to mimic actual user behavior.
-            Thread.Sleep(100);
+                // Wait longer than default double press threshold milliseconds, for the press to be recognized as two separate presses.
+                Thread.Sleep(3000);
 
-            button.ReleaseButton();
+                button.PressButton();
 
-            Assert.True(pressed);
-            Assert.False(holding);
-            Assert.False(doublePressed);
+                // Wait a little bit to mimic actual user behavior.
+                Thread.Sleep(100);
+
+                button.ReleaseButton();
+
+                Assert.True(pressed);
+                Assert.False(holding);
+                Assert.False(doublePressed);
+            });
         }
 
         [Fact]
         public void If_Button_Is_Double_Pressed_And_DoublePress_Is_Disabled_DoublePress_Event_Does_Not_Fire()
         {
-            bool pressed = false;
-
-            TestButton button = new TestButton();
-            button.IsDoublePressEnabled = false;
-
-            button.DoublePress += (sender, e) =>
+            RetryHelper.Execute(() =>
             {
-                pressed = true;
-            };
+                bool pressed = false;
 
-            button.PressButton();
+                TestButton button = new TestButton();
+                button.IsDoublePressEnabled = false;
 
-            // Wait a little bit to mimic actual user behavior.
-            Thread.Sleep(100);
+                button.DoublePress += (sender, e) =>
+                {
+                    pressed = true;
+                };
 
-            button.ReleaseButton();
+                button.PressButton();
 
-            // Wait shorter than default double press threshold milliseconds, for the press to be recognized as a double press event.
-            Thread.Sleep(200);
+                // Wait a little bit to mimic actual user behavior.
+                Thread.Sleep(100);
 
-            button.PressButton();
+                button.ReleaseButton();
 
-            // Wait a little bit to mimic actual user behavior.
-            Thread.Sleep(100);
+                // Wait shorter than default double press threshold milliseconds, for the press to be recognized as a double press event.
+                Thread.Sleep(200);
 
-            button.ReleaseButton();
+                button.PressButton();
 
-            Assert.False(pressed);
+                // Wait a little bit to mimic actual user behavior.
+                Thread.Sleep(100);
+
+                button.ReleaseButton();
+
+                Assert.False(pressed);
+            });
         }
 
         [Fact]
         public void If_Button_Is_Pressed_Too_Fast_Debouncing_Removes_Events()
         {
-            bool holding = false;
-            bool doublePressed = false;
-            int pressedCounter = 0;
-
-            TestButton button = new TestButton(TimeSpan.FromMilliseconds(1000));
-
-            button.Press += (sender, e) =>
+            RetryHelper.Execute(() =>
             {
-                pressedCounter++;
-            };
+                bool holding = false;
+                bool doublePressed = false;
+                int pressedCounter = 0;
 
-            button.Holding += (sender, e) =>
-            {
-                holding = true;
-            };
+                TestButton button = new TestButton(TimeSpan.FromMilliseconds(1000));
 
-            button.DoublePress += (sender, e) =>
-            {
-                doublePressed = true;
-            };
+                button.Press += (sender, e) =>
+                {
+                    pressedCounter++;
+                };
 
-            button.PressButton();
-            button.ReleaseButton();
-            button.PressButton();
-            button.ReleaseButton();
-            button.PressButton();
-            button.ReleaseButton();
-            button.PressButton();
-            button.ReleaseButton();
-            button.PressButton();
-            button.ReleaseButton();
+                button.Holding += (sender, e) =>
+                {
+                    holding = true;
+                };
 
-            Assert.Equal(1, pressedCounter);
-            Assert.False(holding);
-            Assert.False(doublePressed);
+                button.DoublePress += (sender, e) =>
+                {
+                    doublePressed = true;
+                };
+
+                button.PressButton();
+                button.ReleaseButton();
+                button.PressButton();
+                button.ReleaseButton();
+                button.PressButton();
+                button.ReleaseButton();
+                button.PressButton();
+                button.ReleaseButton();
+                button.PressButton();
+                button.ReleaseButton();
+
+                Assert.Equal(1, pressedCounter);
+                Assert.False(holding);
+                Assert.False(doublePressed);
+            });
         }
 
         /// <summary>
@@ -298,60 +321,63 @@ namespace Iot.Device.Button.Tests
         [Fact]
         public void If_Button_Is_Held_Down_Longer_Than_Debouncing()
         {
-            bool holding = false;
-            bool doublePressed = false;
-            int buttonDownCounter = 0;
-            int buttonUpCounter = 0;
-            int pressedCounter = 0;
-
-            // holding is 2 secs, debounce is 1 sec
-            TestButton button = new TestButton(TimeSpan.FromMilliseconds(1000));
-            button.IsHoldingEnabled = true;
-
-            button.Press += (sender, e) =>
+            RetryHelper.Execute(() =>
             {
-                pressedCounter++;
-            };
+                bool holding = false;
+                bool doublePressed = false;
+                int buttonDownCounter = 0;
+                int buttonUpCounter = 0;
+                int pressedCounter = 0;
 
-            button.ButtonDown += (sender, e) =>
-            {
-                buttonDownCounter++;
-            };
+                // holding is 2 secs, debounce is 1 sec
+                TestButton button = new TestButton(TimeSpan.FromMilliseconds(1000));
+                button.IsHoldingEnabled = true;
 
-            button.ButtonUp += (sender, e) =>
-            {
-                buttonUpCounter++;
-            };
+                button.Press += (sender, e) =>
+                {
+                    pressedCounter++;
+                };
 
-            button.Holding += (sender, e) =>
-            {
-                holding = true;
-            };
+                button.ButtonDown += (sender, e) =>
+                {
+                    buttonDownCounter++;
+                };
 
-            button.DoublePress += (sender, e) =>
-            {
-                doublePressed = true;
-            };
+                button.ButtonUp += (sender, e) =>
+                {
+                    buttonUpCounter++;
+                };
 
-            // pushing the button. This will trigger the buttonDown event
-            button.PressButton();
-            Thread.Sleep(2200);
-            // releasing the button. This will trigger the pressed and buttonUp event
-            button.ReleaseButton();
+                button.Holding += (sender, e) =>
+                {
+                    holding = true;
+                };
 
-            // now simulating hw bounces which should not be detected
-            button.PressButton();
-            button.ReleaseButton();
-            button.PressButton();
-            button.ReleaseButton();
-            button.PressButton();
-            button.ReleaseButton();
+                button.DoublePress += (sender, e) =>
+                {
+                    doublePressed = true;
+                };
 
-            Assert.True(buttonDownCounter == 1, "ButtonDown counter is wrong");
-            Assert.True(buttonUpCounter == 1, "ButtonUp counter is wrong");
-            Assert.True(pressedCounter == 1, "pressedCounter counter is wrong");
-            Assert.True(holding, "holding");
-            Assert.False(doublePressed, "doublePressed");
+                // pushing the button. This will trigger the buttonDown event
+                button.PressButton();
+                Thread.Sleep(2200);
+                // releasing the button. This will trigger the pressed and buttonUp event
+                button.ReleaseButton();
+
+                // now simulating hw bounces which should not be detected
+                button.PressButton();
+                button.ReleaseButton();
+                button.PressButton();
+                button.ReleaseButton();
+                button.PressButton();
+                button.ReleaseButton();
+
+                Assert.True(buttonDownCounter == 1, "ButtonDown counter is wrong");
+                Assert.True(buttonUpCounter == 1, "ButtonUp counter is wrong");
+                Assert.True(pressedCounter == 1, "pressedCounter counter is wrong");
+                Assert.True(holding, "holding");
+                Assert.False(doublePressed, "doublePressed");
+            });
         }
     }
 }


### PR DESCRIPTION
We've seen that some of our Button tests can be flaky some times, so adding the RetryHelper we  use for hardware tests should help reducing that noise. For review, it is easier to make sure you check the option of ignoring spaces which would show the real diff which is only adding RetryHelper to wrap the methods.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2102)