### PR TITLE
Added CM4 model check to IsPi4

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/RaspberryPi3LinuxDriver.cs
@@ -722,7 +722,7 @@ internal unsafe class RaspberryPi3LinuxDriver : GpioDriver
                 if (File.Exists(ModelFilePath))
                 {
                     string model = File.ReadAllText(ModelFilePath, Text.Encoding.ASCII);
-                    if (model.Contains("Raspberry Pi 4"))
+                    if (model.Contains("Raspberry Pi 4") || model.Contains("Raspberry Pi Compute Module 4"))
                     {
                         IsPi4 = true;
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/iot/issues/2126
Compute Module 4 needs to be handled the same way as a pi4. Right now, due to the device model of a CM4 being "Raspberry Pi Compute Module 4" it is being treated as a pi3(only in code that uses the IsPi4 bool). This causes a problem with the pin mapping and prevents the CM4 from having it's input/output and pullup/pulldown changed on OpenPin().

<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2125)