### PR TITLE
Fix GrovePi binding timing issue when read sensors

### DIFF
--- a/src/devices/GrovePi/GrovePi.cs
+++ b/src/devices/GrovePi/GrovePi.cs
@@ -17,7 +17,7 @@ namespace Iot.Device.GrovePiDevice
     /// </summary>
     public class GrovePi : IDisposable
     {
-        private const byte MaxRetries = 4;
+        private const byte MaxRetries = 10;
         private readonly bool _shouldDispose;
         private I2cDevice _i2cDevice;
 

--- a/src/devices/GrovePi/GrovePi.cs
+++ b/src/devices/GrovePi/GrovePi.cs
@@ -175,20 +175,13 @@ namespace Iot.Device.GrovePiDevice
         public PinValue DigitalRead(GrovePort pin)
         {
             WriteCommand(GrovePiCommand.DigitalRead, pin, 0, 0);
-            try
-            {
-                var data = ReadCommand(GrovePiCommand.DigitalRead, pin);
-                if (data is null || data.Length < 2)
-                {
-                    return (PinValue)(-1);
-                }
-
-                return (PinValue)data[1];
-            }
-            catch (IOException)
+            var data = ReadCommand(GrovePiCommand.DigitalRead, pin);
+            if (data is null || data.Length < 2)
             {
                 return (PinValue)(-1);
             }
+
+            return (PinValue)data[1];
         }
 
         /// <summary>

--- a/src/devices/GrovePi/GrovePi.cs
+++ b/src/devices/GrovePi/GrovePi.cs
@@ -175,33 +175,20 @@ namespace Iot.Device.GrovePiDevice
         public PinValue DigitalRead(GrovePort pin)
         {
             WriteCommand(GrovePiCommand.DigitalRead, pin, 0, 0);
-            byte tries = 0;
-            IOException? innerEx = null;
-            // When writing/reading to the I2C port, GrovePi doesn't respond on time in some cases
-            // So we wait a little bit before retrying
-            // In most cases, the I2C read/write can go thru without waiting
-            while (tries < MaxRetries)
+            try
             {
-                try
+                var data = ReadCommand(GrovePiCommand.DigitalRead, pin);
+                if (data is null || data.Length < 2)
                 {
-                    var inArray = ReadCommand(GrovePiCommand.DigitalRead, pin);
-                    if (inArray is null || inArray.Length < 2)
-                    {
-                        return (PinValue)(-1);
-                    }
+                    return (PinValue)(-1);
+                }
 
-                    return (PinValue)inArray[1];
-                }
-                catch (IOException ex)
-                {
-                    // Give it another try
-                    innerEx = ex;
-                    tries++;
-                    Thread.Sleep(10);
-                }
+                return (PinValue)data[1];
             }
-
-            throw new IOException($"{nameof(DigitalRead)}: Failed to read byte with command {GrovePiCommand.DigitalRead}", innerEx);
+            catch (IOException)
+            {
+                return (PinValue)(-1);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #2337

## Summary
Fix timing issue in the GrovePi Binding logic for sensor reading.

## Detail
As mentioned in the issue I raised, there is a bug in the current GrovePi Binding that prevents it from correctly reading sensor values on the Raspberry Pi 4. To fix this bug, I have modified the code to wait and retry when an invalid response is received from the device. Additionally, I've standardized the implementation of the `DigitalRead` method with other sensor readings so that it can also benefit from this bug fix.

## Validation
I have confirmed that the changes in this PR work as intended by testing with sample code from the GrovePi directory. I connected a button, potentiometer, relay, ultrasonic distance sensor, and temperature & humidity sensor to both Raspberry Pi 3 and 4.

![IMG_20241023_163606](https://github.com/user-attachments/assets/c8d0fa89-b1b6-4ae2-a3d6-166e91ea7a31)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2359)