### PR TITLE
Removed probably unnecessary code of Sysfs driver

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/SysFsDriver.cs
@@ -492,27 +492,6 @@ public class SysFsDriver : UnixDriver
             if (waitResult > 0)
             {
                 pinNumber = events.data.pinNumber;
-
-                // This entire section is probably not necessary, but this seems to be hard to validate.
-                // See https://github.com/dotnet/iot/pull/914#discussion_r389924106 and issue #1024.
-                if (valueFileDescriptor == -1)
-                {
-                    // valueFileDescriptor will be -1 when using the callback eventing. For WaitForEvent, the value will be set.
-                    valueFileDescriptor = _devicePins[pinNumber].FileDescriptor;
-                }
-
-                int lseekResult = Interop.lseek(valueFileDescriptor, 0, SeekFlags.SEEK_SET);
-                if (lseekResult == -1)
-                {
-                    throw new IOException("Error while trying to seek in value file.");
-                }
-
-                int readResult = Interop.read(valueFileDescriptor, bufPtr, 1);
-                if (readResult != 1)
-                {
-                    throw new IOException("Error while trying to read value file.");
-                }
-
                 return true;
             }
         }


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->

Fixes #2131 
When using the SysFs driver the following exception gets thrown when pressing the button connected to the pin:
```
Unhandled exception. System.IO.IOException: Error while trying to seek in value file.
   at System.Device.Gpio.Drivers.SysFsDriver.WasEventDetected(Int32 pollFileDescriptor, Int32 valueFileDescriptor, Int32& pinNumber, CancellationToken cancellationToken)
   at System.Device.Gpio.Drivers.SysFsDriver.DetectEvents()
   at System.Threading.Thread.StartHelper.Callback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Thread.StartCallback()
```
After removing the code, the exception is not thrown.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2151)