### PR TITLE
Allow creation of duplicate device addresses for the Tca9548A.

### DIFF
--- a/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
+++ b/src/System.Device.Gpio/System/Device/I2c/I2cConnectionSettings.cs
@@ -6,7 +6,7 @@ namespace System.Device.I2c;
 /// <summary>
 /// The connection settings of a device on an I2C bus.
 /// </summary>
-public sealed class I2cConnectionSettings
+public sealed class I2cConnectionSettings : IEquatable<I2cConnectionSettings>
 {
     private I2cConnectionSettings()
     {
@@ -38,4 +38,46 @@ public sealed class I2cConnectionSettings
     /// The bus address of the I2C device.
     /// </summary>
     public int DeviceAddress { get; }
+
+    /// <summary>
+    /// Equality comparator
+    /// </summary>
+    /// <param name="other">The other instance</param>
+    /// <returns>True or false</returns>
+    public bool Equals(I2cConnectionSettings? other)
+    {
+        if (ReferenceEquals(null, other))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return BusId == other.BusId && DeviceAddress == other.DeviceAddress;
+    }
+
+    /// <summary>
+    /// Basic equality overload
+    /// </summary>
+    /// <param name="obj">The other instance</param>
+    /// <returns>True on value equality, false otherwise</returns>
+    public override bool Equals(object? obj)
+    {
+        return ReferenceEquals(this, obj) || (obj is I2cConnectionSettings other && Equals(other));
+    }
+
+    /// <summary>
+    /// Standard hash function
+    /// </summary>
+    /// <returns>A hash code</returns>
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return (BusId * 397) ^ DeviceAddress;
+        }
+    }
 }

--- a/src/devices/Tca954x/Tca9548A.cs
+++ b/src/devices/Tca954x/Tca9548A.cs
@@ -122,6 +122,43 @@ namespace Iot.Device.Tca954x
             }
         }
 
+        /// <summary>
+        /// Returns the given channel.
+        /// </summary>
+        /// <param name="channelNo">The channel number (0-7)</param>
+        /// <returns>An <see cref="I2cBus"/> representing the provided channel</returns>
+        public I2cBus GetChannel(int channelNo)
+        {
+            if (channelNo < 0 || channelNo >= 8)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channelNo), "Valid channels are 0-7");
+            }
+
+            return GetChannel((MultiplexerChannel)(1 << channelNo));
+        }
+
+        /// <summary>
+        /// Returns the given channel
+        /// </summary>
+        /// <param name="channel">A single channel value</param>
+        /// <returns>The given channel as <see cref="I2cBus"/> instance</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The channel value is not valid or represents more than one channel</exception>
+        public I2cBus GetChannel(MultiplexerChannel channel)
+        {
+            return channel switch
+            {
+                MultiplexerChannel.Channel0 => this[0],
+                MultiplexerChannel.Channel1 => this[1],
+                MultiplexerChannel.Channel2 => this[2],
+                MultiplexerChannel.Channel3 => this[3],
+                MultiplexerChannel.Channel4 => this[4],
+                MultiplexerChannel.Channel5 => this[5],
+                MultiplexerChannel.Channel6 => this[6],
+                MultiplexerChannel.Channel7 => this[7],
+                _ => throw new ArgumentOutOfRangeException(nameof(channel), $"Not a valid single channel selection: {channel}"),
+            };
+        }
+
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/src/devices/Tca954x/Tca9548AChannelBus.cs
+++ b/src/devices/Tca954x/Tca9548AChannelBus.cs
@@ -19,6 +19,7 @@ namespace Iot.Device.Tca954x
         private readonly Tca9548A _tca9548A;
         private readonly MultiplexerChannel _tcaChannel;
         private readonly Dictionary<int, I2cDevice> _devices;
+        private readonly int _busNo;
 
         /// <summary>
         /// Creates new I2C bus Instance for multiplexer channel
