### PR TITLE
Detect Raspberry 3B Plus with upgraded Firmware

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/RaspberryBoardInfo.cs
@@ -165,7 +165,7 @@ internal class RaspberryBoardInfo
         0x00C1 => Model.RaspberryPiZeroW,
         0x2120 => Model.RaspberryPiZero2W,
         0x2082 or 0x2083 => Model.RaspberryPi3B,
-        0x20D3 => Model.RaspberryPi3BPlus,
+        0x20D3 or 0x20D4 => Model.RaspberryPi3BPlus,
         0x20E0 => Model.RaspberryPi3APlus,
         0x20E1 => Model.RaspberryPi3APlus, // 3A, rev 1.1
         0x20A0 or 0x2100 => Model.RaspberryPiComputeModule3,


### PR DESCRIPTION
Raspberry 3B Plus when upgraded with new firmware will not be detected correctly. This change adds the detection of the new firmware version 20D4

Hardware        : BCM2835
Revision        : a0**20d4**
Serial          : 00000000687e3c1d
Model           : Raspberry Pi 3 Model B Plus Rev 1.4
