### PR TITLE
Adjusting config.txt documentation on Raspberry PI

### DIFF
--- a/Documentation/raspi-i2c.md
+++ b/Documentation/raspi-i2c.md
@@ -48,11 +48,14 @@ See at the end if you want to write your own I2C scanner and find the correct de
 
 In most of the cases, it is easy and straight forward to enable I2C for your Raspberry Pi. The basic case can be [found here](https://www.raspberrypi-spy.co.uk/2014/11/enabling-the-i2c-interface-on-the-raspberry-pi/).
 
-Sometimes, you have I2C devices which can't support fast mode and the speed needs to be adjusted. In case you want to change the speed of the line, you'll need to add into the `/boot/config.txt` file:
+Sometimes, you have I2C devices which can't support fast mode and the speed needs to be adjusted. In case you want to change the speed of the line, you'll need to add into the `/boot/firmware/config.txt` file:
 
 ```bash
-sudo nano /boot/config.txt
+sudo nano /boot/firmware/config.txt
 ```
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/config.txt` if you have an older OS version.
 
 Add the line which will change the speed from 100_000 (default speed) to 10_000:
 

--- a/Documentation/raspi-pwm.md
+++ b/Documentation/raspi-pwm.md
@@ -50,7 +50,10 @@ Unhandled exception. System.UnauthorizedAccessException: Access to the path '/sy
 
 ## Enabling hardware PWM
 
-In order to have the hardware PWM activated on the Raspberry Pi, you'll have to edit the /boot/config.txt file and add an overlay.
+In order to have the hardware PWM activated on the Raspberry Pi, you'll have to edit the /boot/firmware/config.txt file and add an overlay.
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 Main Raspberry Pi kernel documentation gives 2 possibilities. Either a [single channel](https://github.com/raspberrypi/linux/blob/04c8e47067d4873c584395e5cb260b4f170a99ea/arch/arm/boot/dts/overlays/README#L925), either a [dual channel](https://github.com/raspberrypi/linux/blob/04c8e47067d4873c584395e5cb260b4f170a99ea/arch/arm/boot/dts/overlays/README#L944).
 
@@ -81,11 +84,14 @@ We have then 4 options for the exposed GPIO pins:
 | PWM1 | 13 | 4 | Alt0 | dtoverlay=pwm,pin=13,func=4 |
 | PWM1 | 19 | 2 | Alt5 | dtoverlay=pwm,pin=19,func=2 |
 
-Edit the /boot/config.txt file and add the dtoverlay line in the file. You need root privileges for this:
+Edit the /boot/firmware/config.txt file and add the dtoverlay line in the file. You need root privileges for this:
 
 ```bash
-sudo nano /boot/config.txt
+sudo nano /boot/firmware/config.txt
 ```
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 Save the file with `ctrl + x` then `Y` then `enter`
 
@@ -106,11 +112,14 @@ You are all setup, the basic example should now work with the PWM and channel yo
 | PWM0 | 12 | 4 | Alt0 | PWM1 | 19 | 2 | Alt5 | dtoverlay=pwm-2chan,pin=12,func=4,pin2=19,func2=2 |
 | PWM0 | 18 | 2 | Alt5 | PWM1 | 19 | 2 | Alt5 | dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2 |
 
-Edit the /boot/config.txt file and add the dtoverlay line in the file. You need root privileges for this:
+Edit the /boot/firmware/config.txt file and add the dtoverlay line in the file. You need root privileges for this:
 
 ```bash
-sudo nano /boot/config.txt
+sudo nano /boot/firmware/config.txt
 ```
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 Save the file with `ctrl + x` then `Y` then `enter`
 

--- a/Documentation/raspi-spi.md
+++ b/Documentation/raspi-spi.md
@@ -40,11 +40,14 @@ Aborted
 
 ## Enabling SPI0 without Hardware Chip Select
 
-In very short, this is the line you'll need to add into the `/boot/config.txt` file:
+In very short, this is the line you'll need to add into the `/boot/firmware/config.txt` file:
 
 ```bash
-sudo nano /boot/config.txt
+sudo nano /boot/firmware/config.txt
 ```
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 Add the line:
 
@@ -72,7 +75,10 @@ This will enable SPI0 where those are the pins which will be selected, only Soft
 
 ## Enabling any SPI with any Chip Select
 
-In order to activate  Chip Select, you'll need to add a specific dtoverlay on the `/boot/config.txt` file. If you've used the previous way of activating SPI0, you should comment the line `dtparam=spi=on` and add what follows using the `dtoverlay`configurations.
+In order to activate  Chip Select, you'll need to add a specific dtoverlay on the `/boot/firmware/config.txt` file. If you've used the previous way of activating SPI0, you should comment the line `dtparam=spi=on` and add what follows using the `dtoverlay`configurations.
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 Here is the table with the different options for SP0 and SP1 (please refer to the [Raspberry Pi documentation](https://www.raspberrypi.org/documentation/hardware/raspberrypi/spi/) to activate other SPI)
 

--- a/src/System.Device.Gpio.Tests/README.md
+++ b/src/System.Device.Gpio.Tests/README.md
@@ -128,7 +128,10 @@ All headers are standard 2.54mm headers. Male headers are usually sold longer an
 
 ### Linux
 
-`/boot/config.txt`
+`/boot/firmware/config.txt`
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 ```text
 # Enable I2C, SPI, PWM

--- a/src/devices/Board/RaspberryPiBoard.cs
+++ b/src/devices/Board/RaspberryPiBoard.cs
@@ -23,6 +23,7 @@ namespace Iot.Device.Board
     /// </summary>
     public class RaspberryPiBoard : GenericBoard
     {
+        private readonly string[] _configFile = new string[] { "/boot/firmware/config.txt", "/boot/config.txt" };
         private readonly object _initLock = new object();
         private readonly string[] _possibleI2cActivations = new string[]
         {
@@ -95,6 +96,20 @@ namespace Iot.Device.Board
             // TODO: Ideally detect board type, so that invalid combinations can be prevented (i.e. I2C bus 2 on Raspi 3)
             PinCount = 28;
             _initialized = false;
+
+            // Try to find the right configuration file
+            // There has been changes in RPI and it's now "/boot/firmware/config.txt"
+            // On older OS, the location is "/boot/config.txt"
+            // BUT, the "/boot/config.txt" still exists on newer OS but the file is not accessible
+            // So we have to try first the existance of the new location, then the old one
+            if (File.Exists(_configFile[0]))
+            {
+                ConfigurationFile = _configFile[0];
+            }
+            else
+            {
+                ConfigurationFile = _configFile[1];
+            }
         }
 
         /// <summary>
@@ -160,47 +175,47 @@ namespace Iot.Device.Board
             switch (busId)
             {
                 case 0:
-                {
-                    // Bus 0 is the one on logical pins 0 and 1. According to the docs, it should not
-                    // be used by application software and instead is reserved for HATs, but if you don't have one, it is free for other purposes
-                    sda = 0;
-                    scl = 1;
-                    break;
-                }
+                    {
+                        // Bus 0 is the one on logical pins 0 and 1. According to the docs, it should not
+                        // be used by application software and instead is reserved for HATs, but if you don't have one, it is free for other purposes
+                        sda = 0;
+                        scl = 1;
+                        break;
+                    }
 
                 case 1:
-                {
-                    // This is the bus commonly used by application software.
-                    sda = 2;
-                    scl = 3;
-                    break;
-                }
+                    {
+                        // This is the bus commonly used by application software.
+                        sda = 2;
+                        scl = 3;
+                        break;
+                    }
 
                 case 2:
-                {
-                    throw new NotSupportedException("I2C Bus number 2 doesn't exist");
-                }
+                    {
+                        throw new NotSupportedException("I2C Bus number 2 doesn't exist");
+                    }
 
                 case 3:
-                {
-                    sda = 4;
-                    scl = 5;
-                    break;
-                }
+                    {
+                        sda = 4;
+                        scl = 5;
+                        break;
+                    }
 
                 case 4:
-                {
-                    sda = 6;
-                    scl = 7;
-                    break;
-                }
+                    {
+                        sda = 6;
+                        scl = 7;
+                        break;
+                    }
 
                 case 5:
-                {
-                    sda = 10;
-                    scl = 11;
-                    break;
-                }
+                    {
+                        sda = 10;
+                        scl = 11;
+                        break;
+                    }
 
                 case 6:
                     sda = 22;

--- a/src/devices/Ccs811/README.md
+++ b/src/devices/Ccs811/README.md
@@ -32,11 +32,14 @@ Understanding the measurement:
 
 In order to have this sensor working on a Raspberry Pi, you need to lower the bus speed. This sensor uses a mode called I2C stretching and it is not supported natively on Raspberry Pi. So you **must** lower the I2C clock to the minimum to make it working properly or use a software I2C with a low clock as well.
 
-In order to do so, open a ssh session with your Raspberry and edit the /boot/config.txt file:
+In order to do so, open a ssh session with your Raspberry and edit the /boot/firmware/config.txt file:
 
 ```bash
-sudo nano /boot/config.txt
+sudo nano /boot/firmware/config.txt
 ```
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 ## Lowering the hardware I2C clock
 

--- a/src/devices/Nmea0183/README.md
+++ b/src/devices/Nmea0183/README.md
@@ -261,7 +261,10 @@ Filter rules are used to tell the router which messages from which source need t
 ## A note on the use of serial ports on the Raspberry Pi
 
 The Raspberry Pi 4 has up to 6 UART interfaces that can be enabled. UART0 on GPIO pins 14 and 15 is enabled by default, the others can be
-enabled using overlays configured in `/boot/config.txt`. The following entries add UARTS 2 and 3 on GPIO Pins 0/1 and 4/5 respectively:
+enabled using overlays configured in `/boot/firmware/config.txt`. The following entries add UARTS 2 and 3 on GPIO Pins 0/1 and 4/5 respectively:
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 ```text
 enable_uart=1

--- a/src/devices/Nrf24l01/README.md
+++ b/src/devices/Nrf24l01/README.md
@@ -45,11 +45,14 @@ The nRF24L01 is a single chip radio transceiver for the world wide 2.4 - 2.5 GHz
 
 This example needs to enable SPI1 on Raspberry Pi running Raspbian.
 
-1. Open **/boot/config.txt** using editor, like
+1. Open **/boot/firmware/config.txt** using editor, like
 
     ```shell
-    sudo nano /boot/config.txt
+    sudo nano /boot/firmware/config.txt
     ```
+
+    > [!Note]
+    > Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 2. Add the line **dtoverlay=spi1-3cs** and save
 3. Reboot

--- a/src/devices/OneWire/README.md
+++ b/src/devices/OneWire/README.md
@@ -57,7 +57,10 @@ else
 
 ## How to setup 1-wire on Raspberry Pi
 
-Add the following to `/boot/config.txt` to enable 1-wire protocol. The default gpio is 4 (pin 7).
+Add the following to `/boot/firmware/config.txt` to enable 1-wire protocol. The default gpio is 4 (pin 7).
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 ```text
 dtoverlay=w1-gpio

--- a/src/devices/Seesaw/README.md
+++ b/src/devices/Seesaw/README.md
@@ -19,7 +19,7 @@ This binding was developed using the Adafruit Seesaw breakout board which uses t
 
 ## Usage
 
-These samples connect to a Raspberry Pi via the first I2C interface. Issues were noticed when using the out-of-the-box stiings and so the I2C bus has been slowed down by adding the following to the /boot/Config.txt file
+These samples connect to a Raspberry Pi via the first I2C interface. Issues were noticed when using the out-of-the-box stiings and so the I2C bus has been slowed down by adding the following to the /boot/firmware/config.txt file
 
  `dtparam=i2c1_baudrate=50000`
 

--- a/src/devices/SenseHat/README.md
+++ b/src/devices/SenseHat/README.md
@@ -228,7 +228,10 @@ Note: There are more than 1 temperature sensors on SenseHat board
 
 ## Binding notes
 
-When using SysFs implementation please make sure to enable Sense HAT in `/boot/config.txt` before using by adding following line:
+When using SysFs implementation please make sure to enable Sense HAT in `/boot/firmware/config.txt` before using by adding following line:
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 ```text
 dtoverlay=rpi-sense

--- a/src/devices/SocketCan/README.md
+++ b/src/devices/SocketCan/README.md
@@ -69,7 +69,10 @@ using (CanRaw can = new CanRaw())
 
 - Connect SPI device to regular SPI pins (SI/MOSI - `BCM 10`; SO/MISO - `BCM 9`; CLK/SCK - `BCM 11`; CS - `CE0`)
 - Interrupt pin should be connected to any GPIO pin i.e. `BCM 25` (note: interrupt pin can be adjusted below)
-- Add following in `/boot/config.txt`
+- Add following in `/boot/firmware/config.txt`
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 ```text
 dtparam=spi=on

--- a/src/devices/Ws28xx/README.md
+++ b/src/devices/Ws28xx/README.md
@@ -82,7 +82,10 @@ var newColor = Color.FromArgb(0, color.R, color.G, color.B);
 
 ## Binding Notes
 
-### Raspberry Pi setup (/boot/config.txt)
+### Raspberry Pi setup (/boot/firmware/config.txt)
+
+> [!Note]
+> Prior to *Bookworm*, Raspberry Pi OS stored the boot partition at `/boot/`. Since Bookworm, the boot partition is located at `/boot/firmware/`. Adjust the previous line to be `sudo nano /boot/firmware/config.txt` if you have an older OS version.
 
 * Make sure SPI is enabled
 


### PR DESCRIPTION
The config.txt file has changed place on recent version of Raspberry PI OS. See https://www.raspberrypi.com/documentation/computers/config_txt.html#what-is-config-txt

It still seems that the /boot/config.txt is present but as a mirror.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2304)