### PR TITLE
Use RandomNumberGenerator.Fill in Credit Card code

### DIFF
--- a/src/devices/Card/CreditCard/CreditCard.cs
+++ b/src/devices/Card/CreditCard/CreditCard.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using Iot.Device.Common;
 using Microsoft.Extensions.Logging;
@@ -454,8 +455,7 @@ namespace Iot.Device.Card.CreditCardProcessing
                                 // 0x9F37 Unpredictable number
                                 else if (dol.TagNumber == 0x9F37)
                                 {
-                                    var rand = new Random();
-                                    rand.NextBytes(toSend.Slice(index, dol.Data[0]));
+                                    RandomNumberGenerator.Fill(toSend.Slice(index, dol.Data[0]));
                                 }
 
                                 // Currency


### PR DESCRIPTION
Note that this PR will fail until https://github.com/dotnet/iot/pull/2355 is merged and it doesn't seems worth to ifdef or use alternative API at this point.

Since this code is relying on randomness we should use the proper randomness here. Also that code analyzers don't complain about it :-)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2377)