### PR TITLE
Pressure to altitude conversion fixed

### DIFF
--- a/src/Iot.Device.Bindings/CompatibilitySuppressions.xml
+++ b/src/Iot.Device.Bindings/CompatibilitySuppressions.xml
@@ -24,6 +24,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Iot.Device.Common.WeatherHelper.CalculateAltitude(UnitsNet.Pressure,UnitsNet.Temperature)</Target>
+    <Left>lib/net8.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net8.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Iot.Device.Nmea0183.Ais.TrackEstimationParameters.get_WarningDistance</Target>
     <Left>lib/net8.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/net8.0/Iot.Device.Bindings.dll</Right>

--- a/src/Iot.Device.Bindings/CompatibilitySuppressions.xml
+++ b/src/Iot.Device.Bindings/CompatibilitySuppressions.xml
@@ -3,6 +3,13 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Iot.Device.Common.WeatherHelper.MeanSeaLevel</Target>
+    <Left>lib/net8.0/Iot.Device.Bindings.dll</Left>
+    <Right>lib/net8.0/Iot.Device.Bindings.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Iot.Device.Tca955x.Tca955x.DefaultI2cAdress</Target>
     <Left>lib/net8.0/Iot.Device.Bindings.dll</Left>
     <Right>lib/net8.0/Iot.Device.Bindings.dll</Right>

--- a/src/devices/Bmp180/Bmp180.cs
+++ b/src/devices/Bmp180/Bmp180.cs
@@ -98,7 +98,7 @@ namespace Iot.Device.Bmp180
         /// <returns>
         ///  Height in meters above sea level
         /// </returns>
-        public Length ReadAltitude() => ReadAltitude(WeatherHelper.MeanSeaLevel);
+        public Length ReadAltitude() => ReadAltitude(WeatherHelper.MeanSeaLevelPressure);
 
         /// <summary>
         ///  Calculates the pressure at sea level when given a known altitude

--- a/src/devices/Bmp180/samples/Program.cs
+++ b/src/devices/Bmp180/samples/Program.cs
@@ -27,8 +27,8 @@ Pressure preValue = i2cBmp280.ReadPressure();
 Console.WriteLine($"Pressure: {preValue.Hectopascals:0.##}hPa");
 
 // Note that if you already have the pressure value and the temperature, you could also calculate altitude by
-// calling WeatherHelper.CalculateAltitude(preValue, Pressure.MeanSeaLevel, tempValue) which would be more performant.
-Length altValue = i2cBmp280.ReadAltitude(WeatherHelper.MeanSeaLevel);
+// calling WeatherHelper.CalculateAltitude(preValue, WeatherHelper.MeanSeaLevelPressure, tempValue) which would be more performant.
+Length altValue = i2cBmp280.ReadAltitude(WeatherHelper.MeanSeaLevelPressure);
 
 Console.WriteLine($"Altitude: {altValue:0.##}m");
 Thread.Sleep(1000);
@@ -43,6 +43,6 @@ preValue = i2cBmp280.ReadPressure();
 Console.WriteLine($"Pressure: {preValue.Hectopascals:0.##}hPa");
 
 // Note that if you already have the pressure value and the temperature, you could also calculate altitude by
-// calling WeatherHelper.CalculateAltitude(preValue, Pressure.MeanSeaLevel, tempValue) which would be more performant.
-altValue = i2cBmp280.ReadAltitude(WeatherHelper.MeanSeaLevel);
+// calling WeatherHelper.CalculateAltitude(preValue, WeatherHelper.MeanSeaLevelPressure, tempValue) which would be more performant.
+altValue = i2cBmp280.ReadAltitude(WeatherHelper.MeanSeaLevelPressure);
 Console.WriteLine($"Altitude: {altValue:0.##}m");

--- a/src/devices/Bmxx80/Bmx280Base.cs
+++ b/src/devices/Bmxx80/Bmx280Base.cs
@@ -176,7 +176,7 @@ namespace Iot.Device.Bmxx80
         /// Contains <see cref="double.NaN"/> otherwise.
         /// </param>
         /// <returns><code>true</code> if pressure measurement was not skipped, otherwise <code>false</code>.</returns>
