### PR TITLE
Add GPIO support for Rockchip RV1103

### DIFF
--- a/src/devices/Gpio/Drivers/LuckFoxPicoDriver.cs
+++ b/src/devices/Gpio/Drivers/LuckFoxPicoDriver.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Gpio.Drivers
+{
+    /// <summary>
+    /// A GPIO driver for the LuckFox Pico
+    /// </summary>
+    /// <remarks>
+    /// SoC: Rockchip RV1103
+    /// </remarks>
+    public class LuckFoxPicoDriver : Rv1103Driver
+    {
+        /// <inheritdoc/>
+        protected override int PinCount => 24;
+
+        /// <inheritdoc/>
+        protected override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            return pinNumber switch
+            {
+                1 => MapPinNumber(1, 'B', 2),
+                2 => MapPinNumber(1, 'B', 3),
+                4 => MapPinNumber(1, 'C', 7),
+                5 => MapPinNumber(1, 'C', 6),
+                6 => MapPinNumber(1, 'C', 5),
+                7 => MapPinNumber(1, 'C', 4),
+                9 => MapPinNumber(1, 'D', 2),
+                10 => MapPinNumber(1, 'D', 3),
+                11 => MapPinNumber(1, 'A', 2),
+                12 => MapPinNumber(1, 'C', 0),
+                14 => MapPinNumber(1, 'C', 1),
+                15 => MapPinNumber(1, 'C', 2),
+                16 => MapPinNumber(1, 'C', 3),
+                17 => MapPinNumber(0, 'A', 4),
+                19 => MapPinNumber(1, 'D', 0),
+                20 => MapPinNumber(1, 'D', 1),
+                21 => MapPinNumber(4, 'B', 1),
+                22 => MapPinNumber(4, 'B', 0),
+                24 => MapPinNumber(4, 'A', 6),
+                25 => MapPinNumber(4, 'A', 2),
+                26 => MapPinNumber(4, 'A', 3),
+                27 => MapPinNumber(4, 'A', 4),
+                31 => MapPinNumber(4, 'C', 0),
+                32 => MapPinNumber(4, 'C', 1),
+                _ => throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber))
+            };
+        }
+    }
+}

--- a/src/devices/Gpio/Drivers/LuckFoxPicoMiniDriver.cs
+++ b/src/devices/Gpio/Drivers/LuckFoxPicoMiniDriver.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Gpio.Drivers
+{
+    /// <summary>
+    /// A GPIO driver for the LuckFox Pico Mini
+    /// </summary>
+    /// <remarks>
+    /// SoC: Rockchip RV1103
+    /// </remarks>
+    public class LuckFoxPicoMiniDriver : Rv1103Driver
+    {
+        /// <inheritdoc/>
+        protected override int PinCount => 17;
+
+        /// <inheritdoc/>
+        protected override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            return pinNumber switch
+            {
+                4 => MapPinNumber(1, 'B', 2),
+                5 => MapPinNumber(1, 'B', 3),
+                6 => MapPinNumber(1, 'C', 0),
+                7 => MapPinNumber(1, 'C', 1),
+                8 => MapPinNumber(1, 'C', 2),
+                9 => MapPinNumber(1, 'C', 3),
+                10 => MapPinNumber(1, 'C', 4),
+                11 => MapPinNumber(1, 'C', 5),
+                12 => MapPinNumber(1, 'D', 0),
+                13 => MapPinNumber(1, 'D', 1),
+                14 => MapPinNumber(1, 'D', 2),
+                15 => MapPinNumber(1, 'D', 3),
+                16 => MapPinNumber(1, 'C', 6),
+                17 => MapPinNumber(1, 'C', 7),
+                18 => MapPinNumber(0, 'A', 4),
+                19 => MapPinNumber(4, 'C', 0),
+                20 => MapPinNumber(4, 'C', 1),
+                _ => throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber))
+            };
+        }
+    }
+}

--- a/src/devices/Gpio/Drivers/LuckFoxPicoPlusDriver.cs
+++ b/src/devices/Gpio/Drivers/LuckFoxPicoPlusDriver.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Iot.Device.Gpio.Drivers
+{
+    /// <summary>
+    /// A GPIO driver for the LuckFox Pico Plus
+    /// </summary>
+    /// <remarks>
+    /// SoC: Rockchip RV1103
+    /// </remarks>
+    public class LuckFoxPicoPlusDriver : Rv1103Driver
+    {
+        /// <inheritdoc/>
+        protected override int PinCount => 25;
+
+        /// <inheritdoc/>
+        protected override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            return pinNumber switch
+            {
+                1 => MapPinNumber(1, 'B', 2),
+                2 => MapPinNumber(1, 'B', 3),
+                4 => MapPinNumber(1, 'C', 7),
+                5 => MapPinNumber(1, 'C', 6),
+                6 => MapPinNumber(1, 'C', 5),
+                7 => MapPinNumber(1, 'C', 4),
+                9 => MapPinNumber(1, 'D', 2),
+                10 => MapPinNumber(1, 'D', 3),
+                11 => MapPinNumber(1, 'A', 2),
+                12 => MapPinNumber(1, 'C', 0),
+                14 => MapPinNumber(1, 'C', 1),
+                15 => MapPinNumber(1, 'C', 2),
+                16 => MapPinNumber(1, 'C', 3),
+                17 => MapPinNumber(0, 'A', 4),
+                19 => MapPinNumber(1, 'D', 0),
+                20 => MapPinNumber(1, 'D', 1),
+                21 => MapPinNumber(3, 'A', 6),
+                22 => MapPinNumber(3, 'A', 7),
+                24 => MapPinNumber(3, 'A', 5),
+                25 => MapPinNumber(3, 'A', 4),
+                26 => MapPinNumber(3, 'A', 2),
+                27 => MapPinNumber(3, 'A', 3),
+                29 => MapPinNumber(3, 'A', 1),
+                31 => MapPinNumber(4, 'C', 0),
+                32 => MapPinNumber(4, 'C', 1),
+                _ => throw new ArgumentException($"Board (header) pin {pinNumber} is not a GPIO pin on the {GetType().Name} device.", nameof(pinNumber))
+            };
+        }
+    }
+}

