### PR TITLE
Add support for Adafruit Seesaw NeoPixel and Adafruit NeoDriver

### DIFF
--- a/src/devices/Seesaw/NeopixelSpeed.cs
+++ b/src/devices/Seesaw/NeopixelSpeed.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Seesaw
+{
+    /// <summary>
+    /// NeoPixel speed setting.
+    /// </summary>
+    public enum NeopixelSpeed : byte
+    {
+        /// <summary>
+        /// 400MHz.
+        /// </summary>
+        Speed_400Mhz = 0x0,
+
+        /// <summary>
+        /// 800MHz.
+        /// </summary>
+        Speed_800MHz = 0x1,
+    }
+}

--- a/src/devices/Seesaw/Seesaw.sln
+++ b/src/devices/Seesaw/Seesaw.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seesaw", "Seesaw.csproj", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seesaw.Sample.Encoder", "samples\Encoder\Seesaw.Sample.Encoder.csproj", "{2AF6BC30-E051-45A3-AA35-9CBB7E6352BA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seesaw.Sample.Neopixel", "samples\Neopixel\Seesaw.Sample.Neopixel.csproj", "{DBE41D68-547B-425E-949C-F0DA97222F27}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,6 +87,18 @@ Global
 		{2AF6BC30-E051-45A3-AA35-9CBB7E6352BA}.Release|x64.Build.0 = Release|Any CPU
 		{2AF6BC30-E051-45A3-AA35-9CBB7E6352BA}.Release|x86.ActiveCfg = Release|Any CPU
 		{2AF6BC30-E051-45A3-AA35-9CBB7E6352BA}.Release|x86.Build.0 = Release|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Debug|x64.Build.0 = Debug|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Debug|x86.Build.0 = Debug|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Release|x64.ActiveCfg = Release|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Release|x64.Build.0 = Release|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Release|x86.ActiveCfg = Release|Any CPU
+		{DBE41D68-547B-425E-949C-F0DA97222F27}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -94,6 +108,7 @@ Global
 		{5807BB95-184F-47CC-A8A4-63519079B525} = {A15390DB-F07B-4014-9840-5F792089E026}
 		{164336C0-7E90-4082-B98D-0AEBB60717E3} = {A15390DB-F07B-4014-9840-5F792089E026}
 		{2AF6BC30-E051-45A3-AA35-9CBB7E6352BA} = {A15390DB-F07B-4014-9840-5F792089E026}
+		{DBE41D68-547B-425E-949C-F0DA97222F27} = {A15390DB-F07B-4014-9840-5F792089E026}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FAE88427-BD54-45C3-B93A-0FCBC92E93F0}

--- a/src/devices/Seesaw/SeesawBase.cs
+++ b/src/devices/Seesaw/SeesawBase.cs
@@ -13,7 +13,8 @@ namespace Iot.Device.Seesaw
     /// </summary>
     public partial class Seesaw : IDisposable
     {
-        private const byte SessawHardwareId = 0x55;
+        private const byte SeesawHardwareId = 0x55;
+        private const byte NeoDriverHardwareId = 0x87;
 
         /// <summary>
         /// I2C device used for communication
@@ -67,13 +68,19 @@ namespace Iot.Device.Seesaw
             SoftwareReset();
             DelayHelper.DelayMilliseconds(10, true);
 
-            if (ReadByte(SeesawModule.Status, SeesawFunction.StatusHwId) != SessawHardwareId)
+            switch (ReadByte(SeesawModule.Status, SeesawFunction.StatusHwId))
             {
-                throw new NotSupportedException($"The hardware on I2C Bus {I2cDevice.ConnectionSettings.BusId}, Address 0x{I2cDevice.ConnectionSettings.DeviceAddress:X2} does not appear to be an Adafruit SeeSaw module");
+                case SeesawHardwareId:
+                    _options = GetOptions();
+                    Version = GetVersion();
+                    break;
+                case NeoDriverHardwareId:
+                    _options = 1 << (byte)SeesawModule.Neopixel;
+                    Version = GetVersion();
+                    break;
+                default:
+                    throw new NotSupportedException($"The hardware on I2C Bus {I2cDevice.ConnectionSettings.BusId}, Address 0x{I2cDevice.ConnectionSettings.DeviceAddress:X2} does not appear to be an Adafruit SeeSaw module");
             }
-
-            _options = GetOptions();
-            Version = GetVersion();
         }
 
         /// <summary>

--- a/src/devices/Seesaw/SeesawModules.cs
+++ b/src/devices/Seesaw/SeesawModules.cs
@@ -154,8 +154,22 @@ namespace Iot.Device.Seesaw
             EncoderPosition = 0x30,
 
             /// <summary>Encoder position delta</summary>
-            EncoderDelta = 0x40
+            EncoderDelta = 0x40,
 
