### PR TITLE
fix exception when disposing Ft232h device with SPI manager initialized

### DIFF
--- a/src/devices/Board/Board.cs
+++ b/src/devices/Board/Board.cs
@@ -248,7 +248,7 @@ namespace Iot.Device.Board
                     bus.Value.Dispose();
                 }
 
-                foreach (var bus in _managers)
+                foreach (var bus in _managers.ToList())
                 {
                     bus.Dispose();
                 }

--- a/src/devices/Ft232H/Ftx232HDevice.cs
+++ b/src/devices/Ft232H/Ftx232HDevice.cs
@@ -1062,7 +1062,7 @@ namespace Iot.Device.FtCommon
         /// </summary>
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && _ftHandle != null)
             {
                 _ftHandle.Dispose();
                 _ftHandle = null!;

--- a/src/devices/Ft232H/samples/Program.cs
+++ b/src/devices/Ft232H/samples/Program.cs
@@ -176,7 +176,7 @@ void TestI2c(Ftx232HDevice ft232h)
 
 void TestI2cTsl2561(Ftx232HDevice ft232H)
 {
-    var ftI2cBus = ft232h.CreateOrGetI2cBus(ft232h.GetDefaultI2cBusNumber());
+    var ftI2cBus = ft232H.CreateOrGetI2cBus(ft232H.GetDefaultI2cBusNumber());
     var i2cDevice = ftI2cBus.CreateDevice(Tsl256x.DefaultI2cAddress);
     Tsl256x tsl256X = new(i2cDevice, PackageType.Other);
 


### PR DESCRIPTION
**Summary of problem:**
When I initialize the Ft232h as a SPI device and then dispose of it, an InvalidOperationException error is thrown because we are disposing of the same elements from the list that we are iterating over.

**Resolution:**
Make a copy of the "_managers" list by using "ToList" so that the iteration continues as we dispose from the target list

**Example:**
<img width="507" alt="image" src="https://github.com/dotnet/iot/assets/43303451/37d46dd7-989f-403c-a2ef-c0006df46db6">
Path: /Users/joshbender/DocumentsLocal/Github/iot/src/devices/Ft232H/samples/Program.cs<br/>

<img width="1218" alt="image" src="https://github.com/dotnet/iot/assets/43303451/fcda7d30-b22d-4c96-85c0-eb530e608c4a">
<br/>Path: /Users/joshbender/DocumentsLocal/Github/iot/src/devices/Board/Board.cs<br/>


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/iot/pull/2270)