### PR TITLE
TCA955x - making address check optional so this driver can be used with other c…

### DIFF
--- a/src/devices/Tca955x/Tca9554.cs
+++ b/src/devices/Tca955x/Tca9554.cs
@@ -18,8 +18,9 @@ namespace Iot.Device.Tca955x
         /// <param name="interrupt">The input pin number that is connected to the interrupt.</param>
         /// <param name="gpioController">The controller for the reset and interrupt pins. If not specified, the default controller will be used.</param>
         /// <param name="shouldDispose">True to dispose the <paramref name="gpioController"/> when this object is disposed</param>
-        public Tca9554(I2cDevice device, int interrupt = -1, GpioController? gpioController = null, bool shouldDispose = true)
-            : base(device, interrupt, gpioController, shouldDispose)
+        /// <param name="skipAddressCheck">True to skip checking the I2C address is in the valid range for the device. Only set this to true if you are using a compatible device with a different addresss scheme.</param>
+        public Tca9554(I2cDevice device, int interrupt = -1, GpioController? gpioController = null, bool shouldDispose = true, bool skipAddressCheck = false)
+            : base(device, interrupt, gpioController, shouldDispose, skipAddressCheck)
         {
         }
 

--- a/src/devices/Tca955x/Tca9555.cs
+++ b/src/devices/Tca955x/Tca9555.cs
@@ -19,8 +19,9 @@ namespace Iot.Device.Tca955x
         /// <param name="interrupt">The input pin number that is connected to the interrupt.</param>
         /// <param name="gpioController">The controller for the reset and interrupt pins. If not specified, the default controller will be used.</param>
         /// <param name="shouldDispose">True to dispose the <paramref name="gpioController"/> when this object is disposed</param>
-        public Tca9555(I2cDevice device, int interrupt = -1, GpioController? gpioController = null, bool shouldDispose = true)
-            : base(device, interrupt, gpioController, shouldDispose)
+        /// <param name="skipAddressCheck">True to skip checking the I2C address is in the valid range for the device. Only set this to true if you are using a compatible device with a different addresss scheme.</param>
+        public Tca9555(I2cDevice device, int interrupt = -1, GpioController? gpioController = null, bool shouldDispose = true, bool skipAddressCheck = false)
+            : base(device, interrupt, gpioController, shouldDispose, skipAddressCheck)
         {
         }
 

--- a/src/devices/Tca955x/Tca955x.cs
+++ b/src/devices/Tca955x/Tca955x.cs
@@ -69,13 +69,15 @@ namespace Iot.Device.Tca955x
         /// <param name="interrupt">The input pin number that is connected to the interrupt.Must be set together with the <paramref name="gpioController"/></param>
         /// <param name="gpioController">The controller for the interrupt pin. Must be set together with the <paramref name="interrupt"/></param>
         /// <param name="shouldDispose">True to dispose the <paramref name="gpioController"/> when this object is disposed</param>
-        protected Tca955x(I2cDevice device, int interrupt = -1, GpioController? gpioController = null, bool shouldDispose = true)
+        /// <param name="skipAddressCheck">True to skip checking the I2C address is in the valid range for the device. Only set this to true if you are using a compatible device with a different addresss scheme.</param>
+        protected Tca955x(I2cDevice device, int interrupt = -1, GpioController? gpioController = null, bool shouldDispose = true, bool skipAddressCheck = false)
         {
             _busDevice = device;
             _interrupt = interrupt;
 
-            if (_busDevice.ConnectionSettings.DeviceAddress < DefaultI2cAddress ||
-                _busDevice.ConnectionSettings.DeviceAddress > DefaultI2cAddress + AddressRange)
+            if (!skipAddressCheck &&
+                (_busDevice.ConnectionSettings.DeviceAddress < DefaultI2cAddress ||
+                _busDevice.ConnectionSettings.DeviceAddress > DefaultI2cAddress + AddressRange))
             {
                 throw new ArgumentOutOfRangeException(nameof(device), $"Address should be in Range {DefaultI2cAddress} to {DefaultI2cAddress + AddressRange} inclusive");
             }


### PR DESCRIPTION
The Tca955x constructor validates that the address of the passed in i2c device is in the correct range for the Tca955x family. This driver is useful for other register compatible devices that have different addressing schemes. This PR optionally turns off this check so that advanced users can deploy it for other devices.