-        public bool TryReadAltitude(out Length altitude) => TryReadAltitude(WeatherHelper.MeanSeaLevel, out altitude);
+        public bool TryReadAltitude(out Length altitude) => TryReadAltitude(WeatherHelper.MeanSeaLevelPressure, out altitude);
 
         /// <summary>
         /// Get the current status of the device.

--- a/src/devices/Bmxx80/samples/Bme280/Bme280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme280/Bme280.sample.cs
@@ -15,7 +15,7 @@ Console.WriteLine("Hello Bme280!");
 // bus id on the raspberry pi 3
 const int busId = 1;
 // set this to the current sea level pressure in the area for correct altitude readings
-Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
+Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevelPressure;
 
 I2cConnectionSettings i2cSettings = new(busId, Bme280.DefaultI2cAddress);
 using I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);

--- a/src/devices/Bmxx80/samples/Bme680/Bme680.sample.cs
+++ b/src/devices/Bmxx80/samples/Bme680/Bme680.sample.cs
@@ -13,7 +13,7 @@ Console.WriteLine("Hello BME680!");
 // The I2C bus ID on the Raspberry Pi 3.
 const int busId = 1;
 // set this to the current sea level pressure in the area for correct altitude readings
-Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
+Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevelPressure;
 
 I2cConnectionSettings i2cSettings = new(busId, Bme680.DefaultI2cAddress);
 I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);

--- a/src/devices/Bmxx80/samples/Bmp280/Bmp280.sample.cs
+++ b/src/devices/Bmxx80/samples/Bmp280/Bmp280.sample.cs
@@ -16,7 +16,7 @@ Length stationHeight = Length.FromMeters(640); // Elevation of the sensor
 // bus id on the raspberry pi 3 and 4
 const int busId = 1;
 // set this to the current sea level pressure in the area for correct altitude readings
-Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
+Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevelPressure;
 
 I2cConnectionSettings i2cSettings = new(busId, Bmp280.DefaultI2cAddress);
 I2cDevice i2cDevice = I2cDevice.Create(i2cSettings);

--- a/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
+++ b/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
@@ -201,16 +201,6 @@ namespace Iot.Device.Common
         #region Pressure
 
         /// <summary>
-        /// Calculates the altitude in meters from the given pressure and air temperature. Assumes mean sea-level pressure.
-        /// </summary>
-        /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>
-        /// <param name="airTemperature">The dry air temperature at the point for which altitude is being calculated</param>
-        /// <returns>The altitude</returns>
-        [Obsolete("Behavior is confusing. Use CalculateAltitude(Pressure, Pressure, Temperature) instead")]
-        public static Length CalculateAltitude(Pressure pressure, Temperature airTemperature) =>
-            CalculateAltitude(pressure, MeanSeaLevelPressure, airTemperature);
-
-        /// <summary>
         /// Calculates the altitude in meters from the given pressure and sea-level pressure.
         /// </summary>
         /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>

--- a/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
+++ b/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
@@ -15,17 +15,17 @@ namespace Iot.Device.Common
         /// <summary>
         /// Gas constant of dry Air, J / (kg * K)
         /// </summary>
-        internal const double SpecificGasConstantOfAir = 287.058;
+        public const double SpecificGasConstantOfAir = 287.058;
 
         /// <summary>
         /// Gas constant of vapor, J / (kg * K)
         /// </summary>
-        internal const double SpecificGasConstantOfVapor = 461.523;
+        public const double SpecificGasConstantOfVapor = 461.523;
 
         /// <summary>
         /// Default atmospheric temperature gradient = 0.0065K/m (or 0.65K per 100m)
         /// </summary>
-        internal const double DefaultTemperatureGradient = 0.0065;
+        public const double DefaultTemperatureGradient = 0.0065;
 
         /// <summary>
         /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level