+            /// <summary>Pin number (PORTA) that is used for the NeoPixel output</summary>
+            NeopixelPin = 0x01,
+
+            /// <summary>The protocol speed. 0x00 = 400khz, 0x01 = 800khz (default)</summary>
+            NeopixelSpeed = 0x02,
+
+            /// <summary>The number of bytes currently used for the pixel array</summary>
+            NeopixelBufferLength = 0x03,
+
+            /// <summary>The data buffer. The first 2 bytes are the start address, and the data to write follows. Data should be written in blocks of maximum size 30 bytes at a time.</summary>
+            NeopixelBuffer = 0x04,
+
+            /// <summary>SHOW command, will cause the output to update. There's no arguments/data after the command</summary>
+            NeopixelShow = 0x05
         }
     }
 }

--- a/src/devices/Seesaw/SeesawNeopixel.cs
+++ b/src/devices/Seesaw/SeesawNeopixel.cs
@@ -101,20 +101,4 @@ namespace Iot.Device.Seesaw
             Write(SeesawModule.Neopixel, SeesawFunction.NeopixelShow, Array.Empty<byte>());
         }
     }
-
-    /// <summary>
-    /// NeoPixel speed setting.
-    /// </summary>
-    public enum NeopixelSpeed : byte
-    {
-        /// <summary>
-        /// 400MHz.
-        /// </summary>
-        Speed_400Mhz = 0x0,
-
-        /// <summary>
-        /// 800MHz.
-        /// </summary>
-        Speed_800MHz = 0x1,
-    }
 }

--- a/src/devices/Seesaw/SeesawNeopixel.cs
+++ b/src/devices/Seesaw/SeesawNeopixel.cs
@@ -1,0 +1,120 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Device.Gpio;
+using System.Device.I2c;
+using System.Linq;
+using System.Threading;
+
+namespace Iot.Device.Seesaw
+{
+    /// <summary>
+    /// Seesaw GPIO driver
+    /// </summary>
+    public partial class Seesaw : IDisposable
+    {
+        /// <summary>
+        /// Change the the pin number (PORTA) that is used for the NeoPixel output.
+        /// </summary>
+        /// <param name="pin">The new pin number.</param>
+        public void SetNeopixelPin(byte pin)
+        {
+            if (!HasModule(SeesawModule.Neopixel))
+            {
+                throw new InvalidOperationException($"The hardware on I2C Bus {I2cDevice.ConnectionSettings.BusId}, Address 0x{I2cDevice.ConnectionSettings.DeviceAddress:X2} does not support Adafruit SeeSaw NeoPixel functionality");
+            }
+
+            Write(SeesawModule.Neopixel, SeesawFunction.NeopixelPin, new[] { pin });
+        }
+
+        /// <summary>
+        /// Change the protocol speed. 0x00 = 400khz, 0x01 = 800khz (default).
+        /// </summary>
+        /// <param name="speed">The new speed.</param>
+        public void SetNeopixelSpeed(NeopixelSpeed speed)
+        {
+            if (!HasModule(SeesawModule.Neopixel))
+            {
+                throw new InvalidOperationException($"The hardware on I2C Bus {I2cDevice.ConnectionSettings.BusId}, Address 0x{I2cDevice.ConnectionSettings.DeviceAddress:X2} does not support Adafruit SeeSaw NeoPixel functionality");
+            }
+
+            Write(SeesawModule.Neopixel, SeesawFunction.NeopixelSpeed, new[] { (byte)speed });
+        }
+
+        /// <summary>
+        /// Change the number of bytes used for the pixel array. This is dependent on when the pixels you are using are RGB or RGBW.
+        /// </summary>
+        /// <param name="length">The new length.</param>
+        public void SetNeopixelBufferLength(ushort length)
+        {
+            if (!HasModule(SeesawModule.Neopixel))
+            {
+                throw new InvalidOperationException($"The hardware on I2C Bus {I2cDevice.ConnectionSettings.BusId}, Address 0x{I2cDevice.ConnectionSettings.DeviceAddress:X2} does not support Adafruit SeeSaw NeoPixel functionality");
+            }
+
+            var lengthInBytes = new byte[2];
+            BinaryPrimitives.WriteUInt16BigEndian(lengthInBytes.AsSpan(), length);
+            Write(SeesawModule.Neopixel, SeesawFunction.NeopixelBufferLength, lengthInBytes);
+        }
+
+        /// <summary>
+        /// Set the data buffer.
+        /// </summary>
+        /// <param name="buffer">The new buffer.</param>
+        /// <param name="offset">The offset in number of bytes.</param>
+        public void SetNeopixelBuffer(ReadOnlySpan<byte> buffer, ushort offset = 0)
+        {
+            const ushort MaxBlockLength = 22;
+
+            if (!HasModule(SeesawModule.Neopixel))
+            {
+                throw new InvalidOperationException($"The hardware on I2C Bus {I2cDevice.ConnectionSettings.BusId}, Address 0x{I2cDevice.ConnectionSettings.DeviceAddress:X2} does not support Adafruit SeeSaw NeoPixel functionality");
+            }
+
+            var block = new byte[MaxBlockLength + 2];
+            var span = block.AsSpan();
+
+            while (offset < buffer.Length)
+            {
+                var blockLength = Math.Min(MaxBlockLength, buffer.Length - offset);
+                BinaryPrimitives.WriteUInt16BigEndian(span.Slice(0, 2), offset);
+                buffer.Slice(offset, blockLength).CopyTo(span.Slice(2, blockLength));
+                Write(SeesawModule.Neopixel, SeesawFunction.NeopixelBuffer, span.Slice(0, blockLength + 2));
+
+                offset += MaxBlockLength;
+            }
+        }
+
+        /// <summary>
+        /// Sending the SHOW command will cause the output to update.
+        /// </summary>
+        public void SetNeopixelShow()
+        {
+            if (!HasModule(SeesawModule.Neopixel))
+            {
+                throw new InvalidOperationException($"The hardware on I2C Bus {I2cDevice.ConnectionSettings.BusId}, Address 0x{I2cDevice.ConnectionSettings.DeviceAddress:X2} does not support Adafruit SeeSaw NeoPixel functionality");
+            }
+
+            Write(SeesawModule.Neopixel, SeesawFunction.NeopixelShow, Array.Empty<byte>());
+        }
+    }
+
+    /// <summary>
+    /// NeoPixel speed setting.
+    /// </summary>
+    public enum NeopixelSpeed : byte
+    {
+        /// <summary>
+        /// 400MHz.
+        /// </summary>
+        Speed_400Mhz = 0x0,
+
+        /// <summary>
+        /// 800MHz.
+        /// </summary>
+        Speed_800MHz = 0x1,
+    }
+}

