### PR TITLE
Make OneWire sysfs paths instance-level and configurable via constructors

### DIFF
--- a/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.Linux.cs
+++ b/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.Linux.cs
@@ -33,21 +33,24 @@ namespace Iot.Device.OneWire
         {
 #if NETSTANDARD2_0
             string data = string.Empty;
+            var sysfsDevicesPath = SysfsDevicesPath;
+            var busId = BusId;
+            var deviceId = DeviceId;
             await Task.Factory.StartNew(() =>
             {
-                data = File.ReadAllText(Path.Combine(OneWireBus.SysfsDevicesPath, BusId, DeviceId, "w1_slave"));
+                data = File.ReadAllText(Path.Combine(sysfsDevicesPath, busId, deviceId, "w1_slave"));
             });
 
             return ParseTemperature(data);
 #else
-            var data = await File.ReadAllTextAsync(Path.Combine(OneWireBus.SysfsDevicesPath, BusId, DeviceId, "w1_slave"));
+            var data = await File.ReadAllTextAsync(Path.Combine(SysfsDevicesPath, BusId, DeviceId, "w1_slave"));
             return ParseTemperature(data);
 #endif
         }
 
         private Temperature ReadTemperatureInternal()
         {
-            var data = File.ReadAllText(Path.Combine(OneWireBus.SysfsDevicesPath, BusId, DeviceId, "w1_slave"));
+            var data = File.ReadAllText(Path.Combine(SysfsDevicesPath, BusId, DeviceId, "w1_slave"));
             return ParseTemperature(data);
         }
     }

--- a/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.cs
+++ b/src/devices/OneWire/FamilyBindings/OneWireThermometerDevice.cs
@@ -23,6 +23,19 @@ namespace Iot.Device.OneWire
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="OneWireThermometerDevice"/> class with a custom sysfs devices path.
+        /// This constructor allows overriding the default sysfs path for testing or non-standard environments.
+        /// </summary>
+        /// <param name="busId">The 1-wire bus the device is found on.</param>
+        /// <param name="devId">The id of the device.</param>
+        /// <param name="sysfsDevicesPath">The sysfs path for device access (default: "/sys/devices").</param>
+        /// <exception cref="ArgumentNullException">Thrown when any parameter is null.</exception>
+        public OneWireThermometerDevice(string busId, string devId, string sysfsDevicesPath)
+            : base(busId, devId, sysfsDevicesPath)
+        {
+        }
+
+        /// <summary>
         /// Check if family is compatible with this type of devices.
         /// </summary>
         /// <param name="family">The family to check.</param>

