### PR TITLE
Added to documentation to warn against problem with libgpiod ver <= 1.0

### DIFF
--- a/Documentation/gpio-linux-libgpiod.md
+++ b/Documentation/gpio-linux-libgpiod.md
@@ -40,14 +40,18 @@ for (int i = 0; i < 5; i++)
 
 ## libgpiod version support
 
-Currently (12/23) dotnet-iot supports v0, v1 and v2 of libgpiod.
+Dotnet-iot supports v0, v1 and v2 of libgpiod.
 
 The following table shows which driver supports which library version
 
 | LibGpiodDriverVersion | Libgpiod version (documented) |
 | --------------------- | ----------------------------- |
-| V1                    | 0.x to 1.x                    |
+| V1                    | 0.x to 1.0.x (Partial support)  1.1 - 1.x (Supported)|
 | V2                    | 2.x                           |
+
+NOTE: Due to a [breaking change in the values of enums in the libgpiod](
+https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/commit/?id=783ff2e3c70788cdd1c65cba9ee0398bda5ebcda), only libgpiod versions 1.1 and later can be expected to function reliably with the V1 driver. 
+To check what libgpiod packages you have on a deb based system, use: ``` $apt show libgpiod* ```
 
 ## Choose LibGpiodDriver Version
 


### PR DESCRIPTION
The early libgpiod implementations used default zero based enums. In [this commit ](https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/commit/?id=783ff2e3c70788cdd1c65cba9ee0398bda5ebcda) they changed to explicit valued 1 based enums. The dotnet versions of the enums use the 1 based scheme. There is no way to easily detect which scheme is in use, and it is not a priority as most platforms will be running more recent code.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2426)