--- a/src/devices/Seesaw/samples/Neopixel/Seesaw.Sample.Neopixel.cs
+++ b/src/devices/Seesaw/samples/Neopixel/Seesaw.Sample.Neopixel.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Device.I2c;
+using System.Device.Gpio;
+using System.Drawing;
+using System.Linq;
+using Iot.Device.Seesaw;
+
+const byte AdafruitSeesawNeopixelI2cAddress = 0x60;
+const byte AdafruitSeesawNeopixelI2cBus = 0x1;
+const byte NeopixelPin = 0xF;
+const int NumberOfPixels = 10;
+const ushort NeopixelBufferLength = NumberOfPixels * 3;
+
+using I2cDevice i2cDevice = I2cDevice.Create(new I2cConnectionSettings(AdafruitSeesawNeopixelI2cBus, AdafruitSeesawNeopixelI2cAddress));
+using Seesaw ssDevice = new(i2cDevice);
+
+ssDevice.SetNeopixelPin(NeopixelPin);
+ssDevice.SetNeopixelSpeed(NeopixelSpeed.Speed_800MHz);
+ssDevice.SetNeopixelBufferLength(NeopixelBufferLength);
+
+byte[] buffer;
+int g = 0, r = 255, b = 0;
+int dg = 0, dr = -1, db = +1;
+
+while (!Console.KeyAvailable)
+{
+    if (dg < 0 && g == 0)
+    {
+        dg = 0;
+        dr = -1;
+        db = +1;
+    }
+    else if (dr < 0 && r == 0)
+    {
+        dg = +1;
+        dr = 0;
+        db = -1;
+    }
+    else if (db < 0 && b == 0)
+    {
+        dg = -1;
+        dr = +1;
+        db = 0;
+    }
+
+    buffer = Enumerable.Repeat(new byte[] { (byte)g, (byte)r, (byte)b }, NumberOfPixels).SelectMany(x => x).ToArray();
+    ssDevice.SetNeopixelBuffer(buffer);
+    ssDevice.SetNeopixelShow();
+
+    g += dg;
+    r += dr;
+    b += db;
+}
+
+buffer = Enumerable.Repeat((byte)0, NumberOfPixels * 3).ToArray();
+ssDevice.SetNeopixelBuffer(buffer);
+ssDevice.SetNeopixelShow();

--- a/src/devices/Seesaw/samples/Neopixel/Seesaw.Sample.Neopixel.csproj
+++ b/src/devices/Seesaw/samples/Neopixel/Seesaw.Sample.Neopixel.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultSampleTfms)</TargetFramework>
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../Seesaw.csproj" />
+    <Compile Include="Seesaw.Sample.Neopixel.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR adds [NeoPixel](https://learn.adafruit.com/adafruit-seesaw-atsamd09-breakout/neopixel) functionality to the Adafruit Seesaw device binding. It also adds support for the[ Adafruit NeoDriver](https://learn.adafruit.com/adafruit-neodriver-i2c-to-neopixel-driver/overview) board, which is basically a specialized version of the Seesaw board that only has the NeoPixel functionality. The API is pretty simple and the accompanying sample shows how to use it.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2142)