### PR TITLE
Fix wrong PinCount evaluation for FT232H

### DIFF
--- a/src/devices/Ft232H/Ftx232HDevice.cs
+++ b/src/devices/Ft232H/Ftx232HDevice.cs
@@ -128,7 +128,7 @@ namespace Iot.Device.FtCommon
         /// <summary>
         /// Gets the number of pins for this specific FT device.
         /// </summary>
-        public int PinCount => Type == FtDeviceType.Ft4232H ? PinNumberFT2x : PinNumberFT4x;
+        public int PinCount => Type == FtDeviceType.Ft4232H ? PinNumberFT4x : PinNumberFT2x;
 
         /// <summary>
         /// Gets or sets the I2C Bus frequency. Default value is 400 KHz.


### PR DESCRIPTION
Currently it is not possible to open pins 8-15 on a FT232H board using the Ft232HGpio driver, because the pin count checked against is the pin count of the device, which is set to 8 instead of 16.

This is caused because the type of the device is checked, but the assignment of the pin count is actually the wrong way around, e.g. FT4232H is assigned 16 pins per channel (instead of 8) and both FT232H and FT2232H are assigned 8 pins per channel (instead of 16).


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2116)