### PR TITLE
Bulk update of all of outdated package dependencies

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -8,7 +8,7 @@ file which is not marked as such, making StyleCop fail. -->
   </PropertyGroup>
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" Link="stylecop.json" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/eng/Versions.external.props
+++ b/eng/Versions.external.props
@@ -7,13 +7,13 @@
   <!-- Automatically include these assemblies in all test projects -->
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
      <PackageReference Include="Moq" Version="4.16.1" />
-     <PackageReference Include="xunit" Version="2.5.0" />
-     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+     <PackageReference Include="xunit" Version="2.6.2" />
+     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.utility" Version="2.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit.runner.utility" Version="2.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,8 +16,8 @@
     <SystemRuntimeInteropServicesWindowsRuntimePackageVersion>4.3.0</SystemRuntimeInteropServicesWindowsRuntimePackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>7.0.0</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>7.0.0</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>7.0.0</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <SystemTextJsonPackageVersion>6.0.1</SystemTextJsonPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>7.0.1</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
+    <SystemTextJsonPackageVersion>6.0.9</SystemTextJsonPackageVersion>
     <SystemIOPipelinesVersion>7.0.0</SystemIOPipelinesVersion>
   </PropertyGroup>
 </Project>

--- a/samples/M5StackRemoteDisplay/M5StackRemoteDisplay.csproj
+++ b/samples/M5StackRemoteDisplay/M5StackRemoteDisplay.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Iot.Device.Bindings" Version="3.0.0" />
-    <PackageReference Include="System.Device.Gpio" Version="3.0.0" />
-    <PackageReference Include="Iot.Device.Bindings.SkiaSharpAdapter" Version="3.0.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="3.1.0" />
+    <PackageReference Include="System.Device.Gpio" Version="3.1.0" />
+    <PackageReference Include="Iot.Device.Bindings.SkiaSharpAdapter" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/bmp280-sensor-azure-iot-hub/DNSensorAzureIoTHub.csproj
+++ b/samples/bmp280-sensor-azure-iot-hub/DNSensorAzureIoTHub.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Iot.Device.Bindings" Version="1.5.0-prerelease.21212.1" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.38.0" />
-    <PackageReference Include="System.Device.Gpio" Version="1.5.0-prerelease.21212.1" />
+    <PackageReference Include="Iot.Device.Bindings" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.42.0" />
+    <PackageReference Include="System.Device.Gpio" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/led-animate/led-animate.csproj
+++ b/samples/led-animate/led-animate.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="1.4.0" />
-    <PackageReference Include="Iot.Device.Bindings" Version="1.4.0" />
+    <PackageReference Include="System.Device.Gpio" Version="3.1.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/led-blink-multiple/led-blink-multiple.csproj
+++ b/samples/led-blink-multiple/led-blink-multiple.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="1.4.0" />
+    <PackageReference Include="System.Device.Gpio" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/samples/led-shift-register/led-shift-register.csproj
+++ b/samples/led-shift-register/led-shift-register.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="1.4.0" />
-    <PackageReference Include="Iot.Device.Bindings" Version="1.4.0" />
+    <PackageReference Include="System.Device.Gpio" Version="3.1.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Iot.Device.Bindings.SkiaSharpAdapter/Iot.Device.Bindings.SkiaSharpAdapter.csproj
+++ b/src/Iot.Device.Bindings.SkiaSharpAdapter/Iot.Device.Bindings.SkiaSharpAdapter.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
     <PackageReference Include="SkiaSharp" Version="2.88.6" />
     <!-- The NativeAssets packages for Windows and MacOS are included in the above by default -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
   </ItemGroup>
 
 

--- a/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerSoftwareTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
+using System.Threading.Tasks;
 using Moq;
 using Xunit;
 
@@ -235,7 +236,7 @@ public class GpioControllerSoftwareTests : IDisposable
     }
 
     [Fact]
