### PR TITLE
Break out of infinite recursion

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/Libgpiod/LibGpiodDriverFactory.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/Libgpiod/LibGpiodDriverFactory.cs
@@ -165,7 +165,11 @@ internal sealed class LibGpiodDriverFactory
                     DirectoryInfo[] subdirectories = currentDirectory.GetDirectories();
                     foreach (var subdirectory in subdirectories)
                     {
-                        directoriesToProcess.Push(subdirectory);
+                        var depth = subdirectory.FullName.Count(separator => separator == Path.DirectorySeparatorChar);
+                        if (depth < 10)
+                        {
+                            directoriesToProcess.Push(subdirectory);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #2332 

Using the Cargo library on a Pi 5 encountered a symbolic link that went to a parent directory creating an infinite loop in the C# code. This change limits the directory depth so that it can break out of the infinite loop when present.

Future major version should be relying on NativeLibrary probing paths as opposed to us doing the probing ourselves as mentioned in #2332 .

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2335)