### PR TITLE
Add event handling methods

### DIFF
--- a/src/devices/Mcp23xxx/Mcp23x1x.cs
+++ b/src/devices/Mcp23xxx/Mcp23x1x.cs
@@ -54,5 +54,25 @@ namespace Iot.Device.Mcp23xxx
         /// Reads the interrupt pin for the given port if configured.
         /// </summary>
         public PinValue ReadInterrupt(Port port) => InternalReadInterrupt(port);
+
+        /// <summary>
+        /// Reads all bits of port A in a single operation.
+        /// </summary>
+        /// <returns></returns>
+        public int ReadPortA()
+        {
+            int value = ReadByte(Register.GPIO, Port.PortA);
+            return value;
+        }
+
+        /// <summary>
+        /// Reads all bits of port B in a single operation.
+        /// </summary>
+        /// <returns></returns>
+        public int ReadPortB()
+        {
+            int value = ReadByte(Register.GPIO, Port.PortB);
+            return value;
+        }
     }
 }

--- a/src/devices/Mcp23xxx/Mcp23xxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23xxx.cs
@@ -767,14 +767,14 @@ namespace Iot.Device.Mcp23xxx
                 Port port = GetPortForPinNumber(pinNumber);
                 if (port == Port.PortA)
                 {
-                    if (_eventHandlers.Any(x => x.Key <= 7))
+                    if (!_eventHandlers.Any(x => x.Key <= 7))
                     {
                         _controller.UnregisterCallbackForPinValueChangedEvent(_interruptA, InterruptHandler);
                     }
                 }
                 else
                 {
-                    if (_eventHandlers.Any(x => x.Key >= 8))
+                    if (!_eventHandlers.Any(x => x.Key >= 8))
                     {
                         _controller.UnregisterCallbackForPinValueChangedEvent(_interruptB, InterruptHandler);
                     }

--- a/src/devices/Mcp23xxx/Mcp23xxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23xxx.cs
@@ -573,7 +573,7 @@ namespace Iot.Device.Mcp23xxx
         /// </summary>
         /// <param name="pinNumber">The pin number for which an interrupt shall be triggered</param>
         /// <param name="eventTypes">Event(s) that should trigger the interrupt on the given pin</param>
-        /// <exception cref="ArgumentException">eventTypes is not valid</exception>
+        /// <exception cref="ArgumentException">EventTypes is not valid (must have at least one event type selected)</exception>
         public void EnableInterruptOnChange(int pinNumber, PinEventTypes eventTypes)
         {
             byte oldValue, newValue;

--- a/src/devices/Mcp23xxx/tests/EventHandlingTests.cs
+++ b/src/devices/Mcp23xxx/tests/EventHandlingTests.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Device.Gpio;
+using System.Device.I2c;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Iot.Device.Mcp23xxx;
+using Iot.Device.Mcp23xxx.Tests;
+using Xunit;
+using Moq;
+
+namespace Iot.Device.Mcp23xxx.Tests
+{
+    public sealed class EventHandlingTests : Mcp23xxxTest, IDisposable
+    {
+        private I2cDeviceMock _mockI2c;
+        private GpioDriverMock _driverMock;
+        private Iot.Device.Mcp23xxx.Mcp23xxx _device;
+        private GpioController _gpioController;
+        private int _callbackNo;
+
+        public EventHandlingTests()
+        {
+            _callbackNo = 0;
+            _mockI2c = new I2cDeviceMock(2, null);
+            _driverMock = new GpioDriverMock();
+            _gpioController = new GpioController(PinNumberingScheme.Logical, _driverMock);
+            _device = new Mcp23017(_mockI2c, -1, 11, 22, _gpioController, false);
+        }
+
+        [Fact]
+        public void EnableDisableEvents()
+        {
+            _device.EnableInterruptOnChange(0, PinEventTypes.Falling | PinEventTypes.Rising);
+            _device.DisableInterruptOnChange(0);
+        }
+
+        [Fact]
+        public void AddEventHandler()
+        {
+            GpioController theDeviceController = new GpioController(PinNumberingScheme.Logical, _device);
+            theDeviceController.OpenPin(1, PinMode.Input);
+            theDeviceController.RegisterCallbackForPinValueChangedEvent(1, PinEventTypes.Rising, Callback);
+
+            _mockI2c.DeviceMock.Registers[14] = 2; // Port A INTF register (pin 1 triggered the event)
+            _mockI2c.DeviceMock.Registers[0x12] = 2; // Port A GPIO register (pin 1 is high now)
+            // This should simulate the interrupt being triggered on the master controller, not the mcp!
+            _driverMock.FireEvent(new PinValueChangedEventArgs(PinEventTypes.Falling, 11));
+            Assert.True(_callbackNo == 1);
+            // Nothing registered for an event on interrupt B, so this shouldn't do anything
+            _driverMock.FireEvent(new PinValueChangedEventArgs(PinEventTypes.Falling, 22));
+            Assert.True(_callbackNo == 1);
+        }
+
+        [Fact]
+        public void AddRemoveEventHandler()
+        {
+            GpioController theDeviceController = new GpioController(PinNumberingScheme.Logical, _device);
+            theDeviceController.OpenPin(1, PinMode.Input);
+            theDeviceController.RegisterCallbackForPinValueChangedEvent(1, PinEventTypes.Rising, Callback);
+            theDeviceController.UnregisterCallbackForPinValueChangedEvent(1, Callback);
+
+            // Now trigger an event, shouldn't do anything
+            _mockI2c.DeviceMock.Registers[14] = 2; // Port A INTF register (pin 1 triggered the event)
+            _mockI2c.DeviceMock.Registers[0x12] = 2; // Port A GPIO register (pin 1 is high now)
+            // This should simulate the interrupt being triggered on the master controller, not the mcp!
+            _driverMock.FireEvent(new PinValueChangedEventArgs(PinEventTypes.Falling, 11));
+            Assert.True(_callbackNo == 0);
+            theDeviceController.ClosePin(1);
+        }
+
+        private void Callback(object sender, PinValueChangedEventArgs e)
+        {
+            Assert.Equal(PinEventTypes.Rising, e.ChangeType);
+            Assert.Equal(1, e.PinNumber);
+            _callbackNo++;
+        }
+
+        public void Dispose()
+        {
+            _gpioController.Dispose();
+        }
+    }
+}

--- a/src/devices/Mcp23xxx/tests/Mcp23xxxTest.cs
+++ b/src/devices/Mcp23xxx/tests/Mcp23xxxTest.cs
@@ -185,6 +185,7 @@ namespace Iot.Device.Mcp23xxx.Tests
         {
             private Dictionary<int, PinValue> _pinValues = new Dictionary<int, PinValue>();
             private ConcurrentDictionary<int, PinMode> _pinModes = new ConcurrentDictionary<int, PinMode>();
+            private PinChangeEventHandler? _callback;
 
             protected override int PinCount => 10;
 
@@ -247,9 +248,20 @@ namespace Iot.Device.Mcp23xxx.Tests
 
             protected override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-            protected override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback) => throw new NotImplementedException();
+            protected override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+            {
+                _callback = callback; // Keep it simple for this test class
+            }
 
-            protected override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback) => throw new NotImplementedException();
+            protected override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
+            {
+                _callback = null;
+            }
+
+            public void FireEvent(PinValueChangedEventArgs e)
+            {
+                _callback?.Invoke(this, e);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #2134 

I had the `EnableInterruptOnChange` written long ago already, but apparently forgot to write a PR for it. Now that's done, together with the support for event handling using the "normal" GpioDriver methods. 