### PR TITLE
Fix EINTR not handled in `LineRequest.WaitEdgeEventsRespectfully`

### DIFF
--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/V2/Proxies/LineRequest.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/V2/Proxies/LineRequest.cs
@@ -311,7 +311,7 @@ internal class LineRequest : LibGpiodProxyBase
                             break;
                         }
 
-                        var errorCode = Marshal.GetLastWin32Error();
+                        int errorCode = Marshal.GetLastWin32Error();
 
                         if (errorCode == ERROR_CODE_EINTR)
                         {
@@ -319,7 +319,13 @@ internal class LineRequest : LibGpiodProxyBase
                             continue;
                         }
 
-                        throw new GpiodException($"Error while waiting for edge events, epoll_wait: {LastErr.GetMsg()}");
+#if NET7_0_OR_GREATER
+                        string err = Marshal.GetLastPInvokeErrorMessage();
+#else
+                        string err = errorCode.ToString();
+#endif
+                        string errMsg = string.IsNullOrWhiteSpace(err) ? string.Empty : $"Error: '{err}'";
+                        throw new GpiodException($"Error while waiting for edge events, epoll_wait: {errMsg}");
                     }
 
                     bool isTimeout = ret == 0;

--- a/src/System.Device.Gpio/Interop/Unix/libgpiod/V2/Proxies/LineRequest.cs
+++ b/src/System.Device.Gpio/Interop/Unix/libgpiod/V2/Proxies/LineRequest.cs
@@ -19,6 +19,8 @@ namespace System.Device.Gpio.Libgpiod.V2;
 /// <seealso href="https://libgpiod.readthedocs.io/en/latest/group__line__request.html#details"/>
 internal class LineRequest : LibGpiodProxyBase
 {
+    private const int ERROR_CODE_EINTR = 4; // Interrupted system call
+
     private readonly LineRequestSafeHandle _handle;
 
     private readonly object _signalPipeWriteSideLock = new();
@@ -299,9 +301,24 @@ internal class LineRequest : LibGpiodProxyBase
                     }
 
                     using var eventBuffer = new UnmanagedArray<epoll_event>(2);
-                    ret = Interop.epoll_wait(pollFileDescriptor, eventBuffer, 2, (int)timeout.Value.TotalMilliseconds);
-                    if (ret < 0)
+
+                    while (true)
                     {
+                        ret = Interop.epoll_wait(pollFileDescriptor, eventBuffer, 2, (int)timeout.Value.TotalMilliseconds);
+
+                        if (ret >= 0)
+                        {
+                            break;
+                        }
+
+                        var errorCode = Marshal.GetLastWin32Error();
+
+                        if (errorCode == ERROR_CODE_EINTR)
+                        {
+                            // ignore Interrupted system call error and retry
+                            continue;
+                        }
+
                         throw new GpiodException($"Error while waiting for edge events, epoll_wait: {LastErr.GetMsg()}");
                     }
 


### PR DESCRIPTION
<!--
- If PR is fixing any issue please add `Fixes #1234` as a first thing in the description of your PR
- Describe what is the issue being fixed
- If there is any follow-up work please create issues for that
- If your PR is adding device binding please make sure to read [conventions for devices APIs](https://github.com/dotnet/iot/blob/main/Documentation/Devices-conventions.md)
- Avoid force pushing to your PR (especially on large PRs) - it makes it much harder to incrementally review
-->
Fixes https://github.com/dotnet/iot/issues/2598

Related to https://github.com/dotnet/iot/issues/1210

`LineRequest.WaitEdgeEventsRespectfully` (used by `LibGpiodV2Driver`) calls `Interop.epoll_wait` without handling `EINTR` (errno 4). If the call is interrupted by a signal — which happens when a device resumes from standby/suspend — the method throws a `GpiodException` instead of retrying.

The V1 `LibGpiodDriverEventHandler` already ignores `Interrupted system call` error and continues waiting for events (see https://github.com/dotnet/iot/issues/1210). This PR implements the same behaviour for `LibGpiodV2Driver`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2599)