### PR TITLE
Draft: See whether this update helps

### DIFF
--- a/eng/ArduinoCsCI.cmd
+++ b/eng/ArduinoCsCI.cmd
@@ -5,7 +5,7 @@ REM Second argument is either "Debug" or "Release"
 if %1!==! goto :usage
 
 REM Defines the revision to check out in the ExtendedConfigurableFirmata repo
-set FIRMATA_SIMULATOR_CHECKOUT_REVISION=4539d6465cad97dd4a88a99a323f03093b489964
+set FIRMATA_SIMULATOR_CHECKOUT_REVISION=31276a8baf0f08006a0745775ccb7bc140ba45a3
 set RUN_COMPILER_TESTS=FALSE
 
 choco install -y --no-progress arduino-cli

--- a/eng/ArduinoCsCI.cmd
+++ b/eng/ArduinoCsCI.cmd
@@ -5,7 +5,7 @@ REM Second argument is either "Debug" or "Release"
 if %1!==! goto :usage
 
 REM Defines the revision to check out in the ExtendedConfigurableFirmata repo
-set FIRMATA_SIMULATOR_CHECKOUT_REVISION=e52474a1c7b0c147ff9fc635c0d424d02866a54c
+set FIRMATA_SIMULATOR_CHECKOUT_REVISION=4539d6465cad97dd4a88a99a323f03093b489964
 set RUN_COMPILER_TESTS=FALSE
 
 choco install -y --no-progress arduino-cli

--- a/eng/ArduinoCsCI.cmd
+++ b/eng/ArduinoCsCI.cmd
@@ -5,7 +5,7 @@ REM Second argument is either "Debug" or "Release"
 if %1!==! goto :usage
 
 REM Defines the revision to check out in the ExtendedConfigurableFirmata repo
-set FIRMATA_SIMULATOR_CHECKOUT_REVISION=a354343cebc35964450dfa01dba2cd996065fd5c
+set FIRMATA_SIMULATOR_CHECKOUT_REVISION=e52474a1c7b0c147ff9fc635c0d424d02866a54c
 set RUN_COMPILER_TESTS=FALSE
 
 choco install -y --no-progress arduino-cli

--- a/eng/ArduinoCsCI.cmd
+++ b/eng/ArduinoCsCI.cmd
@@ -5,7 +5,7 @@ REM Second argument is either "Debug" or "Release"
 if %1!==! goto :usage
 
 REM Defines the revision to check out in the ExtendedConfigurableFirmata repo
-set FIRMATA_SIMULATOR_CHECKOUT_REVISION=31276a8baf0f08006a0745775ccb7bc140ba45a3
+set FIRMATA_SIMULATOR_CHECKOUT_REVISION=aa750ff4fb690e7bca54752d87ec896597cfe2b1
 set RUN_COMPILER_TESTS=FALSE
 
 choco install -y --no-progress arduino-cli


### PR DESCRIPTION
There's a nasty GC bug in the runtime that sometimes causes an out-of-memory exception when allocating the first block. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2520)