### PR TITLE
Fixes #2415 - Testing construction for null in libgpioddriver

### DIFF
--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/V1/LineHandle.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/V1/LineHandle.cs
@@ -31,10 +31,6 @@ internal sealed class LineHandle : IDisposable
 
             return _handle;
         }
-        set
-        {
-            _handle = value;
-        }
     }
 
     /// <summary>

--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/V1/LineHandle.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/V1/LineHandle.cs
@@ -14,6 +14,11 @@ internal sealed class LineHandle : IDisposable
     private IntPtr _handle;
     public LineHandle(IntPtr handle)
     {
+        if (handle == IntPtr.Zero)
+        {
+            throw ExceptionHelper.GetIOException(ExceptionResource.OpenPinError, Marshal.GetLastWin32Error());
+        }
+
         _handle = handle;
         PinMode = PinMode.Input;
     }
@@ -42,13 +47,11 @@ internal sealed class LineHandle : IDisposable
         Interop.LibgpiodV1.gpiod_line_release(_handle);
     }
 
-    public bool IsInvalid => _handle == IntPtr.Zero || _handle == Interop.LibgpiodV1.InvalidHandleValue;
-
     public void Dispose()
     {
         if (_handle != IntPtr.Zero)
         {
-            Interop.LibgpiodV1.gpiod_line_release(_handle);
+            ReleaseLock();
             _handle = IntPtr.Zero;
         }
     }

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
@@ -238,13 +238,7 @@ public class LibGpiodDriver : UnixDriver
                 return;
             }
 
-            IntPtr rawHandle = LibgpiodV1.gpiod_chip_get_line(_chip, pinNumber);
-            if (rawHandle == IntPtr.Zero)
-            {
-                throw ExceptionHelper.GetIOException(ExceptionResource.OpenPinError, Marshal.GetLastWin32Error());
-            }
-
-            LineHandle pinHandle = new LineHandle(rawHandle);
+            LineHandle pinHandle = new LineHandle(LibgpiodV1.gpiod_chip_get_line(_chip, pinNumber));
 
             int mode = LibgpiodV1.gpiod_line_direction(pinHandle.Handle);
             if (mode == 1)

--- a/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/Drivers/LibGpiodDriver.cs
@@ -238,11 +238,13 @@ public class LibGpiodDriver : UnixDriver
                 return;
             }
 
-            LineHandle pinHandle = new LineHandle(LibgpiodV1.gpiod_chip_get_line(_chip, pinNumber));
-            if (pinHandle == null)
+            IntPtr rawHandle = LibgpiodV1.gpiod_chip_get_line(_chip, pinNumber);
+            if (rawHandle == IntPtr.Zero)
             {
                 throw ExceptionHelper.GetIOException(ExceptionResource.OpenPinError, Marshal.GetLastWin32Error());
             }
+
+            LineHandle pinHandle = new LineHandle(rawHandle);
 
             int mode = LibgpiodV1.gpiod_line_direction(pinHandle.Handle);
             if (mode == 1)


### PR DESCRIPTION
fixes #2415

Now checking for IntPtr.Zero which was probably the original intention.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2418)