### PR TITLE
Amg88xx: fix 'occured' -> 'occurred' in StatusFlagBit XML doc comments

### DIFF
--- a/src/devices/Amg88xx/StatusFlagBit.cs
+++ b/src/devices/Amg88xx/StatusFlagBit.cs
@@ -11,17 +11,17 @@ namespace Iot.Device.Amg88xx
     internal enum StatusFlagBit : byte
     {
         /// <summary>
-        /// Interrupt occured
+        /// Interrupt occurred
         /// </summary>
         INTF = 1,
 
         /// <summary>
-        /// Temperature output overflow occured for one or more pixel
+        /// Temperature output overflow occurred for one or more pixel
         /// </summary>
         OVF_IRS = 2,
 
         /// <summary>
-        /// Thermistor output overflow occured
+        /// Thermistor output overflow occurred
         /// Note: the bit is only menthioned in early versions of the reference specification.
         /// It is not clear whether this is a specification error or a change in a newer
         /// revision of the sensor.


### PR DESCRIPTION
Three XML doc comments in `src/devices/Amg88xx/StatusFlagBit.cs` (lines 14, 19, 24) read `occured`. Fixed to `occurred`. Comment-only change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2494)