### PR TITLE
Do not pass static zero IntPtr to epoll wait. Dispose driver in tests…

### DIFF
--- a/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
+++ b/src/System.Device.Gpio.Tests/GpioControllerTestBase.cs
@@ -28,7 +28,7 @@ public abstract class GpioControllerTestBase
     [InlineData(false)]
     public void PinValueStaysSameAfterDispose(bool closeAsHigh)
     {
-        var driver = GetTestDriver();
+        using var driver = GetTestDriver();
         if (driver is SysFsDriver)
         {
             // This check fails on the SysFsDriver, because it always sets the value to 0 when the pin is opened (but on close, the value does stay high)
@@ -181,7 +181,7 @@ public abstract class GpioControllerTestBase
     [Trait("SkipOnTestRun", "Windows_NT")] // Currently, the Windows Driver is defaulting to InputPullDown, and it seems this cannot be changed
     public void OpenPinDefaultsModeToLastMode(PinMode modeToTest)
     {
-        var driver = GetTestDriver();
+        using var driver = GetTestDriver();
         if (driver is SysFsDriver)
         {
             // See issue #1581. There seems to be a library-version issue or some other random cause for this test to act differently on different hardware.
@@ -230,7 +230,7 @@ public abstract class GpioControllerTestBase
     [Fact]
     public void AddCallbackFallingEdgeNotDetectedTest()
     {
-        var driver = GetTestDriver();
+        using var driver = GetTestDriver();
         if (driver is SysFsDriver)
         {
             // This test is unreliable (flaky) with SysFs.
@@ -317,7 +317,7 @@ public abstract class GpioControllerTestBase
     [Fact]
     public void AddCallbackRemoveAllCallbackTest()
     {
-        GpioDriver testDriver = GetTestDriver();
+        using GpioDriver testDriver = GetTestDriver();
         // Skipping the test for now when using the SysFsDriver or the RaspberryPi3Driver given that this test is flaky for those drivers.
         // Issue tracking this problem is https://github.com/dotnet/iot/issues/629
         if (testDriver is SysFsDriver || testDriver is RaspberryPi3Driver)

--- a/src/System.Device.Gpio/Interop/UnmanagedArray.cs
+++ b/src/System.Device.Gpio/Interop/UnmanagedArray.cs
@@ -10,8 +10,6 @@ internal sealed class UnmanagedArray<T> : SafeHandle
     private readonly int _arrayLength;
     private readonly int _typeSize;
 
-    public static readonly UnmanagedArray<T> Empty = new(0);
-
     public UnmanagedArray(int arrayLength)
         : base(IntPtr.Zero, true)
     {
@@ -21,7 +19,7 @@ internal sealed class UnmanagedArray<T> : SafeHandle
         }
 
         _arrayLength = arrayLength;
-        _typeSize = Marshal.SizeOf(typeof(T));
+        _typeSize = Marshal.SizeOf<T>();
         SetHandle(Marshal.AllocHGlobal(_typeSize * arrayLength));
     }
 
@@ -58,4 +56,3 @@ internal sealed class UnmanagedArray<T> : SafeHandle
         return !unmanagedArray.IsInvalid ? unmanagedArray.handle : throw new InvalidOperationException("Invalid handle");
     }
 }
-


### PR DESCRIPTION
See [here](https://github.com/dotnet/iot/pull/2287)
This PR fixes a bug introduced by the merge of #2184.
The bug was introduced by an unintentional change in the behaviour of the SysFsDriver, that utilizes the native epoll_wait function to discard not needed events.
Originally the binding of `epoll_wait` was implemented as
`public static extern int epoll_wait(int epfd, out epoll_event events, int maxevents, int timeout);`
which does not fully match the native function
`int epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout);`
because `events` is a pointer to an array.

Some new functionality in #2184 relies on epoll_wait, what prompted me to correct the binding.
As a consequence I had to update calls in the SysFsDriver, but mistakenly passed IntPtr.Zero to epoll_wait, which does not seem to result in the same behaviour. The fix is to pass an actual buffer instead.

This PR also includes some additional "using" statements in the GpioControllerTestBase because during testing, some sporadic occurrences of PermissionDeniedException occured. It complained about not having root permission for changing GPIO mode of used GPIOs. I'm pretty sure that was because of not yet disposed SysFsDriver instance/s.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2291)