### PR TITLE
#2346 decode ATS if present (ISO 14443-4 card)

### DIFF
--- a/src/devices/Pn532/Pn532.cs
+++ b/src/devices/Pn532/Pn532.cs
@@ -575,12 +575,14 @@ namespace Iot.Device.Pn532
                     nfcId[i] = toDecode[5 + i];
                 }
 
-                if ((5 + nfcId.Length) > toDecode.Length)
+                if ((5 + nfcId.Length) < toDecode.Length)
                 {
+                    // The first byte of the ATS is the length,
+                    // which includes itself.
                     ats = new byte[toDecode[5 + nfcId.Length]];
                     for (int i = 0; i < ats.Length; i++)
                     {
-                        ats[i] = toDecode[6 + nfcId.Length + i];
+                        ats[i] = toDecode[5 + nfcId.Length + i];
                     }
                 }
 


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->
The PN532 will return the ATS for a ISO 14443-4 card, but the existing logic in `PN532.TryDecode106kbpsTypeA` does not decode it. As noted in issue #2346, the length check has the wrong sense. Also, as per ISO 14443-4 (section 5.2) the ATS includes the length byte, the value of which includes itself. 

Tested with an ISO 14443-4 card - the ATS is decoded.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2347)