-    public void WaitForEventAsyncFail()
+    public async Task WaitForEventAsyncFail()
     {
         var ctrl = new GpioController(PinNumberingScheme.Logical, _mockedGpioDriver.Object);
         _mockedGpioDriver.Setup(x => x.OpenPinEx(1));
@@ -249,11 +250,11 @@ public class GpioControllerSoftwareTests : IDisposable
         ctrl.OpenPin(1, PinMode.Input);
 
         var task = ctrl.WaitForEventAsync(1, PinEventTypes.Falling | PinEventTypes.Rising, TimeSpan.FromSeconds(0.01)).AsTask();
-        task.Wait(CancellationToken.None);
+        var result = await task.WaitAsync(CancellationToken.None);
         Assert.True(task.IsCompleted);
         Assert.Null(task.Exception);
-        Assert.True(task.Result.TimedOut);
-        Assert.Equal(PinEventTypes.None, task.Result.EventTypes);
+        Assert.True(result.TimedOut);
+        Assert.Equal(PinEventTypes.None, result.EventTypes);
     }
 
     [Fact]

--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -496,7 +496,7 @@ public abstract class GpioControllerTestBase
     }
 
     [Fact]
-    public void WaitForEventBothEdgesTest()
+    public async Task WaitForEventBothEdgesTest()
     {
         using (GpioController controller = new GpioController(GetTestNumberingScheme(), GetTestDriver()))
         {
@@ -529,7 +529,7 @@ public abstract class GpioControllerTestBase
             result = controller.WaitForEvent(InputPin, PinEventTypes.Falling | PinEventTypes.Rising, tokenSource.Token);
             Assert.False(result.TimedOut);
             Assert.Equal(PinEventTypes.Rising, result.EventTypes);
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30))); // Should end long before that
+            await task.WaitAsync(TimeSpan.FromSeconds(30)); // Should end long before that
             tokenSource.Dispose();
         }
     }

--- a/src/devices/BuildHat/tests/BuildHatTests/BuildHatTests.csproj
+++ b/src/devices/BuildHat/tests/BuildHatTests/BuildHatTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/devices/Camera/tests/TestCamera/TestCamera.csproj
+++ b/src/devices/Camera/tests/TestCamera/TestCamera.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/devices/Media/VideoDevice/samples/MjpegStream/MjpegStream.csproj
+++ b/src/devices/Media/VideoDevice/samples/MjpegStream/MjpegStream.csproj
@@ -11,11 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.26.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.42.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.32" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.32" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.32" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/tools/ArduinoCsCompiler/ArduinoCsCompiler.csproj
+++ b/tools/ArduinoCsCompiler/ArduinoCsCompiler.csproj
@@ -24,7 +24,7 @@
    </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
     <ProjectReference Include="..\..\src\devices\Arduino\Arduino.csproj" />
     <ProjectReference Include="..\..\src\System.Device.Gpio\System.Device.Gpio.csproj" />
   </ItemGroup>

--- a/tools/ArduinoCsCompiler/Frontend/Frontend.csproj
+++ b/tools/ArduinoCsCompiler/Frontend/Frontend.csproj
@@ -18,7 +18,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\devices\Arduino\Arduino.csproj" />

--- a/tools/DevicesApiTester/DeviceApiTester.csproj
+++ b/tools/DevicesApiTester/DeviceApiTester.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.6.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
     <ProjectReference Include="$(MainLibraryPath)System.Device.Gpio.csproj" />
   </ItemGroup>
 

--- a/tools/GenerateDocFxStructure/GenerateDocFxStructure.csproj
+++ b/tools/GenerateDocFxStructure/GenerateDocFxStructure.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
FYI: @pgrawehr 

After looking at all of the PRs that got created from dependabot, I decided to instead have a Bulk update of all versions that are outdated instead and close all of those dependabot PRs. This should be taking care of all of them. To calculate these, I took advantage of the [dotnet-outdated-tool](https://github.com/dotnet-outdated/dotnet-outdated) which can be used to perform the update in bulk automatically.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2228)