### PR TITLE
Add a missing statement to the documentation

### DIFF
--- a/src/devices/Ili934x/README.md
+++ b/src/devices/Ili934x/README.md
@@ -33,6 +33,9 @@ const int pinID_DC = 25;
 const int pinID_Reset = 24;
 const int interruptPin = 39;
 
+// This is required to initialize the graphics library
+SkiaSharpAdapter.Register();
+
 Chsc6440 touch = null;
 using SpiDevice displaySPI = SpiDevice.Create(new SpiConnectionSettings(0, 0) { Mode = SpiMode.Mode3, DataBitLength = 8, ClockFrequency = 12_000_000 /* 12MHz */ });
 using Ili9341 ili9341 = new(displaySPI, pinID_DC, pinID_Reset);


### PR DESCRIPTION
Fixes #2181

The documentation was missing this important instruction. I've verified the binding with the sample under /samples/M5StackRemoteDisplay once again on Windows and on my Raspberry Pi 4 (arm64). Both are working fine for me.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2185)