### PR TITLE
Use only one interrup callback for one chip.

### DIFF
--- a/src/devices/Tca955x/README.md
+++ b/src/devices/Tca955x/README.md
@@ -13,7 +13,7 @@ The family contains the TCA9554 (8-bit) and the TCA9555 (16-bit) device. Both de
 
 ## Interrupt support
 
-The `Tca955x` has one interrupt pin. The corresponding pins need to be connected to a master GPIO controller for this feature to work. You can use a GPIO controller around the MCP device to handle everything for you:
+The `Tca955x` has one interrupt pin. The corresponding pins need to be connected to a master GPIO controller for this feature to work. You can use a GPIO controller around the Tca955x device to handle everything for you:
 
 ```csharp
 // Gpio controller from parent device (eg. Raspberry Pi)

--- a/src/devices/Tca955x/Tca955x.cs
+++ b/src/devices/Tca955x/Tca955x.cs
@@ -168,7 +168,7 @@ namespace Iot.Device.Tca955x
             {
                 if (mode != PinMode.Input && mode != PinMode.Output && mode != PinMode.InputPullUp)
                 {
-                    throw new ArgumentException("The Mcp controller supports the following pin modes: Input, Output and InputPullUp.");
+                    throw new ArgumentException("The Tca955x controller supports the following pin modes: Input, Output and InputPullUp.");
                 }
 
                 byte polarityInversionRegister = GetRegisterIndex(pinNumber, Register.PolarityInversionPort);
@@ -434,7 +434,12 @@ namespace Iot.Device.Tca955x
 
             _interruptPins.Add(pinNumber, eventType);
             _interruptLastInputValues.Add(pinNumber, Read(pinNumber));
-            _controller.RegisterCallbackForPinValueChangedEvent(_interrupt, PinEventTypes.Falling, InterruptHandler);
+
+            // Only register the callback if this is the first add callback
+            if (_interruptPins.Count == 1)
+            {
+                _controller.RegisterCallbackForPinValueChangedEvent(_interrupt, PinEventTypes.Falling, InterruptHandler);
+            }
 
             _eventHandlers[pinNumber] = callback;
         }
@@ -452,7 +457,12 @@ namespace Iot.Device.Tca955x
             {
                 _interruptPins.Remove(pinNumber);
                 _interruptLastInputValues.Remove(pinNumber);
-                _controller.UnregisterCallbackForPinValueChangedEvent(_interrupt, InterruptHandler);
+
+                // Only remove interrup callback if there are no more interrup pins active
+                if (_interruptPins.Count == 0)
+                {
+                    _controller.UnregisterCallbackForPinValueChangedEvent(_interrupt, InterruptHandler);
+                }
             }
         }
 


### PR DESCRIPTION
Prevent multiple callbacks on the interrupt pin. Only use one inpterrupt callback.
Fixing typos.
Code is test with a Tca9555 and Tca9554