### PR TITLE
Add kernel timestamp support

### DIFF
--- a/src/devices/SocketCan/CanRaw.cs
+++ b/src/devices/SocketCan/CanRaw.cs
@@ -125,7 +125,7 @@ namespace Iot.Device.SocketCan
         /// <param name="id">Recipient identifier</param>
         /// <param name="timestamp">UTC time when this frame was received with microsecond resolution</param>
         /// <returns></returns>
-        public bool TryReadFrame(Span<byte> data, out int frameLength, out CanId id, out DateTime timestamp)
+        public bool TryReadFrame(Span<byte> data, out int frameLength, out CanId id, out DateTimeOffset timestamp)
         {
             bool ret = TryReadFrame(data, out frameLength, out id);
             timestamp = Interop.GetLastTimeStamp(_handle);

--- a/src/devices/SocketCan/Interop.cs
+++ b/src/devices/SocketCan/Interop.cs
@@ -152,7 +152,7 @@ namespace Iot.Device.SocketCan
             return ifr.ifr_ifindex;
         }
 
-        public static unsafe DateTime GetLastTimeStamp(SafeHandle handle)
+        public static unsafe DateTimeOffset GetLastTimeStamp(SafeHandle handle)
         {
             // From Linux 6.12.33+deb13-amd64 x86_64
             const uint SIOCGSTAMP = 0x8906;
@@ -164,11 +164,8 @@ namespace Iot.Device.SocketCan
                 throw new IOException("Could not get socketcan timestamp");
             }
 
-            DateTime dt_utc = DateTimeOffset.FromUnixTimeSeconds(tv.tv_sec)
-                            .AddTicks(tv.tv_usec * 10) // 1 tick = 100 ns
-                            .UtcDateTime;
-
-            return dt_utc;  // UtcDateTime
+            // tv_usec is in [us]. DateTimeOffset in ticks of [100 ns], that's why * 10 is needed
+            return DateTimeOffset.FromUnixTimeSeconds(tv.tv_sec).AddTicks(tv.tv_usec * 10);
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/devices/SocketCan/samples/Program.cs
+++ b/src/devices/SocketCan/samples/Program.cs
@@ -74,7 +74,7 @@ void ReceiveAllExample()
 
     while (true)
     {
-        if (can.TryReadFrame(buffer, out int frameLength, out CanId id, out DateTime ts))
+        if (can.TryReadFrame(buffer, out int frameLength, out CanId id, out DateTimeOffset ts))
         {
             Span<byte> data = new Span<byte>(buffer, 0, frameLength);
             string type = id.ExtendedFrameFormat ? "EFF" : "SFF";


### PR DESCRIPTION
The linux kernel provides high resolution timestamps for received CAN frames. 

This pull requests adds `CanRaw.GetLastTimeStamp()` to retrieve the timestamp of the last read frame.

The timestamp is in micro-seconds unix time.

Tested with linux virtual CAN device (no hardware needed).

```bash
# Add virtual CAN interface called `vcan0`
sudo ip link add dev vcan0 type vcan
sudo ip link set up vcan0

dotnet run --project src/devices/SocketCan/samples/SocketCan.Samples.csproj receive vcan0

# in another window
cansend vcan0 123#DEADBEEF

# Send 10 packets back to back
for i in {1..10}; do cansend vcan0 123#DEADBEEF; done

# Console output
  Can.Samples.csproj receive vcan0
  Listening for any id
  Ts: 2025-08-24T17:59:17.9521580Z Id: 0x123 [SFF]: DEADBEEF
  Ts: 2025-08-24T17:59:18.2795050Z Id: 0x123 [SFF]: DEADBEEF
  Ts: 2025-08-24T17:59:19.2140580Z Id: 0x123 [SFF]: DEADBEEF
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2412)