### PR TITLE
add WriteAllPixels to Is31fl3731

### DIFF
--- a/src/devices/Is31fl3731/Is31fl3731.cs
+++ b/src/devices/Is31fl3731/Is31fl3731.cs
@@ -235,8 +235,8 @@ namespace Iot.Device.Display
 
         private void WriteLedPwm(ReadOnlySpan<byte> value)
         {
-            int num = FrameRegister.Pwm + GetLedAddress(0, 0);
-            Write(0, (byte)num, value);
+            int address = FrameRegister.Pwm + GetLedAddress(0, 0);
+            Write(0, (byte)address, value);
         }
 
         private void WriteLed(int x, int y, bool enable)

--- a/src/devices/Is31fl3731/Is31fl3731.cs
+++ b/src/devices/Is31fl3731/Is31fl3731.cs
@@ -100,6 +100,28 @@ namespace Iot.Device.Display
         }
 
         /// <summary>
+        /// Set value for all LEDs.
+        /// </summary>
+        public void WriteAllPixels(int[,] brightness)
+        {
+            Span<byte> data = stackalloc byte[_pwmRegisterLength];
+
+            int maxX = brightness.GetLength(0);
+            int maxY = brightness.GetLength(1);
+
+            for (int x = 0; x < maxX; x++)
+            {
+                for (int y = 0; y < maxY; y++)
+                {
+                    int address = GetLedAddress(x, y);
+                    data[address] = (byte)brightness[x, y];
+                }
+            }
+
+            WriteLedPwm(data);
+        }
+
+        /// <summary>
         /// Fill all LEDs.
         /// </summary>
         public void Fill(byte brightness = 128, byte page = 0)
@@ -209,6 +231,12 @@ namespace Iot.Device.Display
         {
             int address = FrameRegister.Pwm + GetLedAddress(x, y);
             Write(0, (byte)address, (byte)brightness);
+        }
+
+        private void WriteLedPwm(ReadOnlySpan<byte> value)
+        {
+            int num = FrameRegister.Pwm + GetLedAddress(0, 0);
+            Write(0, (byte)num, value);
         }
 
         private void WriteLed(int x, int y, bool enable)


### PR DESCRIPTION
in order to facilitate the subclasses in implementing a one-time update of all pixel states. #2138

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2144)