--- a/src/devices/OneWire/OneWireBus.Linux.cs
+++ b/src/devices/OneWire/OneWireBus.Linux.cs
@@ -12,20 +12,23 @@ namespace Iot.Device.OneWire
 {
     public partial class OneWireBus
     {
-        internal const string SysfsBusDevicesPath = "/sys/bus/w1/devices";
-        internal const string SysfsDevicesPath = "/sys/devices";
+        internal const string DefaultSysfsBusDevicesPath = "/sys/bus/w1/devices";
+        internal const string DefaultSysfsDevicesPath = "/sys/devices";
 
-        internal static IEnumerable<string> EnumerateBusIdsInternal()
+        private readonly string _sysfsBusDevicesPath = DefaultSysfsBusDevicesPath;
+        private readonly string _sysfsDevicesPath = DefaultSysfsDevicesPath;
+
+        internal static IEnumerable<string> EnumerateBusIdsInternal(string sysfsBusDevicesPath)
         {
-            foreach (var entry in Directory.EnumerateDirectories(SysfsBusDevicesPath, "w1_bus_master*"))
+            foreach (var entry in Directory.EnumerateDirectories(sysfsBusDevicesPath, "w1_bus_master*"))
             {
                 yield return Path.GetFileName(entry);
             }
         }
 
-        internal static IEnumerable<string> EnumerateDeviceIdsInternal(string busId, DeviceFamily family)
+        internal static IEnumerable<string> EnumerateDeviceIdsInternal(string sysfsDevicesPath, string busId, DeviceFamily family)
         {
-            var devIds = File.ReadLines(Path.Combine(SysfsDevicesPath, busId, "w1_master_slaves"));
+            var devIds = File.ReadLines(Path.Combine(sysfsDevicesPath, busId, "w1_master_slaves"));
             return family switch
             {
                 DeviceFamily.Any => devIds,
@@ -40,36 +43,38 @@ namespace Iot.Device.OneWire
             return (DeviceFamily)devFamily;
         }
 
-        internal static async Task ScanForDeviceChangesInternalAsync(OneWireBus bus, int numDevices, int numScans)
+        private async Task ScanForDeviceChangesInternalAsync(int numDevices, int numScans)
         {
 #if NETSTANDARD2_0
+            var sysfsDevicesPath = _sysfsDevicesPath;
+            var busId = BusId;
             await Task.Factory.StartNew(() =>
             {
                 if (numDevices > 0)
                 {
-                    File.WriteAllText(Path.Combine(SysfsDevicesPath, bus.BusId, "w1_master_max_slave_count"), numDevices.ToString());
+                    File.WriteAllText(Path.Combine(sysfsDevicesPath, busId, "w1_master_max_slave_count"), numDevices.ToString());
                 }
 
-                File.WriteAllText(Path.Combine(SysfsDevicesPath, bus.BusId, "w1_master_search"), numScans.ToString());
+                File.WriteAllText(Path.Combine(sysfsDevicesPath, busId, "w1_master_search"), numScans.ToString());
             });
 #else
             if (numDevices > 0)
             {
-                await File.WriteAllTextAsync(Path.Combine(SysfsDevicesPath, bus.BusId, "w1_master_max_slave_count"), numDevices.ToString());
+                await File.WriteAllTextAsync(Path.Combine(_sysfsDevicesPath, BusId, "w1_master_max_slave_count"), numDevices.ToString());
             }
 
-            await File.WriteAllTextAsync(Path.Combine(SysfsDevicesPath, bus.BusId, "w1_master_search"), numScans.ToString());
+            await File.WriteAllTextAsync(Path.Combine(_sysfsDevicesPath, BusId, "w1_master_search"), numScans.ToString());
 #endif
         }
 
-        internal static void ScanForDeviceChangesInternal(OneWireBus bus, int numDevices, int numScans)
+        private void ScanForDeviceChangesInternal(int numDevices, int numScans)
         {
             if (numDevices > 0)
             {
-                File.WriteAllText(Path.Combine(SysfsDevicesPath, bus.BusId, "w1_master_max_slave_count"), numDevices.ToString());
+                File.WriteAllText(Path.Combine(_sysfsDevicesPath, BusId, "w1_master_max_slave_count"), numDevices.ToString());
             }
 
-            File.WriteAllText(Path.Combine(SysfsDevicesPath, bus.BusId, "w1_master_search"), numScans.ToString());
+            File.WriteAllText(Path.Combine(_sysfsDevicesPath, BusId, "w1_master_search"), numScans.ToString());
         }
     }
 }

--- a/src/devices/OneWire/OneWireBus.Linux.cs
+++ b/src/devices/OneWire/OneWireBus.Linux.cs
@@ -26,9 +26,9 @@ namespace Iot.Device.OneWire
             }
         }
 
