### PR TITLE
Branding changes for 3.1

### DIFF
--- a/src/Iot.Device.Bindings.SkiaSharpAdapter/Directory.Build.props
+++ b/src/Iot.Device.Bindings.SkiaSharpAdapter/Directory.Build.props
@@ -2,11 +2,11 @@
   <!-- Packaging related properties -->
   <PropertyGroup>
     <MajorVersion>3</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MinorVersion>1</MinorVersion>
     <Description>This package contains the BitmapImage adapter using SkiaSharp. This library is an optional package to provide imaging functionality for Iot.Device.Bidnings.dll</Description>
     <PackageTags>.NET Core IoT Device Bindings SkiaSharp Adapter</PackageTags>
-    <EnablePackageValidation>false</EnablePackageValidation>
-    <PackageValidationBaselineVersion>2.2.0</PackageValidationBaselineVersion>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <Import Project="../../Directory.Build.props" />

--- a/src/Iot.Device.Bindings/Directory.Build.props
+++ b/src/Iot.Device.Bindings/Directory.Build.props
@@ -2,11 +2,11 @@
   <!-- Packaging related properties -->
   <PropertyGroup>
     <MajorVersion>3</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MinorVersion>1</MinorVersion>
     <Description>This package provides a set of Device Bindings that use System.Device.Gpio package to communicate with a microcontroller.</Description>
     <PackageTags>.NET Core GPIO Pins SPI I2C PWM BCM2835 BCM2837 RPi IoT Device Bindings</PackageTags>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>2.2.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <Import Project="../../Directory.Build.props" />

--- a/src/System.Device.Gpio/Directory.Build.props
+++ b/src/System.Device.Gpio/Directory.Build.props
@@ -2,11 +2,11 @@
   <!-- Packaging related properties -->
   <PropertyGroup>
     <MajorVersion>3</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MinorVersion>1</MinorVersion>
     <Description>The System.Device.Gpio package supports general-purpose I/O (GPIO) pins, PWM, I2C, SPI and related interfaces for interacting with low level hardware pins to control hardware sensors, displays and input devices on single-board-computers; Raspberry Pi, BeagleBoard, HummingBoard, ODROID, and other single-board-computers that are supported by Linux and Windows 10 IoT Core OS can be used with .NET Core and System.Device.Gpio.  On Windows 10 IoT Core OS, the library wraps the Windows.Devices.Gpio.dll assembly.  On Linux, the library supports three driver modes: libgpiod for fast full-featured GPIO access on all Linux distros since version 4.8 of the Linux kernel; slower and limited-functionality GPIO access via the deprecated Sysfs interface (/sys/class/gpio) when running on older Linux distro versions with a Linux kernel older than version 4.8; and lastly board-specific Linux drivers that access GPIO addresses in /dev/mem for fasted performance at the trade-off of being able to run on very specific versions of single-board-computers.  In the future, the board-specific Linux drivers may be removed in favor of only supporting libgpiod and sysfs Linux interfaces.  In addition to System.Device.Gpio, the optional Iot.Device.Bindings NuGet package contains device bindings for many sensors, displays, and input devices that can be used with System.Device.Gpio.
     </Description>
     <PackageTags>.NET Core GPIO Pins SPI I2C PWM BCM2835 RPi IoT</PackageTags>
-    <PackageValidationBaselineVersion>2.2.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
     <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 


### PR DESCRIPTION
Branding changes for 3.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2103)