### PR TITLE
Remove duplicate @ prefix from issueAuthor in GitOps

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -24,7 +24,7 @@ configuration:
       actions:
       - closeIssue
       - addReply:
-          reply: Hello ${issueAuthor}, the reviewers on this PR have requested changes and there has not been any activity for **14 days**, so it will be closed for housekeeping pourposes. Feel free to reopen or send a new one if you wish to resume the progress.
+          reply: Hello ${issueAuthor}, the reviewers on this PR have requested changes and there has not been any activity for **14 days**, so it will be closed for housekeeping purposes. Feel free to reopen or send a new one if you wish to resume the progress.
     - description: Add no recent activity label to pull requests
       frequencies:
       - hourly:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -24,7 +24,7 @@ configuration:
       actions:
       - closeIssue
       - addReply:
-          reply: Hello @${issueAuthor}, the reviewers on this PR have requested changes and there has not been any activity for **14 days**, so it will be closed for housekeeping pourposes. Feel free to reopen or send a new one if you wish to resume the progress.
+          reply: Hello ${issueAuthor}, the reviewers on this PR have requested changes and there has not been any activity for **14 days**, so it will be closed for housekeeping pourposes. Feel free to reopen or send a new one if you wish to resume the progress.
     - description: Add no recent activity label to pull requests
       frequencies:
       - hourly:


### PR DESCRIPTION
https://github.com/GitOps-microsoft/GitOps.PullRequestIssueManagement/pull/262 (internal Microsoft link) changed the `${issueAuthor}` placeholder to include the `@` character.

Remove the one we added so we don't duplicate it.

<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2491)