### PR TITLE
Add batch read-write methods for GPIO

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -427,10 +427,7 @@ public class GpioController : IDisposable
     /// <param name="pinValuePairs">The pin/value pairs to write.</param>
     public void Write(ReadOnlySpan<PinValuePair> pinValuePairs)
     {
-        for (int i = 0; i < pinValuePairs.Length; i++)
-        {
-            Write(pinValuePairs[i].PinNumber, pinValuePairs[i].PinValue);
-        }
+        _driver.Write(pinValuePairs);
     }
 
     /// <summary>
@@ -439,11 +436,7 @@ public class GpioController : IDisposable
     /// <param name="pinValuePairs">The pin/value pairs to read.</param>
     public void Read(Span<PinValuePair> pinValuePairs)
     {
-        for (int i = 0; i < pinValuePairs.Length; i++)
-        {
-            int pin = pinValuePairs[i].PinNumber;
-            pinValuePairs[i] = new PinValuePair(pin, Read(pin));
-        }
+        _driver.Read(pinValuePairs);
     }
 
     /// <summary>

--- a/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioDriver.cs
@@ -132,6 +132,31 @@ public abstract class GpioDriver : IDisposable
     protected internal abstract void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback);
 
     /// <summary>
+    /// Write the given pins with the given values.
+    /// </summary>
+    /// <param name="pinValuePairs">The pin/value pairs to write.</param>
+    protected internal virtual void Write(ReadOnlySpan<PinValuePair> pinValuePairs)
+    {
+        for (int i = 0; i < pinValuePairs.Length; i++)
+        {
+            Write(pinValuePairs[i].PinNumber, pinValuePairs[i].PinValue);
+        }
+    }
+
+    /// <summary>
+    /// Read the given pins with the given pin numbers.
+    /// </summary>
+    /// <param name="pinValuePairs">The pin/value pairs to read.</param>
+    protected internal virtual void Read(Span<PinValuePair> pinValuePairs)
+    {
+        for (int i = 0; i < pinValuePairs.Length; i++)
+        {
+            int pin = pinValuePairs[i].PinNumber;
+            pinValuePairs[i] = new PinValuePair(pin, Read(pin));
+        }
+    }
+
+    /// <summary>
     /// Disposes this instance, closing all open pins
     /// </summary>
     public void Dispose()


### PR DESCRIPTION
for #2147 

The original `public void Write(ReadOnlySpan<PinValuePair> pinValuePairs)` and `public void Read(Span<PinValuePair> pinValuePairs)` in `GpioController` were moved to `GpioDriver`, and were made overrideable to support a more efficient batch read-write method implementation in specific GPIO driver classes.