### PR TITLE
Fixes the button holding test randomly failing on Mac (part 2)

### DIFF
--- a/src/devices/Button/tests/ButtonTests.cs
+++ b/src/devices/Button/tests/ButtonTests.cs
@@ -50,7 +50,7 @@ namespace Iot.Device.Button.Tests
         }
 
         [Fact]
-        public async void If_Button_Is_Held_Holding_Event_Fires()
+        public async Task If_Button_Is_Held_Holding_Event_Fires()
         {
             bool pressed = false;
             bool holding = false;

--- a/src/devices/Button/tests/ButtonTests.cs
+++ b/src/devices/Button/tests/ButtonTests.cs
@@ -72,10 +72,7 @@ namespace Iot.Device.Button.Tests
             button.Holding += (sender, e) =>
             {
                 holding = true;
-                if (e.HoldingState == ButtonHoldingState.Completed)
-                {
-                    tcs.SetResult(DateTime.Now);
-                }
+                tcs.TrySetResult(DateTime.Now);
             };
 
             button.DoublePress += (sender, e) =>
@@ -362,10 +359,7 @@ namespace Iot.Device.Button.Tests
             button.Holding += (sender, e) =>
             {
                 holding = true;
-                if (e.HoldingState == ButtonHoldingState.Completed)
-                {
-                    tcs.SetResult(DateTime.Now);
-                }
+                tcs.TrySetResult(DateTime.Now);
             };
 
             button.DoublePress += (sender, e) =>

--- a/src/devices/Button/tests/ButtonTests.cs
+++ b/src/devices/Button/tests/ButtonTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Xunit;
 
@@ -47,14 +48,18 @@ namespace Iot.Device.Button.Tests
         }
 
         [Fact]