-        internal static IEnumerable<string> EnumerateDeviceIdsInternal(string sysfsDevicesPath, string busId, DeviceFamily family)
+        internal static IEnumerable<string> EnumerateDeviceIdsInternal(string sysfsBusDevicesPath, string busId, DeviceFamily family)
         {
-            var devIds = File.ReadLines(Path.Combine(sysfsDevicesPath, busId, "w1_master_slaves"));
+            var devIds = File.ReadLines(Path.Combine(sysfsBusDevicesPath, busId, "w1_master_slaves"));
             return family switch
             {
                 DeviceFamily.Any => devIds,

--- a/src/devices/OneWire/OneWireBus.cs
+++ b/src/devices/OneWire/OneWireBus.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -12,13 +13,31 @@ namespace Iot.Device.OneWire
     public partial class OneWireBus
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="OneWireBus"/> class
+        /// Initializes a new instance of the <see cref="OneWireBus"/> class.
         /// </summary>
         /// <param name="busId">The platform id of the 1-wire bus.</param>
-        public OneWireBus(string busId) => BusId = busId;
+        public OneWireBus(string busId)
+            : this(busId, DefaultSysfsBusDevicesPath, DefaultSysfsDevicesPath)
+        {
+        }
 
         /// <summary>
-        /// The 1-wire device id.
+        /// Initializes a new instance of the <see cref="OneWireBus"/> class with custom sysfs paths.
+        /// This constructor allows overriding the default sysfs paths for testing or non-standard environments.
+        /// </summary>
+        /// <param name="busId">The platform id of the 1-wire bus.</param>
+        /// <param name="sysfsBusDevicesPath">The sysfs path for bus device enumeration (default: "/sys/bus/w1/devices").</param>
+        /// <param name="sysfsDevicesPath">The sysfs path for device access (default: "/sys/devices").</param>
+        /// <exception cref="ArgumentNullException">Thrown when any parameter is null.</exception>
+        public OneWireBus(string busId, string sysfsBusDevicesPath, string sysfsDevicesPath)
+        {
+            BusId = busId ?? throw new ArgumentNullException(nameof(busId));
+            _sysfsBusDevicesPath = sysfsBusDevicesPath ?? throw new ArgumentNullException(nameof(sysfsBusDevicesPath));
+            _sysfsDevicesPath = sysfsDevicesPath ?? throw new ArgumentNullException(nameof(sysfsDevicesPath));
+        }
+
+        /// <summary>
+        /// The 1-wire bus id.
         /// </summary>
         public string BusId { get; }
 
@@ -26,7 +45,7 @@ namespace Iot.Device.OneWire
         /// Enumerate names of all 1-wire busses in the system.
         /// </summary>
         /// <returns>A list of discovered bus ids.</returns>
-        public static IEnumerable<string> EnumerateBusIds() => EnumerateBusIdsInternal();
+        public static IEnumerable<string> EnumerateBusIds() => EnumerateBusIdsInternal(DefaultSysfsBusDevicesPath);
 
         /// <summary>
         /// Enumerates all devices currently detected on this bus. Platform can update device list
@@ -36,7 +55,7 @@ namespace Iot.Device.OneWire
         /// <returns>A list of discovered devices.</returns>
         public IEnumerable<string> EnumerateDeviceIds(DeviceFamily family = DeviceFamily.Any)
         {
-            foreach (var devId in EnumerateDeviceIdsInternal(BusId, family))
+            foreach (var devId in EnumerateDeviceIdsInternal(_sysfsDevicesPath, BusId, family))
             {
                 yield return devId;
             }
@@ -48,13 +67,13 @@ namespace Iot.Device.OneWire
         /// <param name="numDevices">Max number of devices to scan for before finishing. Use -1 for platform default.</param>
         /// <param name="numScans">Number of scans to do to find numDevices devices. Use -1 for platform default.</param>
         /// <returns>Task representing the async work.</returns>
-        public Task ScanForDeviceChangesAsync(int numDevices = -1, int numScans = -1) => ScanForDeviceChangesInternalAsync(this, numDevices, numScans);
+        public Task ScanForDeviceChangesAsync(int numDevices = -1, int numScans = -1) => ScanForDeviceChangesInternalAsync(numDevices, numScans);
 
         /// <summary>
         /// Start a new scan for device changes on the bus.
         /// </summary>
         /// <param name="numDevices">Max number of devices to scan for before finishing. Use -1 for platform default.</param>
         /// <param name="numScans">Number of scans to do to find numDevices devices. Use -1 for platform default.</param>
-        public void ScanForDeviceChanges(int numDevices = -1, int numScans = -1) => ScanForDeviceChangesInternal(this, numDevices, numScans);
+        public void ScanForDeviceChanges(int numDevices = -1, int numScans = -1) => ScanForDeviceChangesInternal(numDevices, numScans);
     }
 }

--- a/src/devices/OneWire/OneWireBus.cs
+++ b/src/devices/OneWire/OneWireBus.cs
@@ -55,7 +55,7 @@ namespace Iot.Device.OneWire
         /// <returns>A list of discovered devices.</returns>
         public IEnumerable<string> EnumerateDeviceIds(DeviceFamily family = DeviceFamily.Any)
         {
-            foreach (var devId in EnumerateDeviceIdsInternal(_sysfsDevicesPath, BusId, family))
+            foreach (var devId in EnumerateDeviceIdsInternal(_sysfsBusDevicesPath, BusId, family))
             {
                 yield return devId;
             }

--- a/src/devices/OneWire/OneWireDevice.cs
+++ b/src/devices/OneWire/OneWireDevice.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 
 namespace Iot.Device.OneWire
@@ -16,9 +17,23 @@ namespace Iot.Device.OneWire
         /// <param name="busId">The 1-wire bus the device is found on.</param>
         /// <param name="devId">The id of the device.</param>
         public OneWireDevice(string busId, string devId)
+            : this(busId, devId, OneWireBus.DefaultSysfsDevicesPath)
         {
-            BusId = busId;
-            DeviceId = devId;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OneWireDevice"/> class with a custom sysfs devices path.
+        /// This constructor allows overriding the default sysfs path for testing or non-standard environments.
+        /// </summary>
+        /// <param name="busId">The 1-wire bus the device is found on.</param>
+        /// <param name="devId">The id of the device.</param>
+        /// <param name="sysfsDevicesPath">The sysfs path for device access (default: "/sys/devices").</param>
+        /// <exception cref="ArgumentNullException">Thrown when any parameter is null.</exception>
+        public OneWireDevice(string busId, string devId, string sysfsDevicesPath)
+        {
+            BusId = busId ?? throw new ArgumentNullException(nameof(busId));
+            DeviceId = devId ?? throw new ArgumentNullException(nameof(devId));
+            SysfsDevicesPath = sysfsDevicesPath ?? throw new ArgumentNullException(nameof(sysfsDevicesPath));
             Family = OneWireBus.GetDeviceFamilyInternal(busId, devId);
         }
 
@@ -29,9 +44,9 @@ namespace Iot.Device.OneWire
         /// <returns>A list of devices found.</returns>
         public static IEnumerable<(string BusId, string DevId)> EnumerateDeviceIds(DeviceFamily family = DeviceFamily.Any)
         {
-            foreach (var busId in OneWireBus.EnumerateBusIdsInternal())
+            foreach (var busId in OneWireBus.EnumerateBusIdsInternal(OneWireBus.DefaultSysfsBusDevicesPath))
             {
-                foreach (var devId in OneWireBus.EnumerateDeviceIdsInternal(busId, family))
+                foreach (var devId in OneWireBus.EnumerateDeviceIdsInternal(OneWireBus.DefaultSysfsDevicesPath, busId, family))
                 {
                     yield return (busId, devId);
                 }
@@ -52,5 +67,10 @@ namespace Iot.Device.OneWire
         /// The device family id of this device.
         /// </summary>
         public DeviceFamily Family { get; }
+
+        /// <summary>
+        /// The sysfs path used for device access.
+        /// </summary>
+        internal string SysfsDevicesPath { get; }
     }
 }

--- a/src/devices/OneWire/OneWireDevice.cs
+++ b/src/devices/OneWire/OneWireDevice.cs
@@ -46,7 +46,7 @@ namespace Iot.Device.OneWire
         {
             foreach (var busId in OneWireBus.EnumerateBusIdsInternal(OneWireBus.DefaultSysfsBusDevicesPath))
             {
-                foreach (var devId in OneWireBus.EnumerateDeviceIdsInternal(OneWireBus.DefaultSysfsDevicesPath, busId, family))
+                foreach (var devId in OneWireBus.EnumerateDeviceIdsInternal(OneWireBus.DefaultSysfsBusDevicesPath, busId, family))
                 {
                     yield return (busId, devId);
                 }

--- a/src/devices/OneWire/README.md
+++ b/src/devices/OneWire/README.md
@@ -78,3 +78,26 @@ All temperature devices with family id of 0x10, 0x28, 0x3B, or 0x42 supported.
 
 - [MAX31820](https://datasheets.maximintegrated.com/en/ds/MAX31820.pdf)
 - [DS18B20](https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf)
+
+## Testing with custom sysfs paths
+
+The `OneWireBus`, `OneWireDevice`, and `OneWireThermometerDevice` classes accept custom sysfs paths via constructor overloads, enabling integration testing without physical hardware.
+
+```csharp
+// Create a fake sysfs directory structure for testing
+string testBusPath = "/path/to/test/bus/w1/devices";
+string testDevicesPath = "/path/to/test/devices";
+
+// Create bus with custom paths
+var bus = new OneWireBus("w1_bus_master1", testBusPath, testDevicesPath);
+
+// Enumerate devices from custom paths
+foreach (string devId in bus.EnumerateDeviceIds())
+{
+    Console.WriteLine(devId);
+}
+
+// Create thermometer device with custom path
+var thermometer = new OneWireThermometerDevice("w1_bus_master1", "28-00000abcdef", testDevicesPath);
+var temperature = thermometer.ReadTemperature();
+```

--- a/src/devices/OneWire/README.md
+++ b/src/devices/OneWire/README.md
@@ -89,7 +89,7 @@ The `OneWireBus`, `OneWireDevice`, and `OneWireThermometerDevice` classes accept
 // /path/to/test/w1/devices/w1_bus_master1/28-00000abcdef/w1_slave
 string testSysfsPath = "/path/to/test/w1/devices";
 
-// Create bus with custom paths
+// Create bus with custom paths. The fake layout uses one root for bus enumeration and device access.
 var bus = new OneWireBus("w1_bus_master1", testSysfsPath, testSysfsPath);
 
 // Enumerate devices from custom paths

--- a/src/devices/OneWire/README.md
+++ b/src/devices/OneWire/README.md
@@ -84,12 +84,13 @@ All temperature devices with family id of 0x10, 0x28, 0x3B, or 0x42 supported.
 The `OneWireBus`, `OneWireDevice`, and `OneWireThermometerDevice` classes accept custom sysfs paths via constructor overloads, enabling integration testing without physical hardware.
 
 ```csharp
-// Create a fake sysfs directory structure for testing
-string testBusPath = "/path/to/test/bus/w1/devices";
-string testDevicesPath = "/path/to/test/devices";
+// Create a fake sysfs directory structure for testing:
+// /path/to/test/w1/devices/w1_bus_master1/w1_master_slaves
+// /path/to/test/w1/devices/w1_bus_master1/28-00000abcdef/w1_slave
+string testSysfsPath = "/path/to/test/w1/devices";
 
 // Create bus with custom paths
-var bus = new OneWireBus("w1_bus_master1", testBusPath, testDevicesPath);
+var bus = new OneWireBus("w1_bus_master1", testSysfsPath, testSysfsPath);
 
 // Enumerate devices from custom paths
 foreach (string devId in bus.EnumerateDeviceIds())
@@ -98,6 +99,6 @@ foreach (string devId in bus.EnumerateDeviceIds())
 }
 
 // Create thermometer device with custom path
-var thermometer = new OneWireThermometerDevice("w1_bus_master1", "28-00000abcdef", testDevicesPath);
+var thermometer = new OneWireThermometerDevice("w1_bus_master1", "28-00000abcdef", testSysfsPath);
 var temperature = thermometer.ReadTemperature();
 ```


### PR DESCRIPTION
Fixes #2477
Some orphaned branch which apparently fixes above issue
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/iot/pull/2603)