### PR TITLE
Fix typo in GrovePi README

### DIFF
--- a/src/devices/GrovePi/README.md
+++ b/src/devices/GrovePi/README.md
@@ -100,7 +100,7 @@ Note that Analogic pins can be used for both analogic and digital sensors. In ca
 
 ## How to use the high level classes
 
-There are high level classes to handle directly sensors like analogic sensors, buzzers, leds, buttons. All the sensors are using only 1 pin out of the 2 available. There is nothing presenting you to use the 2 pins if you have a sensor using 2 pins. Just make sue you won't use the adjacent Grove plug in this case.
+There are high level classes to handle directly sensors like analogic sensors, buzzers, leds, buttons. All the sensors are using only 1 pin out of the 2 available. There is nothing presenting you to use the 2 pins if you have a sensor using 2 pins. Just make sure you won't use the adjacent Grove plug in this case.
 
 Using the sensor classes is straight forward. Just reference a class and initialized it. Access properties which are common to all sensors, ```Value``` and ```ToString()```.
 


### PR DESCRIPTION
fix typo `sue` to `sure`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2443)