@@ -204,6 +204,7 @@ namespace Iot.Device.Common
         public static Length CalculateAltitude(Pressure pressure, Pressure seaLevelPressure, Temperature airTemperature)
         {
             double meters = ((Math.Pow(seaLevelPressure.Pascals / pressure.Pascals, 1 / 5.255) - 1) * airTemperature.Kelvins) / DefaultTemperatureGradient;
+            // double meters = (airTemperature.Kelvins / DefaultTemperatureGradient) * (1 - Math.Pow(pressure / seaLevelPressure, 1.0 / 5.255));
             return Length.FromMeters(meters);
         }
 

--- a/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
+++ b/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
@@ -199,19 +199,37 @@ namespace Iot.Device.Common
         #endregion TemperatureAndRelativeHumidity
 
         #region Pressure
-        // Formula  from https://de.wikipedia.org/wiki/Barometrische_Höhenformel#Internationale_Höhenformel, solved
-        // for different parameters
+
+        /// <summary>
+        /// Calculates the altitude in meters from the given pressure and sea-level pressure.
+        /// </summary>
+        /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>
+        /// <param name="seaLevelPressure">The sea-level pressure. In aviation, this is called the QNH value and provided by weather reports or ATC</param>
+        /// <remarks>
+        /// Formula  from https://de.wikipedia.org/wiki/Barometrische_Höhenformel#Internationale_Höhenformel, solved
+        /// </remarks>
+        /// <returns>The altitude over mean sea level</returns>
+        public static Length CalculateAltitude(Pressure pressure, Pressure seaLevelPressure)
+        {
+            double meters = (Math.Pow(seaLevelPressure.Pascals / pressure.Pascals, -1.0 / 5.255) - 1) * (DefaultSeaLevelTemperature.Kelvins / -DefaultTemperatureGradient);
+            return Length.FromMeters(meters);
+        }
 
         /// <summary>
         /// Calculates the altitude in meters from the given pressure, sea-level pressure and air temperature.
         /// </summary>
         /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>
         /// <param name="seaLevelPressure">The sea-level pressure. In aviation, this is called the QNH value and provided by weather reports or ATC</param>
+        /// <param name="temperatureAtObservation">Temperature at observation point. Since this depends on the altitude (which we don't know), we use an iterative approach here</param>
         /// <returns>The altitude over mean sea level</returns>
-        public static Length CalculateAltitude(Pressure pressure, Pressure seaLevelPressure)
+        public static Length CalculateAltitude(Pressure pressure, Pressure seaLevelPressure, Temperature temperatureAtObservation)
         {
+            // The first iteration is to get an approximation of the current height, so we can do the temperature compensation
             double meters = (Math.Pow(seaLevelPressure.Pascals / pressure.Pascals, -1.0 / 5.255) - 1) * (DefaultSeaLevelTemperature.Kelvins / -DefaultTemperatureGradient);
-            return Length.FromMeters(meters);
+            // It gets hotter when going down (when in the Troposphere)
+            Temperature temperatureAtSeaLevel = temperatureAtObservation + TemperatureDelta.FromDegreesCelsius(DefaultTemperatureGradient * meters);
+            double meters2 = (Math.Pow(seaLevelPressure.Pascals / pressure.Pascals, -1.0 / 5.255) - 1) * (temperatureAtSeaLevel.Kelvins / -DefaultTemperatureGradient);
+            return Length.FromMeters(meters2);
         }
 
         /// <summary>

--- a/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
+++ b/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
@@ -28,6 +28,14 @@ namespace Iot.Device.Common
         public const double DefaultTemperatureGradient = 0.0065;
 
         /// <summary>
+        /// The default assumed temperature at sea level.
+        /// This is used for <see cref="CalculateAltitude(Pressure, Pressure)"/> since it is not possible to calculate the temperature at sea level
+        /// for this formula, as we do not know the altitude (it is the result of that computation, after all). The QNH value does consider the
+        /// temperature, though.
+        /// </summary>
+        public static Temperature DefaultSeaLevelTemperature => Temperature.FromDegreesCelsius(15);
+
+        /// <summary>
         /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level
         /// </summary>
         public static readonly Pressure MeanSeaLevel = Pressure.FromPascals(101325);
@@ -198,33 +206,13 @@ namespace Iot.Device.Common
         /// Calculates the altitude in meters from the given pressure, sea-level pressure and air temperature.
         /// </summary>
         /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>
