### PR TITLE
Fix a possible crash when disposing ADS1115 device

### DIFF
--- a/src/devices/Ads1115/Ads1115.cs
+++ b/src/devices/Ads1115/Ads1115.cs
@@ -289,6 +289,8 @@ namespace Iot.Device.Ads1115
                     {
                         throw;
                     }
+
+                    Thread.Sleep(100);
                 }
             }
 

--- a/src/devices/Common/Iot/Device/Common/AngleExtensions.cs
+++ b/src/devices/Common/Iot/Device/Common/AngleExtensions.cs
@@ -71,7 +71,7 @@ namespace Iot.Device.Common
         /// <param name="currentTrack">First angle, actual direction</param>
         /// <param name="destinationTrack">Second angle, desired direction</param>
         /// <returns>The normalized result of <paramref name="currentTrack"/>-<paramref name="destinationTrack"/>. The value is negative if
-        /// the current track is to port (left) of the the desired track and positive otherwise</returns>
+        /// the current track is to port (left) of the desired track and positive otherwise</returns>
         public static Angle Difference(Angle currentTrack, Angle destinationTrack)
         {
             double val = currentTrack.Radians - destinationTrack.Radians;


### PR DESCRIPTION
In case a communication error happens during dispose, the driver would crash.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2345)