-        public void If_Button_Is_Held_Holding_Event_Fires()
+        public async void If_Button_Is_Held_Holding_Event_Fires()
         {
             bool pressed = false;
             bool holding = false;
             bool doublePressed = false;
 
-            TestButton button = new TestButton();
+            // we set short times to avoid wasting when executing the tests
+            var debounceTime = TimeSpan.FromMilliseconds(200);
+            var holdingTime = TimeSpan.FromMilliseconds(400);
+            TestButton button = new TestButton(debounceTime, holdingTime);
             button.IsHoldingEnabled = true;
+            TaskCompletionSource<DateTime> tcs = new TaskCompletionSource<DateTime>();
 
             button.Press += (sender, e) =>
             {
@@ -64,6 +69,10 @@ namespace Iot.Device.Button.Tests
             button.Holding += (sender, e) =>
             {
                 holding = true;
+                if (e.HoldingState == ButtonHoldingState.Completed)
+                {
+                    tcs.SetResult(DateTime.Now);
+                }
             };
 
             button.DoublePress += (sender, e) =>
@@ -71,13 +80,21 @@ namespace Iot.Device.Button.Tests
                 doublePressed = true;
             };
 
+            DateTime now = DateTime.Now;
             button.PressButton();
 
-            // Wait longer than default holding threshold milliseconds, for the click to be recognized as a holding event.
-            Thread.Sleep(2100);
+            Thread.Sleep((int)holdingTime.TotalMilliseconds + 100);
 
             button.ReleaseButton();
 
+            // this is only needed to avoid to wait indefinitely in case the code gets broken and the test fail
+            var firstTask = await Task.WhenAny(tcs.Task, Task.Delay(2 * (int)holdingTime.TotalMilliseconds));
+            Assert.True(tcs.Task == firstTask, "holding timeout");
+
+            // holdingTime is the DateTime retrieved in the holding timer handler
+            var effectiveHoldingTime = tcs.Task.Result;
+
+            Assert.True(effectiveHoldingTime - now >= holdingTime, "holding");
             Assert.True(holding, "holding");
             Assert.True(pressed, "pressed");
             Assert.False(doublePressed, "doublePressed");
@@ -255,7 +272,8 @@ namespace Iot.Device.Button.Tests
             bool doublePressed = false;
             int pressedCounter = 0;
 
-            TestButton button = new TestButton(TimeSpan.FromMilliseconds(1000));
+            var holdingTime = TimeSpan.FromMilliseconds(2000);
+            TestButton button = new TestButton(TimeSpan.FromMilliseconds(1000), holdingTime);
 
             button.Press += (sender, e) =>
             {
@@ -305,7 +323,8 @@ namespace Iot.Device.Button.Tests
             int pressedCounter = 0;
 
             // holding is 2 secs, debounce is 1 sec
-            TestButton button = new TestButton(TimeSpan.FromMilliseconds(1000));
+            var holdingTime = TimeSpan.FromMilliseconds(2000);
+            TestButton button = new TestButton(TimeSpan.FromMilliseconds(1000), holdingTime);
             button.IsHoldingEnabled = true;
 
             button.Press += (sender, e) =>

--- a/src/devices/Button/tests/ButtonTests.cs
+++ b/src/devices/Button/tests/ButtonTests.cs
@@ -57,6 +57,7 @@ namespace Iot.Device.Button.Tests
             // we set short times to avoid wasting when executing the tests
             var debounceTime = TimeSpan.FromMilliseconds(200);
             var holdingTime = TimeSpan.FromMilliseconds(400);
+            var timeoutTime = TimeSpan.FromMilliseconds(20000);
             TestButton button = new TestButton(debounceTime, holdingTime);
             button.IsHoldingEnabled = true;
             TaskCompletionSource<DateTime> tcs = new TaskCompletionSource<DateTime>();
@@ -88,7 +89,7 @@ namespace Iot.Device.Button.Tests
             button.ReleaseButton();
 
             // this is only needed to avoid to wait indefinitely in case the code gets broken and the test fail
-            var firstTask = await Task.WhenAny(tcs.Task, Task.Delay(2 * (int)holdingTime.TotalMilliseconds));
+            var firstTask = await Task.WhenAny(tcs.Task, Task.Delay(timeoutTime));
             Assert.True(tcs.Task == firstTask, "holding timeout");
 
             // holdingTime is the DateTime retrieved in the holding timer handler

--- a/src/devices/Button/tests/TestButton.cs
+++ b/src/devices/Button/tests/TestButton.cs
@@ -12,8 +12,8 @@ namespace Iot.Device.Button.Tests
         {
         }
 
-        public TestButton(TimeSpan debounceTime)
-            : base(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(2000), debounceTime)
+        public TestButton(TimeSpan debounceTime, TimeSpan holdingTime)
+            : base(TimeSpan.FromSeconds(5), holdingTime, debounceTime)
         {
         }
 

--- a/src/devices/Button/tests/TestButton.cs
+++ b/src/devices/Button/tests/TestButton.cs
@@ -17,6 +17,11 @@ namespace Iot.Device.Button.Tests
         {
         }
 
+        public TestButton(TimeSpan debounceTime, TimeSpan holdingTime, TimeSpan doublePress)
+            : base(doublePress, holdingTime, debounceTime)
+        {
+        }
+
         public void PressButton()
         {
             HandleButtonPressed();


### PR DESCRIPTION
This is the continuation of #2121 

The main point is that tests failed on mac just because the button holding uses a `System.Threading.Timer` and this secondary timer is served very rarely on Mac.
The latest fail was instead due to the *timeout too short*. This is a timeout to only avoid the test can hang forever.

These changes consists in:
- Making the timeout very long because the already fixed test failed because of a timeout (https://github.com/dotnet/iot/pull/2124#issuecomment-1699463438)
- Fixing the only other test that asserts Holding as `true`
- No need to fix the tests asserting Holding as `false`
- Shortening the times used by the tests to avoid wasting time during the CI process

> Please note there is no open issue for this problem




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2127)