### PR TITLE
Group SkiaSharp Dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,17 @@
 #
 # All NuGet projects across the repo (except /eng/common, which is
 # Arcade-maintained) are scanned by a single update block. PRs are bundled
-# into two groups:
+# into these groups:
 #
 #   - dotnet-runtime  -> System.* and Microsoft.Extensions.*
 #                        (any version bump, including majors — these all ship
 #                        together on the .NET release train, so a major like
 #                        9.x -> 10.x lands across them simultaneously and is
 #                        best reviewed as one PR).
+#   - skiasharp       -> SkiaSharp and SkiaSharp.NativeAssets.*
+#                        (any version bump — the managed package and its
+#                        native asset packages must be kept at matching
+#                        versions, so they always land in one PR).
 #   - all-dependencies -> everything else, minor/patch only. Majors of these
 #                         packages fall out as individual PRs so breaking-
 #                         change risk gets dedicated review.
@@ -32,12 +36,18 @@ updates:
         patterns:
           - "System.*"
           - "Microsoft.Extensions.*"
+      skiasharp:
+        patterns:
+          - "SkiaSharp"
+          - "SkiaSharp.NativeAssets.*"
       all-dependencies:
         patterns:
           - "*"
         exclude-patterns:
           - "System.*"
           - "Microsoft.Extensions.*"
+          - "SkiaSharp"
+          - "SkiaSharp.NativeAssets.*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
`SkiaSharp` and its `SkiaSharp.NativeAssets.*` companion packages must be kept at matching versions, but they were slipping through the existing grouping and shipping as separate Dependabot PRs (#2590, #2591 for the 4.148.0 -> 4.150.1 bump). #2591 merged and #2590 did not, which left `src/devices/SkiaSharpAdapter/SkiaSharpAdapter.csproj` with `SkiaSharp` at 4.148.0 and `SkiaSharp.NativeAssets.Linux` at 4.150.1 - exactly the drift the group is meant to prevent.

This adds a dedicated `skiasharp` group modeled after the existing `dotnet-runtime` group:

- Patterns `SkiaSharp` (exact) and `SkiaSharp.NativeAssets.*` (covers `.Linux` today and any future `.Windows` / `.macOS` variants).
- No `update-types` filter, so any bump (major, minor, or patch) is grouped - the two packages always land in one PR regardless of version-change type.
- The same two patterns are added to `all-dependencies`' `exclude-patterns` so routing stays deterministic regardless of group evaluation order.

Follow-up to #2571, which set up the initial grouping but only covered `System.*` / `Microsoft.Extensions.*` and generic minor/patch updates.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2593)