### PR TITLE
Check the length of an NDEF message before checking the end terminator

### DIFF
--- a/src/devices/Card/Ndef/NdefMessage.cs
+++ b/src/devices/Card/Ndef/NdefMessage.cs
@@ -70,8 +70,8 @@ namespace Iot.Device.Ndef
         public static byte[]? ExtractMessage(Span<byte> toExtract)
         {
             var (idx, size) = GetStartSizeNdef(toExtract);
-            // Finally check that the end terminator TLV is 0xFE
-            bool isRealEnd = toExtract[idx + size] == 0xFE;
+            // Finally check that the optional end terminator TLV is 0xFE
+            bool isRealEnd = (toExtract.Length == idx + size) || (toExtract[idx + size] == 0xFE);
             if (!isRealEnd)
             {
                 return new byte[0];


### PR DESCRIPTION
Fixes #2286

Check the length of an NDEF message before checking the end terminator TLV as it is optional and could result in an IndexOfOfRangeException.

Both `MifareCard` and `UltralightCard` trim the message on block boundaries before processing the message. This means that if the end of the message falls exactly at the end of a block boundary, the end terminator TLV is trimmed off, causing the descrbed exception.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2288)