### PR TITLE
Use development branch, so we get the ESP32 IDK 3.X

### DIFF
--- a/eng/ArduinoCsCI.cmd
+++ b/eng/ArduinoCsCI.cmd
@@ -13,7 +13,7 @@ arduino-cli lib install "DHT sensor library"
 arduino-cli lib install "Servo"
 
 arduino-cli config init
-arduino-cli config add board_manager.additional_urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
+arduino-cli config add board_manager.additional_urls https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json
 arduino-cli core update-index
 
 REM directly execute PS, we can ignore any test errors.


### PR DESCRIPTION
The build was still using the 2.X line, which is now incompatible with the firmware
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2305)