-        /// <param name="seaLevelPressure">The sea-level pressure</param>
-        /// <param name="airTemperature">The dry air temperature at the point for which altitude is being calculated</param>
-        /// <returns>The altitude</returns>
-        public static Length CalculateAltitude(Pressure pressure, Pressure seaLevelPressure, Temperature airTemperature)
+        /// <param name="seaLevelPressure">The sea-level pressure. In aviation, this is called the QNH value and provided by weather reports or ATC</param>
+        /// <returns>The altitude over mean sea level</returns>
+        public static Length CalculateAltitude(Pressure pressure, Pressure seaLevelPressure)
         {
-            double meters = ((Math.Pow(seaLevelPressure.Pascals / pressure.Pascals, 1 / 5.255) - 1) * airTemperature.Kelvins) / DefaultTemperatureGradient;
-            // double meters = (airTemperature.Kelvins / DefaultTemperatureGradient) * (1 - Math.Pow(pressure / seaLevelPressure, 1.0 / 5.255));
+            double meters = (Math.Pow(seaLevelPressure.Pascals / pressure.Pascals, -1.0 / 5.255) - 1) * (DefaultSeaLevelTemperature.Kelvins / -DefaultTemperatureGradient);
             return Length.FromMeters(meters);
         }
-
-        /// <summary>
-        /// Calculates the altitude in meters from the given pressure and air temperature. Assumes mean sea-level pressure.
-        /// </summary>
-        /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>
-        /// <param name="airTemperature">The dry air temperature at the point for which altitude is being calculated</param>
-        /// <returns>The altitude</returns>
-        public static Length CalculateAltitude(Pressure pressure, Temperature airTemperature) =>
-             CalculateAltitude(pressure, MeanSeaLevel, airTemperature);
-
-        /// <summary>
-        /// Calculates the altitude in meters from the given pressure and sea-level pressure. Assumes temperature of 15C.
-        /// </summary>
-        /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>
-        /// <param name="seaLevelPressure">The sea-level pressure</param>
-        /// <returns>The altitude</returns>
-        public static Length CalculateAltitude(Pressure pressure, Pressure seaLevelPressure) =>
-            CalculateAltitude(pressure, seaLevelPressure, Temperature.FromDegreesCelsius(15));
 
         /// <summary>
         /// Calculates the altitude in meters from the given pressure. Assumes mean sea-level pressure and temperature of 15C.
@@ -232,7 +220,7 @@ namespace Iot.Device.Common
         /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>
         /// <returns>The altitude</returns>
         public static Length CalculateAltitude(Pressure pressure) =>
-            CalculateAltitude(pressure, MeanSeaLevel, Temperature.FromDegreesCelsius(15));
+            CalculateAltitude(pressure, MeanSeaLevel);
 
         /// <summary>
         /// Calculates the approximate sea-level pressure from given absolute pressure, altitude and air temperature.

--- a/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
+++ b/src/devices/Common/Iot/Device/Common/WeatherHelper.cs
@@ -38,7 +38,7 @@ namespace Iot.Device.Common
         /// <summary>
         /// The mean sea-level pressure (MSLP) is the average atmospheric pressure at mean sea level
         /// </summary>
-        public static readonly Pressure MeanSeaLevel = Pressure.FromPascals(101325);
+        public static Pressure MeanSeaLevelPressure => Pressure.FromPascals(101325);
 
         #region TemperatureAndRelativeHumidity
 
@@ -201,6 +201,16 @@ namespace Iot.Device.Common
         #region Pressure
 
         /// <summary>
+        /// Calculates the altitude in meters from the given pressure and air temperature. Assumes mean sea-level pressure.
+        /// </summary>
+        /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>
+        /// <param name="airTemperature">The dry air temperature at the point for which altitude is being calculated</param>
+        /// <returns>The altitude</returns>
+        [Obsolete("Behavior is confusing. Use CalculateAltitude(Pressure, Pressure, Temperature) instead")]
+        public static Length CalculateAltitude(Pressure pressure, Temperature airTemperature) =>
+            CalculateAltitude(pressure, MeanSeaLevelPressure, airTemperature);
+
+        /// <summary>
         /// Calculates the altitude in meters from the given pressure and sea-level pressure.
         /// </summary>
         /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>
