### PR TITLE
Fix expected NTAG216 GET_VERSION response

### DIFF
--- a/src/devices/Card/Ultralight/UltralightCard.cs
+++ b/src/devices/Card/Ultralight/UltralightCard.cs
@@ -128,7 +128,7 @@ namespace Iot.Device.Card.Ultralight
                     NdefCapacity = 504;
                     UltralightCardType = UltralightCardType.UltralightNtag215;
                 }
-                else if ((Data[2] == 0x04) && (Data[3] == 0x01) && (Data[4] == 0x01) && (Data[5] == 0x00) && (Data[6] == 0x13))
+                else if ((Data[2] == 0x04) && (Data[3] == 0x02) && (Data[4] == 0x01) && (Data[5] == 0x00) && (Data[6] == 0x13))
                 {
                     NdefCapacity = 888;
                     UltralightCardType = UltralightCardType.UltralightNtag216;


### PR DESCRIPTION
Fixes #2285

Detection of the UltralightNtag216 was failing due to the incorrect expected GET_VERSION response.

UltralightNtag216F, UltralightNtag215, UltralightNtag213(F), UltralightNtag212 and UltralightNtag210 detection appear correct according to the specification but haven't been tested with a real tag.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2289)