### PR TITLE
Fix DHT22 reading errors when temperature and humidity are too low

### DIFF
--- a/src/devices/Dhtxx/DhtBase.cs
+++ b/src/devices/Dhtxx/DhtBase.cs
@@ -280,7 +280,7 @@ namespace Iot.Device.DHTxx
 
             if ((newBuf[4] == ((newBuf[0] + newBuf[1] + newBuf[2] + newBuf[3]) & 0xFF)))
             {
-                _isLastReadSuccessful = (newBuf[0] != 0) || (newBuf[2] != 0);
+                _isLastReadSuccessful = !((newBuf[0] == 0) && (newBuf[1] == 0) && (newBuf[2] == 0) && (newBuf[3] == 0));
             }
             else
             {


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->
- Fixes #2087
- Fix DHT22 reading errors when temperature and humidity are too low

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2155)