--- a/src/devices/Gpio/Drivers/Rockchip/RockchipDriver.cs
+++ b/src/devices/Gpio/Drivers/Rockchip/RockchipDriver.cs
@@ -162,6 +162,7 @@ namespace Iot.Device.Gpio.Drivers
             {
                 dataPointer = (uint*)(_gpioPointers[unmapped.GpioNumber] + 0x0004);
             }
+
             uint dataValue = *dataPointer;
 
             // software write enable

--- a/src/devices/Gpio/Drivers/Rockchip/Rv1103Driver.cs
+++ b/src/devices/Gpio/Drivers/Rockchip/Rv1103Driver.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Device.Gpio;
+
+namespace Iot.Device.Gpio.Drivers
+{
+    /// <summary>
+    /// A GPIO driver for Rockchip RV1103
+    /// </summary>
+    public unsafe class Rv1103Driver : RockchipDriver
+    {
+        private static readonly int[] _grfOffsets = new[]
+        {
+            0x8038, -1, -1, -1,  // GPIO0 PU/PD control
+            0x81C0, 0x81C4, 0x81C8, 0x81CC,  // GPIO1 PU/PD control
+            -1, -1, -1, -1,  // GPIO2 PU/PD control
+            0x81E0, -1, -1, 0x81EC,  // GPIO3 PU/PD control
+            0x8070, 0x8074, 0x80C0, -1,  // GPIO4 PU/PD control
+        };
+        private static readonly int[] _iomuxOffsets = new[]
+        {
+            -1, 0x8004, -1, -1, -1, -1, -1, -1,  // GPIO0 iomux control
+            0x8000, -1, 0x8008, -1, 0x8010, 0x8014, 0x8018, -1,  // GPIO1 iomux control
+            -1, -1, -1, -1, -1, -1, -1, -1,  // GPIO2 iomux control
+            0x8040, 0x8044, 0x8048, 0x804C, 0x8050, 0x8054, 0x8058, -1,  // GPIO3 iomux control
+            0x8000, 0x8004, 0x8008, -1, 0x8010, -1, -1, -1,  // GPIO4 iomux control
+        };
+
+        /// <inheritdoc/>
+        protected override uint[] GpioRegisterAddresses => new[] { 0xFF38_0000, 0xFF53_0000, 0u, 0xFF55_0000, 0xFF56_0000 };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Rv1103Driver"/> class.
+        /// </summary>
+        public Rv1103Driver() { }
+
+        /// <inheritdoc/>
+        protected override void SetPinMode(int pinNumber, PinMode mode)
+        {
+            (int GpioNumber, int Port, int PortNumber) unmapped = UnmapPinNumber(pinNumber);
+            uint* dirPointer, modePointer, iomuxPointer;
+            uint dirValue, modeValue, iomuxValue;
+            int iomuxBitOffset = unmapped.PortNumber * 3;
+            int bitOffset = unmapped.PortNumber * 2;
+
+            if (unmapped.PortNumber < 4) 
+            {
+                // low register
+                dirPointer = (uint*)(_gpioPointers[unmapped.GpioNumber] + 0x0008);
+                iomuxPointer = (uint*)(_gpioPointers[unmapped.GpioNumber] + _iomuxOffsets[unmapped.GpioNumber * 8 + unmapped.Port * 2]);
+            }
+            else
+            {
+                // high register
+                dirPointer = (uint*)(_gpioPointers[unmapped.GpioNumber] + 0x000C);
+                iomuxPointer = (uint*)(_gpioPointers[unmapped.GpioNumber] + _iomuxOffsets[unmapped.GpioNumber * 8 + unmapped.Port * 2 + 1]);
+            }
+
+            iomuxValue = *iomuxPointer;
+            // software write enable
+            iomuxValue |= 0b111U << (16 + iomuxBitOffset);
+            // set pin to GPIO mode
+            iomuxValue &= ~(0b111U << iomuxBitOffset);
+            *iomuxPointer = iomuxValue;
+
+            dirValue = *dirPointer;
+            // software write enable
+            dirValue |= 0b1U << (16 + unmapped.Port % 2 * 8 + unmapped.PortNumber);
+            // set GPIO direction
+            switch (mode)
+            {
+                case PinMode.Input:
+                case PinMode.InputPullDown:
+                case PinMode.InputPullUp:
+                    // set direction: input is 0; output is 1
+                    dirValue &= ~(1U << (unmapped.Port * 8 + unmapped.PortNumber));
+                    break;
+                case PinMode.Output:
+                    dirValue |= 1U << (unmapped.Port * 8 + unmapped.PortNumber);
+                    break;
+                default:
+                    break;
+            }
+            *dirPointer = dirValue;
+
+            if (mode == PinMode.InputPullUp || mode == PinMode.InputPullDown)
+            {
+                // set GPIO pull-up/down mode
+                modePointer = (uint*)(_gpioPointers[unmapped.GpioNumber] + _grfOffsets[unmapped.GpioNumber * 4 + unmapped.Port]);
+                modeValue = *modePointer;
+                // software write enable
+                modeValue |= 0b111U << (16 + unmapped.PortNumber * 2);
+                // pull-up is 0b01; pull-down is 0b10; default is 0b00
+                modeValue &= ~(0b11U << bitOffset);
+
+                switch (mode)
+                {
+                    case PinMode.InputPullDown:
+                        modeValue |= 0b10U << bitOffset;
+                        break;
+                    case PinMode.InputPullUp:
+                        modeValue |= 0b01U << bitOffset;
+                        break;
+                    default:
+                        break;
+                }
+                *modePointer = modeValue;
+            }
+
+            if (_pinModes.ContainsKey(pinNumber))
+            {
+                _pinModes[pinNumber].CurrentPinMode = mode;
+            }
+            else
+            {
+                _pinModes.Add(pinNumber, new PinState(mode));
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override bool IsPinModeSupported(int pinNumber, PinMode mode)
+        {
+            return mode switch
+            {
+                PinMode.Input or PinMode.Output or PinMode.InputPullUp or PinMode.InputPullDown => true,
+                _ => false,
+            };
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/devices/Gpio/Drivers/Rockchip/Rv1103Driver.cs
+++ b/src/devices/Gpio/Drivers/Rockchip/Rv1103Driver.cs
@@ -33,7 +33,9 @@ namespace Iot.Device.Gpio.Drivers
         /// <summary>
         /// Initializes a new instance of the <see cref="Rv1103Driver"/> class.
         /// </summary>
-        public Rv1103Driver() { }
+        public Rv1103Driver()
+        {
+        }
 
         /// <inheritdoc/>
         protected override void SetPinMode(int pinNumber, PinMode mode)
@@ -44,7 +46,7 @@ namespace Iot.Device.Gpio.Drivers
             int iomuxBitOffset = unmapped.PortNumber * 3;
             int bitOffset = unmapped.PortNumber * 2;
 
-            if (unmapped.PortNumber < 4) 
+            if (unmapped.PortNumber < 4)
             {
                 // low register
                 dirPointer = (uint*)(_gpioPointers[unmapped.GpioNumber] + 0x0008);
@@ -82,6 +84,7 @@ namespace Iot.Device.Gpio.Drivers
                 default:
                     break;
             }
+
             *dirPointer = dirValue;
 
             if (mode == PinMode.InputPullUp || mode == PinMode.InputPullDown)
@@ -105,6 +108,7 @@ namespace Iot.Device.Gpio.Drivers
                     default:
                         break;
                 }
+
                 *modePointer = modeValue;
             }
 

--- a/src/devices/Gpio/README.md
+++ b/src/devices/Gpio/README.md
@@ -18,6 +18,9 @@ This project contains some **full function(PULL-UP, PULL-DOWN)** generic GPIO dr
 | Orange Pi Zero 2 | [OrangePiZero2Driver](./Drivers/OrangePiZero2Driver.cs) |
 | Rock Pi 4B Plus | [RockPi4bPlusDriver](./Drivers/RockPi4bPlusDriver.cs) |
 | Orange Pi PC | [OrangePiPCDriver](./Drivers/OrangePiPCDriver.cs) |
+| LuckFox Pico | [LuckFoxPicoDriver](./Drivers/LuckFoxPicoDriver.cs) |
+| LuckFox Pico Mini | [LuckFoxPicoMiniDriver](./Drivers/LuckFoxPicoMiniDriver.cs) |
+| LuckFox Pico Plus | [LuckFoxPicoPlusDriver](./Drivers/LuckFoxPicoPlusDriver.cs) |
 
 ## Benchmarks
 


### PR DESCRIPTION
Add GPIO support for Rockchip RV1103 and some boards like LuckFox Pico.

I do some test in LuckFox Pico with pin 137, the OS is Ubuntu 22.04, Linux kernel version is 5.10.110, .NET version is 8.0.203. The GPIO speed is 219KHz

![1](https://github.com/dotnet/iot/assets/15957347/51c560e6-d4b6-4180-979e-1049b15dc6d2)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2303)