@@ -36,6 +37,18 @@ namespace Iot.Device.Tca954x
             _tcaChannel = channels;
             _mainBus = mainBus;
             _devices = new Dictionary<int, I2cDevice>();
+            _busNo = channels switch
+            {
+                MultiplexerChannel.Channel0 => 0,
+                MultiplexerChannel.Channel1 => 1,
+                MultiplexerChannel.Channel2 => 2,
+                MultiplexerChannel.Channel3 => 3,
+                MultiplexerChannel.Channel4 => 4,
+                MultiplexerChannel.Channel5 => 5,
+                MultiplexerChannel.Channel6 => 6,
+                MultiplexerChannel.Channel7 => 7,
+                _ => 0
+            };
         }
 
         private void SelectDeviceChannel() => _tca9548A.SelectChannel(_tcaChannel);
@@ -53,7 +66,8 @@ namespace Iot.Device.Tca954x
                 throw new InvalidOperationException($"Channel {_tcaChannel} has already a device with address 0x{deviceAddress:x2}");
             }
 
-            var device = new Tca9548AI2cDevice(_tca9548A, _tcaChannel, _tca9548A.CreateOrGetMasterBusDevice(deviceAddress));
+            var device = new Tca9548AI2cDevice(_tca9548A, _tcaChannel, _tca9548A.CreateOrGetMasterBusDevice(deviceAddress),
+                new I2cConnectionSettings(_busNo, deviceAddress));
             _devices[deviceAddress] = device;
             return device;
         }

--- a/src/devices/Tca954x/Tca9548ADevice.cs
+++ b/src/devices/Tca954x/Tca9548ADevice.cs
@@ -14,11 +14,12 @@ namespace Iot.Device.Tca954x
         private readonly I2cDevice _realDevice;
         private readonly Tca9548A _tca9548A;
         private readonly MultiplexerChannel _tcaChannel;
+        private readonly I2cConnectionSettings _virtualConnectionSettings;
 
         /// <summary>
-        /// The connection settings of a device on an I2C bus.
+        /// The connection settings of an attached device. This returns the settings for the virtual multiplexer bus.
         /// </summary>
-        public override I2cConnectionSettings ConnectionSettings => _realDevice.ConnectionSettings;
+        public override I2cConnectionSettings ConnectionSettings => _virtualConnectionSettings;
 
         /// <summary>
         ///  Initializes a new instance of the <see cref="Tca9548AI2cDevice"/> class on the <see cref="MultiplexerChannel"/> of TCA mux that will use the specified settings to communicate with the I2C device.
@@ -26,11 +27,14 @@ namespace Iot.Device.Tca954x
         /// <param name="tca9548A">Instance on TCA9548A device</param>
         /// <param name="tcaChannel">Channel on which device is</param>
         /// <param name="device">I2C device (from the parent bus)</param>
-        internal Tca9548AI2cDevice(Tca9548A tca9548A, MultiplexerChannel tcaChannel, I2cDevice device)
+        /// <param name="virtualConnectionSettings">The connection settings to report for this device</param>
+        internal Tca9548AI2cDevice(Tca9548A tca9548A, MultiplexerChannel tcaChannel, I2cDevice device,
+            I2cConnectionSettings virtualConnectionSettings)
         {
             _tca9548A = tca9548A;
             _tcaChannel = tcaChannel;
             _realDevice = device;
+            _virtualConnectionSettings = virtualConnectionSettings;
         }
 
         private void SelectDeviceChannel() => _tca9548A.SelectChannel(_tcaChannel);

