### PR TITLE
Improve tca955x driver - (and add block GPIO access)

### DIFF
--- a/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/GpioController.cs
@@ -31,6 +31,7 @@ public class GpioController : IDisposable
     /// </summary>
     private readonly ConcurrentDictionary<int, PinValue?> _openPins;
     private readonly ConcurrentDictionary<int, GpioPin> _gpioPins;
+    private readonly bool _driverHasBlockAccess = false; // Cache the block access capability. Doing it this was trades one bool of memory for a little performance gain.
     private GpioDriver _driver;
 
     /// <summary>
@@ -50,6 +51,10 @@ public class GpioController : IDisposable
     public GpioController(GpioDriver driver)
     {
         _driver = driver;
+        if (_driver is IGpioDriverBlockAccess)
+        {
+            _driverHasBlockAccess = true;
+        }
 
 #pragma warning disable CS0612 // PinNumberingScheme is obsolete
         NumberingScheme = PinNumberingScheme.Logical;
@@ -464,9 +469,16 @@ public class GpioController : IDisposable
     /// <param name="pinValuePairs">The pin/value pairs to write.</param>
     public void Write(ReadOnlySpan<PinValuePair> pinValuePairs)
     {
-        for (int i = 0; i < pinValuePairs.Length; i++)
+        if (_driverHasBlockAccess)
         {
-            Write(pinValuePairs[i].PinNumber, pinValuePairs[i].PinValue);
+            ((IGpioDriverBlockAccess)_driver).Write(pinValuePairs);
+        }
+        else
+        {
+            for (int i = 0; i < pinValuePairs.Length; i++)
+            {
+                Write(pinValuePairs[i].PinNumber, pinValuePairs[i].PinValue);
+            }
         }
     }
 
@@ -476,10 +488,17 @@ public class GpioController : IDisposable
     /// <param name="pinValuePairs">The pin/value pairs to read.</param>
     public void Read(Span<PinValuePair> pinValuePairs)
     {
-        for (int i = 0; i < pinValuePairs.Length; i++)
+        if (_driverHasBlockAccess)
         {
-            int pin = pinValuePairs[i].PinNumber;
-            pinValuePairs[i] = new PinValuePair(pin, Read(pin));
+            ((IGpioDriverBlockAccess)_driver).Read(pinValuePairs);
+        }
+        else
+        {
+            for (int i = 0; i < pinValuePairs.Length; i++)
+            {
+                int pin = pinValuePairs[i].PinNumber;
+                pinValuePairs[i] = new PinValuePair(pin, Read(pin));
+            }
         }
     }
 

--- a/src/System.Device.Gpio/System/Device/Gpio/IGpioDriverBlockAccess.cs
+++ b/src/System.Device.Gpio/System/Device/Gpio/IGpioDriverBlockAccess.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Device.Gpio
+{
+    /// <summary>
+    /// Interface to mark drivers that support block access to GPIO pins.
+    /// Block access in this case meaning the ability to read/write multiple pins in one call.
+    /// </summary>
+    public interface IGpioDriverBlockAccess
+    {
+        /// <summary>
+        /// Write the given pins with the given values.
+        /// </summary>
+        /// <param name="pinValuePairs">The pin/value pairs to write.</param>
+        public void Write(ReadOnlySpan<PinValuePair> pinValuePairs);
+
+        /// <summary>
+        /// Read the given pins with the given pin numbers.
+        /// </summary>
+        /// <param name="pinValuePairs">The pin/value pairs to read.</param>
+        public void Read(Span<PinValuePair> pinValuePairs);
+    }
+}

--- a/src/devices/Tca955x/README.md
+++ b/src/devices/Tca955x/README.md
@@ -18,7 +18,7 @@ The `Tca955x` has one interrupt pin. The corresponding pins need to be connected
 ```csharp
 // Gpio controller from parent device (eg. Raspberry Pi)
 _gpioController = new GpioController();
-_i2c = I2cDevice.Create(new I2cConnectionSettings(1, Tca955x.DefaultI2cAdress));
+_i2c = I2cDevice.Create(new I2cConnectionSettings(1, Tca955x.DefaultI2cAddress));
 // The "Interrupt" line of the TCA9554 is connected to GPIO input 11 of the Raspi
 _device = new Tca9554(_i2c, 11, _gpioController, false);
 GpioController theDeviceController = new GpioController(_device);

--- a/src/devices/Tca955x/Register.cs
+++ b/src/devices/Tca955x/Register.cs
@@ -9,23 +9,23 @@ namespace Iot.Device.Tca955x
     public enum Register
     {
         /// <summary>
-        /// Register Adress for the Inputs P0 - P7
+        /// Register Address for the Inputs P0 - P7
         /// Only Read Allowed on this Register
         /// </summary>
         InputPort = 0x00,
 
         /// <summary>
-        /// Register Adress for the Outputs P0 - P7
+        /// Register Address for the Outputs P0 - P7
         /// </summary>
         OutputPort = 0x01,
 
         /// <summary>
-        /// Register Adress for the Polarity Inversion P0 - P7
+        /// Register Address for the Polarity Inversion P0 - P7
         /// </summary>
         PolarityInversionPort = 0x02,
 
         /// <summary>
-        /// Register Adress for the Configuration P0 - P7
+        /// Register Address for the Configuration P0 - P7
         /// </summary>
         ConfigurationPort = 0x03,
     }

--- a/src/devices/Tca955x/Tca9554.cs
+++ b/src/devices/Tca955x/Tca9554.cs
@@ -17,7 +17,7 @@ namespace Iot.Device.Tca955x
         /// <param name="device">The I2C device used for communication</param>
         /// <param name="interrupt">The input pin number that is connected to the interrupt.</param>
         /// <param name="gpioController">The controller for the reset and interrupt pins. If not specified, the default controller will be used.</param>
-        /// <param name="shouldDispose">True to dispose the Gpio Controller.</param>
+        /// <param name="shouldDispose">True to dispose the <paramref name="gpioController"/> when this object is disposed</param>
         public Tca9554(I2cDevice device, int interrupt = -1, GpioController? gpioController = null, bool shouldDispose = true)
             : base(device, interrupt, gpioController, shouldDispose)
         {

--- a/src/devices/Tca955x/Tca9555.cs
+++ b/src/devices/Tca955x/Tca9555.cs
@@ -15,10 +15,10 @@ namespace Iot.Device.Tca955x
         /// <summary>
         /// Constructor for the Tca9555 I2C I/O Expander.
         /// </summary>
-        /// <param name="device">The I2C Device the device is connected to. Expect an I2C Adress between 0x20 and 0x27</param>
+        /// <param name="device">The I2C Device the device is connected to. Expect an I2C Address between 0x20 and 0x27</param>
         /// <param name="interrupt">The input pin number that is connected to the interrupt.</param>
         /// <param name="gpioController">The controller for the reset and interrupt pins. If not specified, the default controller will be used.</param>
-        /// <param name="shouldDispose">True to dispose the Gpio Controller.</param>
+        /// <param name="shouldDispose">True to dispose the <paramref name="gpioController"/> when this object is disposed</param>
         public Tca9555(I2cDevice device, int interrupt = -1, GpioController? gpioController = null, bool shouldDispose = true)
             : base(device, interrupt, gpioController, shouldDispose)
         {
@@ -92,7 +92,7 @@ namespace Iot.Device.Tca955x
         /// Read a byte from the given Register.
         /// </summary>
         /// <param name="register">The given Register.</param>
-        /// <returns>The readed byte from the Register.</returns>
+        /// <returns>The byte read from the Register.</returns>
         public byte ReadByte(Tca9555Register register) => InternalReadByte((byte)register);
     }
 }

--- a/src/devices/Tca955x/Tca9555Register.cs
+++ b/src/devices/Tca955x/Tca9555Register.cs
@@ -9,44 +9,44 @@ namespace Iot.Device.Tca955x
     public enum Tca9555Register
     {
         /// <summary>
-        /// Register Adress for the Inputs P00 - P07
+        /// Register Address for the Inputs P00 - P07
         /// Only Read Allowed on this Register
         /// </summary>
         InputPort0 = 0x00,
 
         /// <summary>
-        /// Register Adress for the Inputs P10 - P17
+        /// Register Address for the Inputs P10 - P17
         /// Only Read Allowed on this Register
         /// </summary>
         InputPort1 = 0x01,
 
         /// <summary>
-        /// Register Adress for the Outputs P00 - P07
+        /// Register Address for the Outputs P00 - P07
         /// </summary>
         OutputPort0 = 0x02,
 
         /// <summary>
-        /// Register Adress for the Outputs P10 - P17
+        /// Register Address for the Outputs P10 - P17
         /// </summary>
         OutputPort1 = 0x03,
 
         /// <summary>
-        /// Register Adress for the Polarity Inversion P00 - P07
+        /// Register Address for the Polarity Inversion P00 - P07
         /// </summary>
         PolarityInversionPort0 = 0x04,
 
         /// <summary>
-        /// Register Adress for the Polarity Inversion P10 - P17
+        /// Register Address for the Polarity Inversion P10 - P17
         /// </summary>
         PolarityInversionPort1 = 0x05,
 
         /// <summary>
-        /// Register Adress for the Configuration P00 - P07
+        /// Register Address for the Configuration P00 - P07
         /// </summary>
         ConfigurationPort0 = 0x06,
 
         /// <summary>
-        /// Register Adress for the Configuration P10 - P17
+        /// Register Address for the Configuration P10 - P17
         /// </summary>
         ConfigurationPort1 = 0x06,
     }

--- a/src/devices/Tca955x/Tca955x.cs
+++ b/src/devices/Tca955x/Tca955x.cs
@@ -129,21 +129,6 @@ namespace Iot.Device.Tca955x
         /// </summary>
         public void WriteByte(byte register, byte value) => InternalWriteByte(register, value);
 
-        /// <inheritdoc/>
-        protected override void Dispose(bool disposing)
-        {
-            if (_shouldDispose)
-            {
-                _controller?.Dispose();
-                _controller = null;
-            }
-
-            _pinValues.Clear();
-            _busDevice?.Dispose();
-            _busDevice = null!;
-            base.Dispose(disposing);
-        }
-
         /// <summary>
         /// Returns the value of the interrupt pin if configured
         /// </summary>
@@ -574,6 +559,27 @@ namespace Iot.Device.Tca955x
         protected override bool IsPinModeSupported(int pinNumber, PinMode mode) =>
             (mode == PinMode.Input || mode == PinMode.Output || mode == PinMode.InputPullUp);
 
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (_shouldDispose)
+            {
+                _controller?.Dispose();
+                _controller = null;
+            }
+            else
+            {
+                // We don't own the interrupt controller, so we must unregister our interrupt handler
+                if (_controller != null && _interrupt != -1)
+                {
+                    _controller.UnregisterCallbackForPinValueChangedEvent(_interrupt, InterruptHandler);
+                }
+            }
+
+            _busDevice?.Dispose();
+
+            base.Dispose(true);
+        }
     }
 
 }

--- a/src/devices/Tca955x/samples/Tca955x.Sample.cs
+++ b/src/devices/Tca955x/samples/Tca955x.Sample.cs
@@ -31,7 +31,7 @@ tca9554.WriteByte(Register.OutputPort, 0xF0);
 // Create an GPIO Controller where the Interrupt Pin connected is.
 GpioController controller = new GpioController();
 
-I2cConnectionSettings i2cConnectionSettings_tca9555 = new(1, Tca955x.DefaultI2cAdress);
+I2cConnectionSettings i2cConnectionSettings_tca9555 = new(1, Tca955x.DefaultI2cAddress);
 I2cDevice i2cDevice_tca9555 = I2cDevice.Create(i2cConnectionSettings_tca9555);
 var tca9555 = new Tca9555(i2cDevice_tca9555, 4);
 // Create an GPIO Controller which represent the TCA9554

--- a/src/devices/Tca955x/tests/Tca9554Tests.cs
+++ b/src/devices/Tca955x/tests/Tca9554Tests.cs
@@ -74,8 +74,8 @@ namespace Iot.Device.Tca955x.Tests
             pin0.Dispose();
             Assert.False(tcaController.IsPinOpen(0));
         }
-        
-                [Fact]
+
+        [Fact]
         public void InterruptCallbackIsInvokedOnPinChange()
         {
             // Arrange
@@ -127,39 +127,6 @@ namespace Iot.Device.Tca955x.Tests
             Assert.NotNull(pin0);
             Assert.True(tcaController.IsPinOpen(0));
             Assert.Throws<ArgumentOutOfRangeException>(() => tcaController.Read(new Span<PinValuePair>(new PinValuePair[] { new(9, PinValue.Low) })));
-            tcaController.OpenPin(1, PinMode.Input);
-            bool callbackInvoked = false;
-            PinValueChangedEventArgs? receivedArgs = null;
-
-            void Callback(object sender, PinValueChangedEventArgs args)
-            {
-                callbackInvoked = true;
-                receivedArgs = args;
-            }
-
-            // Change the device setup to simulate pin1 as high
-            _device.Setup(x => x.Read(It.IsAny<byte[]>())).Callback((byte[] b) =>
-            {
-                b[0] = 0x02;
-            });
-
-            // Register callback for rising edge
-            tcaController.RegisterCallbackForPinValueChangedEvent(1, PinEventTypes.Falling, Callback);
-
-            // Change the device setup to simulate pin1 as low.
-            _device.Setup(x => x.Read(It.IsAny<byte[]>())).Callback((byte[] b) =>
-            {
-                b[0] = 0x00;
-            });
-
-            // Simulate the hardware int pin pin change using the _controller mock
-            _driver.Object.FireEventHandler(interruptPin, PinEventTypes.Rising);
-
-            // Assert
-            Assert.True(callbackInvoked);
-            Assert.NotNull(receivedArgs);
-            Assert.Equal(1, receivedArgs.PinNumber);
-            Assert.Equal(PinEventTypes.Falling, receivedArgs.ChangeType);
         }
 
         [Fact]

--- a/src/devices/Tca955x/tests/Tca9555Tests.cs
+++ b/src/devices/Tca955x/tests/Tca9555Tests.cs
@@ -10,13 +10,13 @@ using Xunit;
 
 namespace Iot.Device.Tca955x.Tests
 {
-    public class Tca9554Tests
+    public class Tca9555Tests
     {
         private readonly Mock<MockableI2cDevice> _device;
         private readonly GpioController _controller;
         private readonly Mock<MockableGpioDriver> _driver;
 
-        public Tca9554Tests()
+        public Tca9555Tests()
         {
             _device = new Mock<MockableI2cDevice>(MockBehavior.Loose);
             _device.CallBase = true;
@@ -28,7 +28,7 @@ namespace Iot.Device.Tca955x.Tests
         [Fact]
         public void CreateWithInterrupt()
         {
-            var testee = new Tca9554(_device.Object, 10, _controller);
+            var testee = new Tca9555(_device.Object, 10, _controller);
             Assert.NotNull(testee);
         }
 
@@ -51,16 +51,16 @@ namespace Iot.Device.Tca955x.Tests
                 b[0] = 1;
             });
 
-            var testee = new Tca9554(_device.Object, -1);
+            var testee = new Tca9555(_device.Object, -1);
             var tcaController = new GpioController(testee);
-            Assert.Equal(8, tcaController.PinCount);
-            GpioPin pin0 = tcaController.OpenPin(0);
-            Assert.NotNull(pin0);
-            Assert.True(tcaController.IsPinOpen(0));
-            var value = pin0.Read();
+            Assert.Equal(16, tcaController.PinCount);
+            GpioPin pin8 = tcaController.OpenPin(8);
+            Assert.NotNull(pin8);
+            Assert.True(tcaController.IsPinOpen(8));
+            var value = pin8.Read();
             Assert.Equal(PinValue.High, value);
-            pin0.Dispose();
-            Assert.False(tcaController.IsPinOpen(0));
+            pin8.Dispose();
+            Assert.False(tcaController.IsPinOpen(8));
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Iot.Device.Tca955x.Tests
             GpioPin pin0 = tcaController.OpenPin(0);
             Assert.NotNull(pin0);
             Assert.True(tcaController.IsPinOpen(0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => tcaController.Read(new Span<PinValuePair>(new PinValuePair[] { new(9, PinValue.Low) })));
+            Assert.Throws<ArgumentOutOfRangeException>(() => tcaController.Read(new Span<PinValuePair>(new PinValuePair[] { new(16, PinValue.Low) })));
         }
     }
 }


### PR DESCRIPTION
This PR has numerous bug fixes and improvements to the TCA955x driver. 

In particular, the handling of the INT pin on the chip is vastly improved. The event handler for the falling edge on that pin now delegates to a Task. This does the work of reading the chip via i2c and calling any signed up events for the pins of the chip. While all this is going on, if there are any more than one further falling edge of the INT pin, they are ignored. If there is at least one then the check of the chip input registers and event firing is redone at the end. This behaviour prevents blocking the GpioDriver that is servicing the INT pin. Blocking could (especially in the case of libgiod v1) cause a queue up the events and subsequent delivery of them long after the actual inputs on the chip have settled.

The TCA955x driver now just does the one or two reads of the i2c that are needed, when the INT pin asserts, rather than repeating that read for every pin that has an event handler. Similar to this change, the GpioController now does a block read of its GpioDriver if the GpioDriver implementation supports block reads of I/O by implementing IGpioDriverBlockAccess. (This should probably be in a separate PR - sorry about that) 

Other fixes:
Report event type of pin in event rather than reporting the types signed up for.
A few more tests and fixed some redundant/incorrect tests.
Fixed reporting of supported pin types.
Fixed pin type of INT pin to support Input or InputPullup and default to Input.
Improved the block io read/write to reduce i2c traffic
Fixed incorrect register address constant
Spelling improved
