### PR TITLE
fixed URL on  Iot.Device.Bindings nuget readme

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
     "MD013": false,
-    "MD033": false
+    "MD033": false,
+    "MD059": false
 }

--- a/src/devices/README-nuget.md
+++ b/src/devices/README-nuget.md
@@ -1,12 +1,12 @@
 # Device Bindings
 
-You will find a large variety of bindings in this nuget. You can [check the list on the repository](https://https://github.com/dotnet/iot/tree/main/src/devices).
+You will find a large variety of bindings in this nuget. You can [check the list on the repository](https://github.com/dotnet/iot/tree/main/src/devices).
 
 ## Getting started
 
 Once you've installed the nuget, you're ready to go! Make sure you have a proper device that support GPIO. See the System.Device.
 
-Each binding has [detailed example](https://https://github.com/dotnet/iot/tree/main/src/devices) in the main repository. Each directory will contain a detailed README with the specific usage of each binding. It will also in the `/samples` folder contains a detailed and commented example.
+Each binding has [detailed example](https://github.com/dotnet/iot/tree/main/src/devices) in the main repository. Each directory will contain a detailed README with the specific usage of each binding. It will also in the `/samples` folder contains a detailed and commented example.
 
 ## Hardware requirements
 


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->
I noticed that the first 2 urls where broken on https://www.nuget.org/packages/Iot.Device.Bindings and saw that there were 2 https:// 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2402)