--- a/src/devices/Tca954x/Tca9548ADevice.cs
+++ b/src/devices/Tca954x/Tca9548ADevice.cs
@@ -8,14 +8,17 @@ namespace Iot.Device.Tca954x
 {
     internal class Tca9548AI2cDevice : I2cDevice
     {
-        private readonly I2cDevice _channelDevice;
+        /// <summary>
+        /// The real device instance (an I2c device on the master bus)
+        /// </summary>
+        private readonly I2cDevice _realDevice;
         private readonly Tca9548A _tca9548A;
         private readonly MultiplexerChannel _tcaChannel;
 
         /// <summary>
         /// The connection settings of a device on an I2C bus.
         /// </summary>
-        public override I2cConnectionSettings ConnectionSettings => _channelDevice.ConnectionSettings;
+        public override I2cConnectionSettings ConnectionSettings => _realDevice.ConnectionSettings;
 
         /// <summary>
         ///  Initializes a new instance of the <see cref="Tca9548AI2cDevice"/> class on the <see cref="MultiplexerChannel"/> of TCA mux that will use the specified settings to communicate with the I2C device.
@@ -27,7 +30,7 @@ namespace Iot.Device.Tca954x
         {
             _tca9548A = tca9548A;
             _tcaChannel = tcaChannel;
-            _channelDevice = device;
+            _realDevice = device;
         }
 
         private void SelectDeviceChannel() => _tca9548A.SelectChannel(_tcaChannel);
@@ -42,7 +45,7 @@ namespace Iot.Device.Tca954x
         public override void Read(Span<byte> buffer)
         {
             SelectDeviceChannel();
-            _channelDevice.Read(buffer);
+            _realDevice.Read(buffer);
         }
 
         /// <summary>
@@ -52,7 +55,7 @@ namespace Iot.Device.Tca954x
         public override byte ReadByte()
         {
             SelectDeviceChannel();
-            return _channelDevice.ReadByte();
+            return _realDevice.ReadByte();
         }
 
         /// <summary>
@@ -65,7 +68,7 @@ namespace Iot.Device.Tca954x
         public override void Write(ReadOnlySpan<byte> buffer)
         {
             SelectDeviceChannel();
-            _channelDevice.Write(buffer);
+            _realDevice.Write(buffer);
         }
 
         /// <summary>
@@ -75,7 +78,7 @@ namespace Iot.Device.Tca954x
         public override void WriteByte(byte value)
         {
             SelectDeviceChannel();
-            _channelDevice.WriteByte(value);
+            _realDevice.WriteByte(value);
         }
 
         /// <summary>
@@ -92,13 +95,13 @@ namespace Iot.Device.Tca954x
         public override void WriteRead(ReadOnlySpan<byte> writeBuffer, Span<byte> readBuffer)
         {
             SelectDeviceChannel();
-            _channelDevice.WriteRead(writeBuffer, readBuffer);
+            _realDevice.WriteRead(writeBuffer, readBuffer);
         }
 
         /// <inheritdoc cref="IDisposable.Dispose"/>
         protected override void Dispose(bool disposing)
         {
-            _channelDevice.Dispose();
+            _tca9548A.ReleaseDevice(_realDevice, ConnectionSettings.DeviceAddress);
             base.Dispose(disposing);
         }
     }

--- a/src/devices/Tca954x/Tca9548a.sln
+++ b/src/devices/Tca954x/Tca9548a.sln
@@ -9,6 +9,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tca9548a.sample", "samples\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Device.Gpio", "..\..\System.Device.Gpio\System.Device.Gpio.csproj", "{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{4BFDEAAC-783A-45EA-91D3-830DD39DEBA7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tca954x.Tests", "tests\Tca954x.Tests.csproj", "{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,9 +59,24 @@ Global
 		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Release|x64.Build.0 = Release|Any CPU
 		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Release|x86.ActiveCfg = Release|Any CPU
 		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Release|x86.Build.0 = Release|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Debug|x64.Build.0 = Debug|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Debug|x86.Build.0 = Debug|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Release|x64.ActiveCfg = Release|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Release|x64.Build.0 = Release|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Release|x86.ActiveCfg = Release|Any CPU
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FAD9985F-8A4C-46CD-BE93-D7240F9E5A86} = {4BFDEAAC-783A-45EA-91D3-830DD39DEBA7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B84C9EE-D5AF-4ABC-ACEE-2F126D8738EA}

--- a/src/devices/Tca954x/Tca9548a.sln
+++ b/src/devices/Tca954x/Tca9548a.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32519.111
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tca954x", "Tca954x.csproj", "{28EDCECC-F951-4004-8213-FAF1ACD3DFD2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tca954x", "Tca954x.csproj", "{28EDCECC-F951-4004-8213-FAF1ACD3DFD2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tca9548a.sample", "samples\Tca9548a.sample.csproj", "{A2232C4D-B1C5-4B59-A0D9-BC7CA364ACF2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tca9548a.sample", "samples\Tca9548a.sample.csproj", "{A2232C4D-B1C5-4B59-A0D9-BC7CA364ACF2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Device.Gpio", "..\..\System.Device.Gpio\System.Device.Gpio.csproj", "{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +43,18 @@ Global
 		{A2232C4D-B1C5-4B59-A0D9-BC7CA364ACF2}.Release|x64.Build.0 = Release|Any CPU
 		{A2232C4D-B1C5-4B59-A0D9-BC7CA364ACF2}.Release|x86.ActiveCfg = Release|Any CPU
 		{A2232C4D-B1C5-4B59-A0D9-BC7CA364ACF2}.Release|x86.Build.0 = Release|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Debug|x64.Build.0 = Debug|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Debug|x86.Build.0 = Debug|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Release|x64.ActiveCfg = Release|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Release|x64.Build.0 = Release|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Release|x86.ActiveCfg = Release|Any CPU
+		{D7C02A20-01E2-4E0C-B0DD-5734ABF61124}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/devices/Tca954x/tests/Tca9548Tests.cs
+++ b/src/devices/Tca954x/tests/Tca9548Tests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Device.I2c;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace Iot.Device.Tca954x.Tests
+{
+    public class Tca9548Tests
+    {
+        private readonly Mock<I2cDevice> _device;
+        private readonly Mock<I2cBus> _mainBus;
+
+        public Tca9548Tests()
+        {
+            _device = new Mock<I2cDevice>(MockBehavior.Strict);
+            _mainBus = new Mock<I2cBus>(MockBehavior.Strict);
+        }
+
+        [Fact]
+        public void Create()
+        {
+            var testee = new Tca9548A(_device.Object, _mainBus.Object);
+            Assert.NotNull(testee);
+            Assert.Equal(8, testee.Count); // Number of buses
+        }
+
+        [Fact]
+        public void TryGetSelectedChannel()
+        {
+            var testee = new Tca9548A(_device.Object, _mainBus.Object);
+            Assert.NotNull(testee);
+            testee.SelectChannel(MultiplexerChannel.Channel0);
+            var channel = testee.TryGetSelectedChannel(out var c);
+            Assert.Equal(MultiplexerChannel.Channel0, c);
+            Assert.True(channel);
+        }
+
+        [Fact]
+        public void CreateDevicesDifferentAddresses()
+        {
+            var testee = new Tca9548A(_device.Object, _mainBus.Object);
+            _device.Setup(x => x.ConnectionSettings).Returns(new I2cConnectionSettings(1, Tca9548A.DefaultI2cAddress));
+            Assert.NotNull(testee);
+            var c0 = testee.GetChannel(0);
+            var c1 = testee.GetChannel(1);
+            var d1 = c0.CreateDevice(0x20);
+            var d2 = c1.CreateDevice(0x21);
+            Assert.NotEqual(d1.ConnectionSettings, d2.ConnectionSettings);
+            Assert.Equal(0, d1.ConnectionSettings.BusId);
+            Assert.Equal(1, d2.ConnectionSettings.BusId);
+        }
+    }
+}

--- a/src/devices/Tca954x/tests/Tca9548Tests.cs
+++ b/src/devices/Tca954x/tests/Tca9548Tests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Iot.Device.Tca954x.Tests
 {
-    public class Tca9548Tests
+    public sealed class Tca9548Tests : IDisposable
     {
         private readonly Mock<I2cDevice> _device;
         private readonly Mock<I2cBus> _mainBus;
@@ -21,6 +21,12 @@ namespace Iot.Device.Tca954x.Tests
         {
             _device = new Mock<I2cDevice>(MockBehavior.Strict);
             _mainBus = new Mock<I2cBus>(MockBehavior.Strict);
+        }
+
+        public void Dispose()
+        {
+            _mainBus.VerifyAll();
+            _device.VerifyAll();
         }
 
         [Fact]
@@ -36,6 +42,9 @@ namespace Iot.Device.Tca954x.Tests
         {
             var testee = new Tca9548A(_device.Object, _mainBus.Object);
             Assert.NotNull(testee);
+
+            _device.Setup(x => x.ReadByte()).Returns(0);
+            _device.Setup(x => x.WriteByte(1));
             testee.SelectChannel(MultiplexerChannel.Channel0);
             var channel = testee.TryGetSelectedChannel(out var c);
             Assert.Equal(MultiplexerChannel.Channel0, c);
@@ -47,6 +56,10 @@ namespace Iot.Device.Tca954x.Tests
         {
             var testee = new Tca9548A(_device.Object, _mainBus.Object);
             _device.Setup(x => x.ConnectionSettings).Returns(new I2cConnectionSettings(1, Tca9548A.DefaultI2cAddress));
+            var device1Mock = new Mock<I2cDevice>(MockBehavior.Strict);
+            var device2Mock = new Mock<I2cDevice>(MockBehavior.Strict);
+            _mainBus.Setup(x => x.CreateDevice(0x20)).Returns(device1Mock.Object);
+            _mainBus.Setup(x => x.CreateDevice(0x21)).Returns(device2Mock.Object);
             Assert.NotNull(testee);
             var c0 = testee.GetChannel(0);
             var c1 = testee.GetChannel(1);
@@ -55,6 +68,26 @@ namespace Iot.Device.Tca954x.Tests
             Assert.NotEqual(d1.ConnectionSettings, d2.ConnectionSettings);
             Assert.Equal(0, d1.ConnectionSettings.BusId);
             Assert.Equal(1, d2.ConnectionSettings.BusId);
+        }
+
+        [Fact]
+        public void CreateDevicesSameAddresses()
+        {
+            var testee = new Tca9548A(_device.Object, _mainBus.Object);
+            _device.Setup(x => x.ConnectionSettings).Returns(new I2cConnectionSettings(1, Tca9548A.DefaultI2cAddress));
+            var device1Mock = new Mock<I2cDevice>(MockBehavior.Strict);
+            _mainBus.Setup(x => x.CreateDevice(0x20)).Returns(device1Mock.Object);
+            Assert.NotNull(testee);
+            var c0 = testee.GetChannel(0);
+            var c1 = testee.GetChannel(1);
+            var d1 = c0.CreateDevice(0x20);
+            var d2 = c1.CreateDevice(0x20);
+            Assert.NotEqual(d1.ConnectionSettings, d2.ConnectionSettings);
+            Assert.Equal(0, d1.ConnectionSettings.BusId);
+            Assert.Equal(1, d2.ConnectionSettings.BusId);
+            Assert.Equal(0x20, d1.ConnectionSettings.DeviceAddress);
+            Assert.Equal(0x20, d2.ConnectionSettings.DeviceAddress);
+            _mainBus.Verify(x => x.CreateDevice(0x20), Times.Exactly(1));
         }
     }
 }

--- a/src/devices/Tca954x/tests/Tca954x.Tests.csproj
+++ b/src/devices/Tca954x/tests/Tca954x.Tests.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTestTfms)</TargetFramework>
+    <LangVersion>10</LangVersion>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Tca954x.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #2141 

This should fix the use case where multiple devices with the same address are used with a TCA9548A. That's one of the main use cases for this device, after all. I have no such device, so the code is only tested using unit testing. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2146)