### PR TITLE
Adapt FTX232H to support new variants (FT232HP, FT2232HP, FT2232HA FT4232HA, FT4232HP)

### DIFF
--- a/src/devices/Ft232H/Ft2232HDevice.cs
+++ b/src/devices/Ft232H/Ft2232HDevice.cs
@@ -23,7 +23,7 @@ namespace Iot.Device.Ft2232H
         public static List<Ft2232HDevice> GetFt2232H()
         {
             List<Ft2232HDevice> ft2232s = new List<Ft2232HDevice>();
-            var devices = FtCommon.FtCommon.GetDevices(new FtDeviceType[] { FtDeviceType.Ft2232H });
+            var devices = FtCommon.FtCommon.GetDevices(new FtDeviceType[] { FtDeviceType.Ft2232H, FtDeviceType.Ft2232HA });
             foreach (var device in devices)
             {
                 ft2232s.Add(new Ft2232HDevice(device));

--- a/src/devices/Ft232H/Ft232HDevice.cs
+++ b/src/devices/Ft232H/Ft232HDevice.cs
@@ -28,7 +28,7 @@ namespace Iot.Device.Ft232H
         public static List<Ft232HDevice> GetFt232H()
         {
             List<Ft232HDevice> ft232s = new List<Ft232HDevice>();
-            var devices = FtCommon.FtCommon.GetDevices(new FtDeviceType[] { FtDeviceType.Ft232H });
+            var devices = FtCommon.FtCommon.GetDevices(new FtDeviceType[] { FtDeviceType.Ft232H, FtDeviceType.Ft232HP });
             foreach (var device in devices)
             {
                 ft232s.Add(new Ft232HDevice(device));

--- a/src/devices/Ft232H/Ft4232HDevice.cs
+++ b/src/devices/Ft232H/Ft4232HDevice.cs
@@ -23,7 +23,7 @@ namespace Iot.Device.Ft4232H
         public static List<Ft4232HDevice> GetFt2232H()
         {
             List<Ft4232HDevice> ft4232s = new List<Ft4232HDevice>();
-            var devices = FtCommon.FtCommon.GetDevices(new FtDeviceType[] { FtDeviceType.Ft4232H });
+            var devices = FtCommon.FtCommon.GetDevices(new FtDeviceType[] { FtDeviceType.Ft4232H, FtDeviceType.Ft4232HA, FtDeviceType.Ft4232HP });
             foreach (var device in devices)
             {
                 ft4232s.Add(new Ft4232HDevice(device));

--- a/src/devices/FtCommon/FtDeviceType.cs
+++ b/src/devices/FtCommon/FtDeviceType.cs
@@ -77,5 +77,60 @@ namespace Iot.Device.FtCommon
         /// OTP programmer board for the FT4222.
         /// </summary>
         Ft4222OtpProgrammerBoard,
+
+        /// <summary>
+        /// FT900 Device
+        /// </summary>
+        Ft900,
+
+        /// <summary>
+        /// FT930 Device
+        /// </summary>
+        Ft930,
+
+        /// <summary>
+        /// FTUMFTPD3A Device
+        /// </summary>
+        FtUmftpd3A,
+
+        /// <summary>
+        /// FT2233HP Device
+        /// </summary>
+        Ft2233HP,
+
+        /// <summary>
+        /// FT4233HP Device
+        /// </summary>
+        Ft4233HP,
+
+        /// <summary>
+        /// FT2232HP Device
+        /// </summary>
+        Ft2232HP,
+
+        /// <summary>
+        /// FT4232HP Device
+        /// </summary>
+        Ft4232HP,
+
+        /// <summary>
+        /// FT233HP Device
+        /// </summary>
+        Ft233HP,
+
+        /// <summary>
+        /// FT232HP Device
+        /// </summary>
+        Ft232HP,
+
+        /// <summary>
+        /// FT2232HA Device
+        /// </summary>
+        Ft2232HA,
+
+        /// <summary>
+        /// FT4232HA Device
+        /// </summary>
+        Ft4232HA,
     }
 }


### PR DESCRIPTION
- Update FT device types from D2XX lib with new variants
- Adapt FTX232H to support new variants (FT232HP, FT2232HP, FT2232HA FT4232HA, FT4232HP)
- Fix Channel when SerialNumber is present