@@ -233,12 +243,12 @@ namespace Iot.Device.Common
         }
 
         /// <summary>
-        /// Calculates the altitude in meters from the given pressure. Assumes mean sea-level pressure and temperature of 15C.
+        /// Calculates the altitude in meters from the given pressure. Assumes mean sea-level pressure.
         /// </summary>
         /// <param name="pressure">The pressure at the point for which altitude is being calculated</param>
         /// <returns>The altitude</returns>
         public static Length CalculateAltitude(Pressure pressure) =>
-            CalculateAltitude(pressure, MeanSeaLevel);
+            CalculateAltitude(pressure, MeanSeaLevelPressure);
 
         /// <summary>
         /// Calculates the approximate sea-level pressure from given absolute pressure, altitude and air temperature.

--- a/src/devices/Common/tests/WeatherTests.cs
+++ b/src/devices/Common/tests/WeatherTests.cs
@@ -101,12 +101,16 @@ namespace Iot.Device.Common.Tests
         }
 
         [Theory]
-        [InlineData(1011.22, 900, 1013.25, 15)]
-        [InlineData(111.18, 1000, 1013.25, 15)]
+        [InlineData(0, 1013.25, 1013.25, 15)]
+        [InlineData(999.96, 898.75, 1013.25, 15)]
+        [InlineData(3000, 701.09, 1013.25, 15)]
         [InlineData(547.1, 950, 1013.25, 15)]
         public void AltitudeIsCalculatedCorrectly(double expected, double hpa, double seaLevelHpa, double celsius)
         {
             Length altitude = WeatherHelper.CalculateAltitude(Pressure.FromHectopascals(hpa), Pressure.FromHectopascals(seaLevelHpa), Temperature.FromDegreesCelsius(celsius));
+
+            double meters1 = (Math.Pow(seaLevelHpa / hpa, -1 / 5.255) - 1) * ((celsius + 273.15) / -WeatherHelper.DefaultTemperatureGradient);
+            double meters2 = ((celsius + 273.15) / WeatherHelper.DefaultTemperatureGradient) * (1 - Math.Pow(hpa / seaLevelHpa, 1.0 / 5.255));
             Assert.Equal(expected, Math.Round(altitude.Meters, 2));
         }
 
@@ -157,6 +161,17 @@ namespace Iot.Device.Common.Tests
             Pressure result = WeatherHelper.CalculateBarometricPressure(Pressure.FromHectopascals(measuredValue),
                 Temperature.FromDegreesCelsius(temperature), Length.FromMeters(altitude));
             Assert.Equal(expected, result.Hectopascals, 2);
+        }
+
+        [Theory]
+        [InlineData(1113.25, -801.147)]
+        [InlineData(1013.25, 0.0)]
+        [InlineData(913.25, 867.955)]
+        [InlineData(813.25, 1816.617)]
+        public void Pressure2Msl(double pressureHPa, double expectedHeightMsl)
+        {
+            var heightMsl = WeatherHelper.CalculateAltitude(Pressure.FromHectopascals(pressureHPa));
+            Assert.Equal(heightMsl.Meters, expectedHeightMsl, 0.1);
         }
 
         [Theory]

--- a/src/devices/Common/tests/WeatherTests.cs
+++ b/src/devices/Common/tests/WeatherTests.cs
@@ -242,5 +242,23 @@ namespace Iot.Device.Common.Tests
             var density = WeatherHelper.CalculateWindForce(airDensity, Speed.FromKilometersPerHour(windSpeed), 1.0);
             Assert.Equal(expected, density.NewtonsPerSquareMeter, 1);
         }
