### PR TITLE
Update .NET SDK version to 9.0.3xx in Azure Pipelines configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,9 +182,9 @@ stages:
       displayName: Download build artifacts
 
     - task: UseDotNet@2
-      displayName: 'Use .NET SDK 9.0.3xx'
+      displayName: 'Use .NET SDK 9.x'
       inputs:
-        version: 9.0.3xx
+        version: 9.x
 
     # Install the code signing tool
     - task: DotNetCoreCLI@2


### PR DESCRIPTION
This pull request updates the .NET SDK version used in the build pipeline to ensure compatibility with the latest features and dependencies.

Build pipeline update:

* Updated the `UseDotNet@2` task in `azure-pipelines.yml` to use .NET SDK version `9.0.3xx` instead of `8.x`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2447)