### PR TITLE
FTx: Invert Data and direction position when setting up outputs for SPI mode

### DIFF
--- a/src/devices/Ft232H/Ftx232HDevice.cs
+++ b/src/devices/Ft232H/Ftx232HDevice.cs
@@ -784,8 +784,8 @@ namespace Iot.Device.FtCommon
             GpioLowDir = (byte)((GpioLowDir & MaskGpio) | 0x03);
             // clock, MOSI and MISO to 0
             GpioLowData = (byte)(GpioLowData & MaskGpio);
-            toSend[idx++] = GpioLowDir;
             toSend[idx++] = GpioLowData;
+            toSend[idx++] = GpioLowDir;
             // The SK clock frequency can be worked out by below algorithm with divide by 5 set as off
             // TCK period = 60MHz / (( 1 + [ (0xValueH * 256) OR 0xValueL] ) * 2)
             // Command to set clock divisor


### PR DESCRIPTION
The opcode specification says that data comes before direction. The current code prevents the clock pin from outputting the clock signal.

I've tested with a FT232H and the previous version made PIN D0 output a constant 3.3v signal. With the changes it outputs the clock signal

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2362)