+
+        [Theory]
+        [InlineData(0, 1013.25, 15, 0)]
+        [InlineData(0, 1020, 15, 0)]
+        [InlineData(0, 1020, -20, 0)]
+        [InlineData(400, 970, 15, 397.989)]
+        [InlineData(400, 970, -5, 399.047)]
+        [InlineData(2000, 940, -5, 1995.953)]
+        public void RoundTripAltitudeAndPressure(double originalAltitude, double originalPressure, double originalTemperature, double expectedResult)
+        {
+            // The expectedResult and the originalAltitude should ideally be equal.
+            Pressure qnh = WeatherHelper.CalculateBarometricPressure(Pressure.FromHectopascals(originalPressure),
+                Temperature.FromDegreesCelsius(originalTemperature), Length.FromMeters(originalAltitude));
+
+            Length altitudeResult = WeatherHelper.CalculateAltitude(Pressure.FromHectopascals(originalPressure), qnh, Temperature.FromDegreesCelsius(originalTemperature));
+
+            Assert.Equal(expectedResult, altitudeResult.Meters, 1E-3);
+        }
     }
 }

--- a/src/devices/Common/tests/WeatherTests.cs
+++ b/src/devices/Common/tests/WeatherTests.cs
@@ -81,37 +81,29 @@ namespace Iot.Device.Common.Tests
         }
 
         [Theory]
-        [InlineData(1011.22, 900)]
-        [InlineData(111.18, 1000)]
-        [InlineData(547.1, 950)]
+        [InlineData(988.50, 900)]
+        [InlineData(110.88, 1000)]
         public void AltitudeIsCalculatedCorrectlyAtMslpAndDefaultTemp(double expected, double hpa)
         {
             Length altitude = WeatherHelper.CalculateAltitude(Pressure.FromHectopascals(hpa));
-            Assert.Equal(expected, Math.Round(altitude.Meters, 2));
-        }
-
-        [Theory]
-        [InlineData(1011.22, 900, 1013.25)]
-        [InlineData(111.18, 1000, 1013.25)]
-        [InlineData(547.1, 950, 1013.25)]
-        public void AltitudeIsCalculatedCorrectlyAtDefaultTemp(double expected, double hpa, double seaLevelHpa)
-        {
-            Length altitude = WeatherHelper.CalculateAltitude(Pressure.FromHectopascals(hpa), Pressure.FromHectopascals(seaLevelHpa));
-            Assert.Equal(expected, Math.Round(altitude.Meters, 2));
+            Assert.Equal(altitude.Meters, expected, 0.5);
         }
 
         [Theory]
         [InlineData(0, 1013.25, 1013.25, 15)]
-        [InlineData(999.96, 898.75, 1013.25, 15)]
-        [InlineData(3000, 701.09, 1013.25, 15)]
-        [InlineData(547.1, 950, 1013.25, 15)]
+        [InlineData(1000.13, 898.75, 1013.25, 15)]
+        [InlineData(3000.43, 701.09, 1013.25, 15)]
+        [InlineData(540.43, 950, 1013.25, 15)]
         public void AltitudeIsCalculatedCorrectly(double expected, double hpa, double seaLevelHpa, double celsius)
         {
-            Length altitude = WeatherHelper.CalculateAltitude(Pressure.FromHectopascals(hpa), Pressure.FromHectopascals(seaLevelHpa), Temperature.FromDegreesCelsius(celsius));
+            Length altitude = WeatherHelper.CalculateAltitude(Pressure.FromHectopascals(hpa), Pressure.FromHectopascals(seaLevelHpa));
 
+            // These two formulas should be equivalent.
             double meters1 = (Math.Pow(seaLevelHpa / hpa, -1 / 5.255) - 1) * ((celsius + 273.15) / -WeatherHelper.DefaultTemperatureGradient);
             double meters2 = ((celsius + 273.15) / WeatherHelper.DefaultTemperatureGradient) * (1 - Math.Pow(hpa / seaLevelHpa, 1.0 / 5.255));
             Assert.Equal(expected, Math.Round(altitude.Meters, 2));
+            Assert.Equal(meters1, expected, 0.01);
+            Assert.Equal(meters2, expected, 0.01);
         }
 
         [Theory]

