### PR TITLE
Fixes #2404 - Execute interrupt handler for all 8 pins

### DIFF
--- a/src/devices/Mcp23xxx/Mcp23xxx.cs
+++ b/src/devices/Mcp23xxx/Mcp23xxx.cs
@@ -746,7 +746,7 @@ namespace Iot.Device.Mcp23xxx
             int mask = 1;
             int pin = 0;
 
-            while (mask < 0x10)
+            while (mask <= 0xF0)
             {
                 if ((interruptPending & mask) != 0)
                 {


### PR DESCRIPTION
Check all 8 pins if the mask is matching the pending interrupts