### PR TITLE
Fix issues in Tca95xx Driver. Output cache not initialised and Uneede…

### DIFF
--- a/src/devices/Tca955x/Tca955x.cs
+++ b/src/devices/Tca955x/Tca955x.cs
@@ -116,6 +116,11 @@ namespace Iot.Device.Tca955x
                 // This is only be done once as there is only one INT pin interrupt for the entire ioexpander
                 _controller.RegisterCallbackForPinValueChangedEvent(_interrupt, PinEventTypes.Falling, InterruptHandler);
             }
+
+            // Initialize the output cache by reading the current output register values
+            Span<byte> outputRegisters = stackalloc byte[2];
+            InternalRead(GetRegisterIndex(0, Register.OutputPort), outputRegisters);
+            _gpioOutputCache = (ushort)(outputRegisters[0] | (outputRegisters[1] << 8));
         }
 
         /// <summary>
@@ -653,14 +658,6 @@ namespace Iot.Device.Tca955x
             {
                 _controller?.Dispose();
                 _controller = null;
-            }
-            else
-            {
-                // We don't own the interrupt controller, so we must unregister our interrupt handler
-                if (_controller != null && _interrupt != -1)
-                {
-                    _controller.UnregisterCallbackForPinValueChangedEvent(_interrupt, InterruptHandler);
-                }
             }
 
             _busDevice?.Dispose();


### PR DESCRIPTION
Because the output cache was not initialised it could get out of sync if the application was restarted but the chip was not reset.

The deregister in the destructor was not needed as it was already done regardless.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2470)