--- a/src/devices/Ft232H/samples/Program.cs
+++ b/src/devices/Ft232H/samples/Program.cs
@@ -115,7 +115,7 @@ void I2cScan(Ftx232HDevice ft232h)
 void TestI2c(Ftx232HDevice ft232h)
 {
     // set this to the current sea level pressure in the area for correct altitude readings
-    Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
+    Pressure defaultSeaLevelPressure = WeatherHelper.MeanSeaLevelPressure;
     Length stationHeight = Length.FromMeters(640); // Elevation of the sensor
     var ftI2cBus = ft232h.CreateOrGetI2cBus(ft232h.GetDefaultI2cBusNumber());
     var i2cDevice = ftI2cBus.CreateDevice(Bmp280.DefaultI2cAddress);

--- a/src/devices/Lps25h/samples/Program.cs
+++ b/src/devices/Lps25h/samples/Program.cs
@@ -12,7 +12,7 @@ using UnitsNet;
 const int I2cAddress = 0x5c;
 
 // set this to the current sea level pressure in the area for correct altitude readings
-var defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
+var defaultSeaLevelPressure = WeatherHelper.MeanSeaLevelPressure;
 
 using Lps25h th = new(CreateI2cDevice());
 while (true)

--- a/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
+++ b/src/devices/SenseHat/samples/PressureAndTemperature.Sample.cs
@@ -17,7 +17,7 @@ namespace Iot.Device.SenseHat.Samples
         public static void Run()
         {
             // set this to the current sea level pressure in the area for correct altitude readings
-            var defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
+            var defaultSeaLevelPressure = WeatherHelper.MeanSeaLevelPressure;
 
             using SenseHatPressureAndTemperature pt = new();
             while (true)

--- a/src/devices/SenseHat/samples/Program.cs
+++ b/src/devices/SenseHat/samples/Program.cs
@@ -9,7 +9,7 @@ using Iot.Device.SenseHat;
 using UnitsNet;
 
 // set this to the current sea level pressure in the area for correct altitude readings
-var defaultSeaLevelPressure = WeatherHelper.MeanSeaLevel;
+var defaultSeaLevelPressure = WeatherHelper.MeanSeaLevelPressure;
 
 using SenseHat sh = new();
 int n = 0;

--- a/src/devices/Tca954x/samples/Program.cs
+++ b/src/devices/Tca954x/samples/Program.cs
@@ -71,8 +71,8 @@ namespace Tca9548a.Sample
                         Console.WriteLine($"Pressure: {preValue.Hectopascals:0.##}hPa");
 
                         // Note that if you already have the pressure value and the temperature, you could also calculate altitude by
-                        // calling WeatherHelper.CalculateAltitude(preValue, Pressure.MeanSeaLevel, tempValue) which would be more performant.
-                        Length altValue = i2cBmp280.ReadAltitude(WeatherHelper.MeanSeaLevel);
+                        // calling WeatherHelper.CalculateAltitude(preValue, WeatherHelper.MeanSeaLevelPressure, tempValue) which would be more performant.
+                        Length altValue = i2cBmp280.ReadAltitude(WeatherHelper.MeanSeaLevelPressure);
 
                         Console.WriteLine($"Altitude: {altValue:0.##}m");
                         Thread.Sleep(1000);
@@ -87,8 +87,8 @@ namespace Tca9548a.Sample
                         Console.WriteLine($"Pressure: {preValue.Hectopascals:0.##}hPa");
 
                         // Note that if you already have the pressure value and the temperature, you could also calculate altitude by
-                        // calling WeatherHelper.CalculateAltitude(preValue, Pressure.MeanSeaLevel, tempValue) which would be more performant.
-                        altValue = i2cBmp280.ReadAltitude(WeatherHelper.MeanSeaLevel);
+                        // calling WeatherHelper.CalculateAltitude(preValue, WeatherHelper.MeanSeaLevelPressure, tempValue) which would be more performant.
+                        altValue = i2cBmp280.ReadAltitude(WeatherHelper.MeanSeaLevelPressure);
                         Console.WriteLine($"Altitude: {altValue:0.##}m");
                     }
 


### PR DESCRIPTION
Fixes #2481 

The formula had a typo, which resulted in values being off around 10%.

The change is breaking, because one overload was removed, as it technically doesn't make sense. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2483)